### PR TITLE
Release/0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,16 +60,19 @@ jobs:
           ls -F
           
           # Find .app bundle
-          APP_NAME=$(find . -maxdepth 1 -name "*.app" | head -n 1)
+          APP_PATH=$(find . -maxdepth 1 -name "*.app" | head -n 1)
           
-          if [ -z "$APP_NAME" ]; then
+          if [ -z "$APP_PATH" ]; then
             echo "❌ 未找到 .app 应用包!"
             exit 1
           fi
           
+          # Get pure name (e.g. GoNavi.app)
+          APP_NAME=$(basename "$APP_PATH")
+          
           DMG_NAME="${{ matrix.artifact_name }}.dmg"
           
-          echo "📦 正在生成 DMG: $DMG_NAME..."
+          echo "📦 正在生成 DMG: $DMG_NAME (源应用: $APP_NAME)..."
           
           # Create DMG
           create-dmg \


### PR DESCRIPTION
- 使用 basename 移除 .app 路径中的相对前缀
- 解决 create-dmg 在 CI 环境下无法定位图标文件的问题