### PR TITLE
🐛 fix(sidebar): 修复断开连接后无法重连及状态残留问题

### DIFF
--- a/frontend/src/components/DataViewer.tsx
+++ b/frontend/src/components/DataViewer.tsx
@@ -162,6 +162,7 @@ const DataViewer: React.FC<{ tab: TabData }> = ({ tab }) => {
   }, [tab, sortInfo, filterConditions]); // Initial load and re-load on sort/filter
 
   return (
+    <div style={{ height: '100%', width: '100%', overflow: 'hidden' }}>
       <DataGrid
           data={data}
           columnNames={columnNames}
@@ -178,6 +179,7 @@ const DataViewer: React.FC<{ tab: TabData }> = ({ tab }) => {
           onToggleFilter={handleToggleFilter}
           onApplyFilter={handleApplyFilter}
       />
+    </div>
   );
 };
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -503,13 +503,21 @@ const Sidebar: React.FC<{ onEditConnection?: (conn: SavedConnection) => void }> 
                  label: '断开连接',
                  icon: <DisconnectOutlined />,
                  onClick: () => {
+                     // Reset status recursively
                      setConnectionStates(prev => {
                          const next = { ...prev };
-                         delete next[node.key];
+                         Object.keys(next).forEach(k => {
+                             if (k === node.key || k.startsWith(`${node.key}-`)) {
+                                 delete next[k];
+                             }
+                         });
                          return next;
                      });
-                     setExpandedKeys(prev => prev.filter(k => k !== node.key));
-                     setLoadedKeys(prev => prev.filter(k => k !== node.key));
+                     // Collapse node and children
+                     setExpandedKeys(prev => prev.filter(k => k !== node.key && !k.toString().startsWith(`${node.key}-`)));
+                     // Reset loaded state recursively
+                     setLoadedKeys(prev => prev.filter(k => k !== node.key && !k.toString().startsWith(`${node.key}-`)));
+                     // Clear children (undefined to trigger reload)
                      setTreeData(origin => updateTreeData(origin, node.key, undefined));
                      message.success("已断开连接");
                  }
@@ -553,8 +561,8 @@ const Sidebar: React.FC<{ onEditConnection?: (conn: SavedConnection) => void }> 
                        delete next[node.key];
                        return next;
                    });
-                   setExpandedKeys(prev => prev.filter(k => k !== node.key));
-                   setLoadedKeys(prev => prev.filter(k => k !== node.key));
+                   setExpandedKeys(prev => prev.filter(k => k !== node.key && !k.toString().startsWith(`${node.key}-`)));
+                   setLoadedKeys(prev => prev.filter(k => k !== node.key && !k.toString().startsWith(`${node.key}-`)));
                    setTreeData(origin => updateTreeData(origin, node.key, undefined));
                }
            },


### PR DESCRIPTION
- 递归清除断开连接/关闭数据库时所有子节点的 loadedKeys 和 connectionStates
- 解决 Ant Design Tree 因状态残留导致不再触发 loadData 的问题
- DataGrid: 优化 ResizeObserver 逻辑，引入 requestAnimationFrame 解决标签页切换高度塌陷
- DataGrid: 为每个表格实例生成唯一 ID 以隔离 CSS 样式冲突
- CSS: 强制禁止侧边栏文字选中，优化右键菜单触发区域