### PR TITLE
🐛 fix(ci): 修复 Release 脚本中文件路径变量引用错误

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,13 @@ jobs:
           # Find .app bundle
           APP_PATH=$(find . -maxdepth 1 -name "*.app" | head -n 1)
           
-          if [ -z "$APP_NAME" ]; then
+          if [ -z "$APP_PATH" ]; then
             echo "❌ 未找到 .app 应用包!"
             exit 1
           fi
+          
+          # Get pure name (e.g. GoNavi.app)
+          APP_NAME=$(basename "$APP_PATH")
           
           # Ad-hoc codesign to prevent "Damaged" error (requires user to allow anyway, but valid structure)
           echo "🔏 正在进行 Ad-hoc 签名..."


### PR DESCRIPTION
- 修正构建脚本中判空检查使用了未定义变量 APP_NAME 的问题