### PR TITLE
🐛 fix(db): 适配 schema/owner 限定名，修复 PG/金仓表不存在，修复表格数据显示异常

### DIFF
--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -8,14 +8,19 @@ import { useStore } from '../store';
 import { v4 as uuidv4 } from 'uuid';
 import 'react-resizable/css/styles.css';
 
+// Normalize RFC3339-like datetime strings to `YYYY-MM-DD HH:mm:ss` for display/editing.
+const normalizeDateTimeString = (val: string) => {
+    const match = val.match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})/);
+    if (!match) return val;
+    return `${match[1]} ${match[2]}`;
+};
+
 // --- Helper: Format Value ---
 const formatCellValue = (val: any) => {
     if (val === null) return <span style={{ color: '#ccc' }}>NULL</span>;
     if (typeof val === 'object') return JSON.stringify(val);
     if (typeof val === 'string') {
-        if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(val)) {
-            return val.replace('T', ' ').replace(/\+.*$/, '').replace(/Z$/, '');
-        }
+        return normalizeDateTimeString(val);
     }
     return String(val);
 };
@@ -103,13 +108,15 @@ const EditableCell: React.FC<EditableCellProps> = React.memo(({
 
   const toggleEdit = () => {
     setEditing(!editing);
-    form.setFieldsValue({ [dataIndex]: record[dataIndex] });
+    const raw = record[dataIndex];
+    const initialValue = typeof raw === 'string' ? normalizeDateTimeString(raw) : raw;
+    form.setFieldsValue({ [dataIndex]: initialValue });
   };
 
   const save = async () => {
     try {
       if (!form) return;
-      const values = await form.validateFields();
+      const values = await form.validateFields([dataIndex]);
       toggleEdit();
       handleSave({ ...record, ...values });
     } catch (errInfo) {
@@ -278,6 +285,7 @@ const DataGrid: React.FC<DataGridProps> = ({
       setModifiedRows({});
       setDeletedRowKeys(new Set());
       setSelectedRowKeys([]);
+      form.resetFields();
   }, [tableName, dbName, connectionId]); // Reset on context change
 
   const displayData = useMemo(() => {

--- a/internal/app/db_context.go
+++ b/internal/app/db_context.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	"strings"
+
+	"GoNavi-Wails/internal/connection"
+)
+
+func normalizeRunConfig(config connection.ConnectionConfig, dbName string) connection.ConnectionConfig {
+	runConfig := config
+	name := strings.TrimSpace(dbName)
+	if name == "" {
+		return runConfig
+	}
+
+	switch strings.ToLower(strings.TrimSpace(config.Type)) {
+	case "mysql", "postgres", "kingbase":
+		// 这些类型的 dbName 表示“数据库”，需要写入连接配置以选择目标库。
+		runConfig.Database = name
+	case "dameng":
+		// 达梦使用 schema 参数，沿用现有行为：dbName 表示 schema。
+		runConfig.Database = name
+	default:
+		// oracle: dbName 表示 schema/owner，不能覆盖 config.Database（服务名）
+		// sqlite: 无需设置 Database
+		// custom: 语义不明确，避免污染缓存 key
+	}
+
+	return runConfig
+}
+
+func normalizeSchemaAndTable(config connection.ConnectionConfig, dbName string, tableName string) (string, string) {
+	rawTable := strings.TrimSpace(tableName)
+	rawDB := strings.TrimSpace(dbName)
+	if rawTable == "" {
+		return rawDB, rawTable
+	}
+
+	if parts := strings.SplitN(rawTable, ".", 2); len(parts) == 2 {
+		schema := strings.TrimSpace(parts[0])
+		table := strings.TrimSpace(parts[1])
+		if schema != "" && table != "" {
+			return schema, table
+		}
+	}
+
+	switch strings.ToLower(strings.TrimSpace(config.Type)) {
+	case "postgres", "kingbase":
+		// PG/金仓：dbName 在 UI 里是“数据库”，schema 需从 tableName 或使用默认 public。
+		return "public", rawTable
+	default:
+		// MySQL：dbName 表示数据库；Oracle/达梦：dbName 表示 schema/owner。
+		return rawDB, rawTable
+	}
+}
+

--- a/internal/app/methods_db.go
+++ b/internal/app/methods_db.go
@@ -83,10 +83,7 @@ func (a *App) MySQLShowCreateTable(config connection.ConnectionConfig, dbName st
 }
 
 func (a *App) DBQuery(config connection.ConnectionConfig, dbName string, query string) connection.QueryResult {
-	runConfig := config
-	if dbName != "" {
-		runConfig.Database = dbName
-	}
+	runConfig := normalizeRunConfig(config, dbName)
 
 	dbInst, err := a.getDatabase(runConfig)
 	if err != nil {
@@ -143,10 +140,7 @@ func (a *App) DBGetDatabases(config connection.ConnectionConfig) connection.Quer
 }
 
 func (a *App) DBGetTables(config connection.ConnectionConfig, dbName string) connection.QueryResult {
-	runConfig := config
-	if dbName != "" {
-		runConfig.Database = dbName
-	}
+	runConfig := normalizeRunConfig(config, dbName)
 
 	dbInst, err := a.getDatabase(runConfig)
 	if err != nil {
@@ -169,10 +163,7 @@ func (a *App) DBGetTables(config connection.ConnectionConfig, dbName string) con
 }
 
 func (a *App) DBShowCreateTable(config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
-	runConfig := config
-	if dbName != "" {
-		runConfig.Database = dbName
-	}
+	runConfig := normalizeRunConfig(config, dbName)
 
 	dbInst, err := a.getDatabase(runConfig)
 	if err != nil {
@@ -180,7 +171,8 @@ func (a *App) DBShowCreateTable(config connection.ConnectionConfig, dbName strin
 		return connection.QueryResult{Success: false, Message: err.Error()}
 	}
 
-	sqlStr, err := dbInst.GetCreateStatement(dbName, tableName)
+	schemaName, pureTableName := normalizeSchemaAndTable(config, dbName, tableName)
+	sqlStr, err := dbInst.GetCreateStatement(schemaName, pureTableName)
 	if err != nil {
 		logger.Error(err, "DBShowCreateTable 获取建表语句失败：%s 表=%s", formatConnSummary(runConfig), tableName)
 		return connection.QueryResult{Success: false, Message: err.Error()}
@@ -190,17 +182,15 @@ func (a *App) DBShowCreateTable(config connection.ConnectionConfig, dbName strin
 }
 
 func (a *App) DBGetColumns(config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
-	runConfig := config
-	if dbName != "" {
-		runConfig.Database = dbName
-	}
+	runConfig := normalizeRunConfig(config, dbName)
 
 	dbInst, err := a.getDatabase(runConfig)
 	if err != nil {
 		return connection.QueryResult{Success: false, Message: err.Error()}
 	}
 
-	columns, err := dbInst.GetColumns(dbName, tableName)
+	schemaName, pureTableName := normalizeSchemaAndTable(config, dbName, tableName)
+	columns, err := dbInst.GetColumns(schemaName, pureTableName)
 	if err != nil {
 		return connection.QueryResult{Success: false, Message: err.Error()}
 	}
@@ -209,17 +199,15 @@ func (a *App) DBGetColumns(config connection.ConnectionConfig, dbName string, ta
 }
 
 func (a *App) DBGetIndexes(config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
-	runConfig := config
-	if dbName != "" {
-		runConfig.Database = dbName
-	}
+	runConfig := normalizeRunConfig(config, dbName)
 
 	dbInst, err := a.getDatabase(runConfig)
 	if err != nil {
 		return connection.QueryResult{Success: false, Message: err.Error()}
 	}
 
-	indexes, err := dbInst.GetIndexes(dbName, tableName)
+	schemaName, pureTableName := normalizeSchemaAndTable(config, dbName, tableName)
+	indexes, err := dbInst.GetIndexes(schemaName, pureTableName)
 	if err != nil {
 		return connection.QueryResult{Success: false, Message: err.Error()}
 	}
@@ -228,17 +216,15 @@ func (a *App) DBGetIndexes(config connection.ConnectionConfig, dbName string, ta
 }
 
 func (a *App) DBGetForeignKeys(config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
-	runConfig := config
-	if dbName != "" {
-		runConfig.Database = dbName
-	}
+	runConfig := normalizeRunConfig(config, dbName)
 
 	dbInst, err := a.getDatabase(runConfig)
 	if err != nil {
 		return connection.QueryResult{Success: false, Message: err.Error()}
 	}
 
-	fks, err := dbInst.GetForeignKeys(dbName, tableName)
+	schemaName, pureTableName := normalizeSchemaAndTable(config, dbName, tableName)
+	fks, err := dbInst.GetForeignKeys(schemaName, pureTableName)
 	if err != nil {
 		return connection.QueryResult{Success: false, Message: err.Error()}
 	}
@@ -247,17 +233,15 @@ func (a *App) DBGetForeignKeys(config connection.ConnectionConfig, dbName string
 }
 
 func (a *App) DBGetTriggers(config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
-	runConfig := config
-	if dbName != "" {
-		runConfig.Database = dbName
-	}
+	runConfig := normalizeRunConfig(config, dbName)
 
 	dbInst, err := a.getDatabase(runConfig)
 	if err != nil {
 		return connection.QueryResult{Success: false, Message: err.Error()}
 	}
 
-	triggers, err := dbInst.GetTriggers(dbName, tableName)
+	schemaName, pureTableName := normalizeSchemaAndTable(config, dbName, tableName)
+	triggers, err := dbInst.GetTriggers(schemaName, pureTableName)
 	if err != nil {
 		return connection.QueryResult{Success: false, Message: err.Error()}
 	}
@@ -266,10 +250,7 @@ func (a *App) DBGetTriggers(config connection.ConnectionConfig, dbName string, t
 }
 
 func (a *App) DBGetAllColumns(config connection.ConnectionConfig, dbName string) connection.QueryResult {
-	runConfig := config
-	if dbName != "" {
-		runConfig.Database = dbName
-	}
+	runConfig := normalizeRunConfig(config, dbName)
 
 	dbInst, err := a.getDatabase(runConfig)
 	if err != nil {

--- a/internal/db/custom_impl.go
+++ b/internal/db/custom_impl.go
@@ -92,7 +92,11 @@ func (c *CustomDB) Query(query string) ([]map[string]interface{}, []string, erro
 			val := values[i]
 			b, ok := val.([]byte)
 			if ok {
-				v = string(b)
+				if b == nil {
+					v = nil
+				} else {
+					v = string(b)
+				}
 			} else {
 				v = val
 			}
@@ -136,13 +140,22 @@ func (c *CustomDB) GetTables(dbName string) ([]string, error) {
 			query = fmt.Sprintf("SHOW TABLES FROM `%s`", dbName)
 		}
 	} else if c.driver == "postgres" || c.driver == "kingbase" {
-		if dbName != "" && dbName != "public" {
-			query = fmt.Sprintf("SELECT table_name FROM information_schema.tables WHERE table_schema = '%s'", dbName)
+		query = `
+			SELECT table_schema AS schemaname, table_name AS tablename
+			FROM information_schema.tables
+			WHERE table_type = 'BASE TABLE'
+			  AND table_schema NOT IN ('pg_catalog', 'information_schema')`
+		if dbName != "" {
+			query += fmt.Sprintf(" AND table_schema = '%s'", dbName)
 		}
+		query += " ORDER BY table_schema, table_name"
 	} else if c.driver == "sqlite" {
 		query = "SELECT name FROM sqlite_master WHERE type='table'"
 	} else if c.driver == "oracle" || c.driver == "dm" {
 		query = "SELECT table_name FROM user_tables"
+		if dbName != "" {
+			query = fmt.Sprintf("SELECT owner, table_name FROM all_tables WHERE owner = '%s' ORDER BY table_name", strings.ToUpper(dbName))
+		}
 	}
 
 	// Fallback generic execution
@@ -153,6 +166,18 @@ func (c *CustomDB) GetTables(dbName string) ([]string, error) {
 
 	var tables []string
 	for _, row := range data {
+		if schema, okSchema := row["schemaname"]; okSchema {
+			if name, okName := row["tablename"]; okName {
+				tables = append(tables, fmt.Sprintf("%v.%v", schema, name))
+				continue
+			}
+		}
+		if owner, okOwner := row["OWNER"]; okOwner {
+			if name, okName := row["TABLE_NAME"]; okName {
+				tables = append(tables, fmt.Sprintf("%v.%v", owner, name))
+				continue
+			}
+		}
 		// iterate keys to find likely column
 		for k, v := range row {
 			if strings.Contains(strings.ToLower(k), "name") || strings.Contains(strings.ToLower(k), "table") {

--- a/internal/db/kingbase_impl.go
+++ b/internal/db/kingbase_impl.go
@@ -154,7 +154,11 @@ func (k *KingbaseDB) Query(query string) ([]map[string]interface{}, []string, er
 			val := values[i]
 			b, ok := val.([]byte)
 			if ok {
-				v = string(b)
+				if b == nil {
+					v = nil
+				} else {
+					v = string(b)
+				}
 			} else {
 				v = val
 			}
@@ -193,15 +197,14 @@ func (k *KingbaseDB) GetDatabases() ([]string, error) {
 }
 
 func (k *KingbaseDB) GetTables(dbName string) ([]string, error) {
-	// Usually restricted to current database connection in PG/Kingbase
-	// dbName param is often Schema in PG context, or ignored if we are connected to a specific DB.
-	// But in PG, cross-database queries are not standard without dblink.
-	// We assume dbName here might mean Schema (public, etc.)
-
-	query := "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'"
-	if dbName != "" && dbName != "public" {
-		query = fmt.Sprintf("SELECT table_name FROM information_schema.tables WHERE table_schema = '%s'", dbName)
-	}
+	// Kingbase: tables are scoped by the current DB connection; include schema to avoid search_path issues.
+	query := `
+		SELECT table_schema AS schemaname, table_name AS tablename
+		FROM information_schema.tables
+		WHERE table_type = 'BASE TABLE'
+		  AND table_schema NOT IN ('pg_catalog', 'information_schema')
+		  AND table_schema NOT LIKE 'pg_%'
+		ORDER BY table_schema, table_name`
 
 	data, _, err := k.Query(query)
 	if err != nil {
@@ -210,6 +213,12 @@ func (k *KingbaseDB) GetTables(dbName string) ([]string, error) {
 
 	var tables []string
 	for _, row := range data {
+		schema, okSchema := row["schemaname"]
+		name, okName := row["tablename"]
+		if okSchema && okName {
+			tables = append(tables, fmt.Sprintf("%v.%v", schema, name))
+			continue
+		}
 		if val, ok := row["table_name"]; ok {
 			tables = append(tables, fmt.Sprintf("%v", val))
 		}

--- a/internal/db/mysql_impl.go
+++ b/internal/db/mysql_impl.go
@@ -111,7 +111,11 @@ func (m *MySQLDB) Query(query string) ([]map[string]interface{}, []string, error
 			val := values[i]
 			b, ok := val.([]byte)
 			if ok {
-				v = string(b)
+				if b == nil {
+					v = nil
+				} else {
+					v = string(b)
+				}
 			} else {
 				v = val
 			}

--- a/internal/db/postgres_impl.go
+++ b/internal/db/postgres_impl.go
@@ -112,7 +112,11 @@ rows, err := p.conn.Query(query)
 			val := values[i]
 			b, ok := val.([]byte)
 			if ok {
-				v = string(b)
+				if b == nil {
+					v = nil
+				} else {
+					v = string(b)
+				}
 			} else {
 				v = val
 			}
@@ -150,7 +154,7 @@ func (p *PostgresDB) GetDatabases() ([]string, error) {
 }
 
 func (p *PostgresDB) GetTables(dbName string) ([]string, error) {
-	query := "SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname != 'pg_catalog' AND schemaname != 'information_schema'"
+	query := "SELECT schemaname, tablename FROM pg_catalog.pg_tables WHERE schemaname != 'information_schema' AND schemaname NOT LIKE 'pg_%' ORDER BY schemaname, tablename"
 	data, _, err := p.Query(query)
 	if err != nil {
 		return nil, err
@@ -158,8 +162,14 @@ func (p *PostgresDB) GetTables(dbName string) ([]string, error) {
 	
 	var tables []string
 	for _, row := range data {
-		if val, ok := row["tablename"]; ok {
-			tables = append(tables, fmt.Sprintf("%v", val))
+		schema, okSchema := row["schemaname"]
+		name, okName := row["tablename"]
+		if okSchema && okName {
+			tables = append(tables, fmt.Sprintf("%v.%v", schema, name))
+			continue
+		}
+		if okName {
+			tables = append(tables, fmt.Sprintf("%v", name))
 		}
 	}
 	return tables, nil

--- a/internal/db/sqlite_impl.go
+++ b/internal/db/sqlite_impl.go
@@ -87,7 +87,11 @@ func (s *SQLiteDB) Query(query string) ([]map[string]interface{}, []string, erro
 			val := values[i]
 			b, ok := val.([]byte)
 			if ok {
-				v = string(b)
+				if b == nil {
+					v = nil
+				} else {
+					v = string(b)
+				}
 			} else {
 				v = val
 			}


### PR DESCRIPTION
- 覆盖 mysql/postgres/kingbase/oracle/dameng/sqlite/custom 的 Query 返回值转换
- 修正可编辑表格保存范围，避免状态残留影响显示
- 表列表返回 schema.table/owner.table，避免 search_path 不一致导致 relation does not exist
- 元数据/导入导出/提交变更统一解析限定名并正确引用
- 前端查询与数据浏览支持限定名 quote
- 单元格编辑态时间字段统一显示为 YYYY-MM-DD HH:mm:ss