### PR TITLE
Release/0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     name: Build ${{ matrix.platform }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: macos-latest
@@ -41,7 +42,7 @@ jobs:
           node-version: '20'
 
       - name: Install Wails
-        run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
+        run: go install -v github.com/wailsapp/wails/v2/cmd/wails@latest
 
       - name: Build
         shell: bash

--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -139,7 +139,7 @@ const ContextMenuRow = React.memo(({ children, ...props }: any) => {
     
     if (!record || !context) return <tr {...props}>{children}</tr>;
 
-    const { selectedRowKeysRef, displayDataRef, handleCopyInsert, handleCopyJson, handleCopyCsv, copyToClipboard } = context;
+    const { selectedRowKeysRef, displayDataRef, handleCopyInsert, handleCopyJson, handleCopyCsv, handleExportSelected, copyToClipboard } = context;
 
     const getTargets = () => {
         const keys = selectedRowKeysRef.current;


### PR DESCRIPTION
- 禁用 fail-fast 策略，确保多平台构建互不干扰
- 为 go install 增加 -v 参数以输出详细日志
- 修复 DataGrid 组件中未解构 handleExportSelected 导致的编译错误