### PR TITLE
Feature/0.2.5

### DIFF
--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -21,6 +21,7 @@ interface AppState {
   savedQueries: SavedQuery[];
   darkMode: boolean;
   sqlFormatOptions: { keywordCase: 'upper' | 'lower' };
+  queryOptions: { maxRows: number };
   sqlLogs: SqlLog[];
   
   addConnection: (conn: SavedConnection) => void;
@@ -41,6 +42,7 @@ interface AppState {
 
   toggleDarkMode: () => void;
   setSqlFormatOptions: (options: { keywordCase: 'upper' | 'lower' }) => void;
+  setQueryOptions: (options: Partial<{ maxRows: number }>) => void;
   
   addSqlLog: (log: SqlLog) => void;
   clearSqlLogs: () => void;
@@ -56,6 +58,7 @@ export const useStore = create<AppState>()(
       savedQueries: [],
       darkMode: false,
       sqlFormatOptions: { keywordCase: 'upper' },
+      queryOptions: { maxRows: 5000 },
       sqlLogs: [],
 
       addConnection: (conn) => set((state) => ({ connections: [...state.connections, conn] })),
@@ -124,13 +127,14 @@ export const useStore = create<AppState>()(
 
       toggleDarkMode: () => set((state) => ({ darkMode: !state.darkMode })),
       setSqlFormatOptions: (options) => set({ sqlFormatOptions: options }),
+      setQueryOptions: (options) => set((state) => ({ queryOptions: { ...state.queryOptions, ...options } })),
       
       addSqlLog: (log) => set((state) => ({ sqlLogs: [log, ...state.sqlLogs].slice(0, 1000) })), // Keep last 1000 logs
       clearSqlLogs: () => set({ sqlLogs: [] }),
     }),
     {
       name: 'lite-db-storage', // name of the item in the storage (must be unique)
-      partialize: (state) => ({ connections: state.connections, savedQueries: state.savedQueries, darkMode: state.darkMode, sqlFormatOptions: state.sqlFormatOptions }), // Don't persist logs
+      partialize: (state) => ({ connections: state.connections, savedQueries: state.savedQueries, darkMode: state.darkMode, sqlFormatOptions: state.sqlFormatOptions, queryOptions: state.queryOptions }), // Don't persist logs
     }
   )
 );

--- a/frontend/src/utils/sql.ts
+++ b/frontend/src/utils/sql.ts
@@ -1,0 +1,173 @@
+export type FilterCondition = {
+  id?: number;
+  column?: string;
+  op?: string;
+  value?: string;
+  value2?: string;
+};
+
+const normalizeIdentPart = (ident: string) => {
+  let raw = (ident || '').trim();
+  if (!raw) return raw;
+  const first = raw[0];
+  const last = raw[raw.length - 1];
+  if ((first === '"' && last === '"') || (first === '`' && last === '`')) {
+    raw = raw.slice(1, -1).trim();
+  }
+  raw = raw.replace(/["`]/g, '').trim();
+  return raw;
+};
+
+export const quoteIdentPart = (dbType: string, ident: string) => {
+  const raw = normalizeIdentPart(ident);
+  if (!raw) return raw;
+  if ((dbType || '').toLowerCase() === 'mysql') return `\`${raw.replace(/`/g, '``')}\``;
+  return `"${raw.replace(/"/g, '""')}"`;
+};
+
+export const quoteQualifiedIdent = (dbType: string, ident: string) => {
+  const raw = (ident || '').trim();
+  if (!raw) return raw;
+  const parts = raw.split('.').map(normalizeIdentPart).filter(Boolean);
+  if (parts.length <= 1) return quoteIdentPart(dbType, raw);
+  return parts.map(p => quoteIdentPart(dbType, p)).join('.');
+};
+
+export const escapeLiteral = (val: string) => (val || '').replace(/'/g, "''");
+
+export const parseListValues = (val: string) => {
+  const raw = (val || '').trim();
+  if (!raw) return [];
+  return raw
+    .split(/[\n,，]+/)
+    .map(s => s.trim())
+    .filter(Boolean);
+};
+
+export const buildWhereSQL = (dbType: string, conditions: FilterCondition[]) => {
+  const whereParts: string[] = [];
+
+  (conditions || []).forEach((cond) => {
+    const op = (cond?.op || '').trim();
+    const column = (cond?.column || '').trim();
+    const value = (cond?.value ?? '').toString();
+    const value2 = (cond?.value2 ?? '').toString();
+
+    if (op === 'CUSTOM') {
+      const expr = value.trim();
+      if (expr) whereParts.push(`(${expr})`);
+      return;
+    }
+
+    if (!column) return;
+
+    const col = quoteIdentPart(dbType, column);
+
+    switch (op) {
+      case 'IS_NULL':
+        whereParts.push(`${col} IS NULL`);
+        return;
+      case 'IS_NOT_NULL':
+        whereParts.push(`${col} IS NOT NULL`);
+        return;
+      case 'IS_EMPTY':
+        // 兼容：空值通常理解为 NULL 或空字符串
+        whereParts.push(`(${col} IS NULL OR ${col} = '')`);
+        return;
+      case 'IS_NOT_EMPTY':
+        whereParts.push(`(${col} IS NOT NULL AND ${col} <> '')`);
+        return;
+      case 'BETWEEN': {
+        const v1 = value.trim();
+        const v2 = value2.trim();
+        if (!v1 || !v2) return;
+        whereParts.push(`${col} BETWEEN '${escapeLiteral(v1)}' AND '${escapeLiteral(v2)}'`);
+        return;
+      }
+      case 'NOT_BETWEEN': {
+        const v1 = value.trim();
+        const v2 = value2.trim();
+        if (!v1 || !v2) return;
+        whereParts.push(`${col} NOT BETWEEN '${escapeLiteral(v1)}' AND '${escapeLiteral(v2)}'`);
+        return;
+      }
+      case 'IN': {
+        const items = parseListValues(value);
+        if (items.length === 0) return;
+        const list = items.map(v => `'${escapeLiteral(v)}'`).join(', ');
+        whereParts.push(`${col} IN (${list})`);
+        return;
+      }
+      case 'NOT_IN': {
+        const items = parseListValues(value);
+        if (items.length === 0) return;
+        const list = items.map(v => `'${escapeLiteral(v)}'`).join(', ');
+        whereParts.push(`${col} NOT IN (${list})`);
+        return;
+      }
+      case 'CONTAINS': {
+        const v = value.trim();
+        if (!v) return;
+        whereParts.push(`${col} LIKE '%${escapeLiteral(v)}%'`);
+        return;
+      }
+      case 'NOT_CONTAINS': {
+        const v = value.trim();
+        if (!v) return;
+        whereParts.push(`${col} NOT LIKE '%${escapeLiteral(v)}%'`);
+        return;
+      }
+      case 'STARTS_WITH': {
+        const v = value.trim();
+        if (!v) return;
+        whereParts.push(`${col} LIKE '${escapeLiteral(v)}%'`);
+        return;
+      }
+      case 'NOT_STARTS_WITH': {
+        const v = value.trim();
+        if (!v) return;
+        whereParts.push(`${col} NOT LIKE '${escapeLiteral(v)}%'`);
+        return;
+      }
+      case 'ENDS_WITH': {
+        const v = value.trim();
+        if (!v) return;
+        whereParts.push(`${col} LIKE '%${escapeLiteral(v)}'`);
+        return;
+      }
+      case 'NOT_ENDS_WITH': {
+        const v = value.trim();
+        if (!v) return;
+        whereParts.push(`${col} NOT LIKE '%${escapeLiteral(v)}'`);
+        return;
+      }
+      case '=':
+      case '!=':
+      case '<':
+      case '<=':
+      case '>':
+      case '>=': {
+        const v = value.trim();
+        if (!v) return;
+        whereParts.push(`${col} ${op} '${escapeLiteral(v)}'`);
+        return;
+      }
+      default: {
+        // 兼容旧值：LIKE
+        if (op.toUpperCase() === 'LIKE') {
+          const v = value.trim();
+          if (!v) return;
+          whereParts.push(`${col} LIKE '%${escapeLiteral(v)}%'`);
+          return;
+        }
+
+        const v = value.trim();
+        if (!v) return;
+        whereParts.push(`${col} ${op} '${escapeLiteral(v)}'`);
+      }
+    }
+  });
+
+  return whereParts.length > 0 ? `WHERE ${whereParts.join(' AND ')}` : '';
+};
+

--- a/frontend/wailsjs/go/app/App.d.ts
+++ b/frontend/wailsjs/go/app/App.d.ts
@@ -37,6 +37,8 @@ export function ExportData(arg1:Array<Record<string, any>>,arg2:Array<string>,ar
 
 export function ExportDatabaseSQL(arg1:connection.ConnectionConfig,arg2:string,arg3:boolean):Promise<connection.QueryResult>;
 
+export function ExportQuery(arg1:connection.ConnectionConfig,arg2:string,arg3:string,arg4:string,arg5:string):Promise<connection.QueryResult>;
+
 export function ExportTable(arg1:connection.ConnectionConfig,arg2:string,arg3:string,arg4:string):Promise<connection.QueryResult>;
 
 export function ExportTablesSQL(arg1:connection.ConnectionConfig,arg2:string,arg3:Array<string>,arg4:boolean):Promise<connection.QueryResult>;

--- a/frontend/wailsjs/go/app/App.js
+++ b/frontend/wailsjs/go/app/App.js
@@ -70,6 +70,10 @@ export function ExportDatabaseSQL(arg1, arg2, arg3) {
   return window['go']['app']['App']['ExportDatabaseSQL'](arg1, arg2, arg3);
 }
 
+export function ExportQuery(arg1, arg2, arg3, arg4, arg5) {
+  return window['go']['app']['App']['ExportQuery'](arg1, arg2, arg3, arg4, arg5);
+}
+
 export function ExportTable(arg1, arg2, arg3, arg4) {
   return window['go']['app']['App']['ExportTable'](arg1, arg2, arg3, arg4);
 }

--- a/internal/app/sql_sanitize.go
+++ b/internal/app/sql_sanitize.go
@@ -1,0 +1,219 @@
+package app
+
+import (
+	"strings"
+	"unicode"
+)
+
+func sanitizeSQLForPgLike(dbType string, query string) string {
+	switch strings.ToLower(strings.TrimSpace(dbType)) {
+	case "postgres", "kingbase":
+		return fixBrokenDoubleDoubleQuotedIdent(query)
+	default:
+		return query
+	}
+}
+
+// fixBrokenDoubleDoubleQuotedIdent fixes accidental identifiers like:
+//   SELECT * FROM ""schema"".""table""
+// which can be produced when a quoted identifier gets wrapped by quotes again.
+//
+// It is intentionally conservative:
+// - only runs outside strings/comments/dollar-quoted blocks
+// - does not touch valid escaped-quote sequences inside quoted identifiers (e.g. "a""b")
+func fixBrokenDoubleDoubleQuotedIdent(query string) string {
+	if !strings.Contains(query, `""`) {
+		return query
+	}
+
+	var b strings.Builder
+	b.Grow(len(query))
+
+	inSingle := false
+	inDoubleIdent := false
+	inLineComment := false
+	inBlockComment := false
+	dollarTag := ""
+
+	for i := 0; i < len(query); i++ {
+		ch := query[i]
+		next := byte(0)
+		if i+1 < len(query) {
+			next = query[i+1]
+		}
+
+		if inLineComment {
+			b.WriteByte(ch)
+			if ch == '\n' {
+				inLineComment = false
+			}
+			continue
+		}
+		if inBlockComment {
+			b.WriteByte(ch)
+			if ch == '*' && next == '/' {
+				b.WriteByte('/')
+				i++
+				inBlockComment = false
+			}
+			continue
+		}
+		if dollarTag != "" {
+			if strings.HasPrefix(query[i:], dollarTag) {
+				b.WriteString(dollarTag)
+				i += len(dollarTag) - 1
+				dollarTag = ""
+				continue
+			}
+			b.WriteByte(ch)
+			continue
+		}
+		if inSingle {
+			b.WriteByte(ch)
+			if ch == '\'' {
+				// escaped single quote
+				if next == '\'' {
+					b.WriteByte('\'')
+					i++
+					continue
+				}
+				inSingle = false
+			}
+			continue
+		}
+		if inDoubleIdent {
+			b.WriteByte(ch)
+			if ch == '"' {
+				// escaped quote inside identifier
+				if next == '"' {
+					b.WriteByte('"')
+					i++
+					continue
+				}
+				inDoubleIdent = false
+			}
+			continue
+		}
+
+		// --- Outside of all string/comment blocks ---
+		if ch == '-' && next == '-' {
+			b.WriteByte(ch)
+			b.WriteByte('-')
+			i++
+			inLineComment = true
+			continue
+		}
+		if ch == '/' && next == '*' {
+			b.WriteByte(ch)
+			b.WriteByte('*')
+			i++
+			inBlockComment = true
+			continue
+		}
+		if ch == '\'' {
+			b.WriteByte(ch)
+			inSingle = true
+			continue
+		}
+		if ch == '$' {
+			if tag := parseDollarTag(query[i:]); tag != "" {
+				b.WriteString(tag)
+				i += len(tag) - 1
+				dollarTag = tag
+				continue
+			}
+		}
+
+		// Fix: ""ident"" -> "ident" (only when it looks like a plain identifier)
+		if ch == '"' && next == '"' {
+			prevIsQuote := i > 0 && query[i-1] == '"'
+			nextIsQuote := i+2 < len(query) && query[i+2] == '"'
+			if !prevIsQuote && !nextIsQuote {
+				if replacement, advance, ok := tryFixDoubleDoubleQuotedIdent(query, i); ok {
+					b.WriteString(replacement)
+					i = advance - 1
+					continue
+				}
+			}
+		}
+
+		if ch == '"' {
+			b.WriteByte(ch)
+			inDoubleIdent = true
+			continue
+		}
+
+		b.WriteByte(ch)
+	}
+
+	return b.String()
+}
+
+func tryFixDoubleDoubleQuotedIdent(query string, start int) (replacement string, advance int, ok bool) {
+	// start points at the first quote of `""...""`
+	if start < 0 || start+1 >= len(query) {
+		return "", 0, false
+	}
+	if query[start] != '"' || query[start+1] != '"' {
+		return "", 0, false
+	}
+	if start > 0 && query[start-1] == '"' {
+		return "", 0, false
+	}
+	if start+2 < len(query) && query[start+2] == '"' {
+		return "", 0, false
+	}
+
+	contentStart := start + 2
+	j := contentStart
+	for j+1 < len(query) {
+		if query[j] == '"' && query[j+1] == '"' {
+			// ensure closing pair is not part of a triple quote
+			if j+2 < len(query) && query[j+2] == '"' {
+				j++
+				continue
+			}
+			content := strings.TrimSpace(query[contentStart:j])
+			if looksLikeIdentifierContent(content) {
+				return `"` + content + `"`, j + 2, true
+			}
+			return "", 0, false
+		}
+		// Fast abort: identifier-like content should not span lines.
+		if query[j] == '\n' || query[j] == '\r' {
+			break
+		}
+		j++
+	}
+	return "", 0, false
+}
+
+func looksLikeIdentifierContent(s string) bool {
+	if strings.TrimSpace(s) == "" {
+		return false
+	}
+	for _, r := range s {
+		if r == '_' || r == '$' || r == '-' || unicode.IsLetter(r) || unicode.IsDigit(r) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func parseDollarTag(s string) string {
+	// Match: $tag$ where tag is [A-Za-z0-9_]* (can be empty => $$)
+	if len(s) < 2 || s[0] != '$' {
+		return ""
+	}
+	for i := 1; i < len(s); i++ {
+		c := s[i]
+		if c == '$' {
+			return s[:i+1]
+		}
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') {
+			return ""
+		}
+	}
+	return ""
+}

--- a/internal/app/sql_sanitize_test.go
+++ b/internal/app/sql_sanitize_test.go
@@ -1,0 +1,37 @@
+package app
+
+import "testing"
+
+func TestSanitizeSQLForPgLike_FixesBrokenDoubleDoubleQuotes(t *testing.T) {
+	in := `SELECT * FROM ""ldf_server"".""t_user"" LIMIT 1`
+	out := sanitizeSQLForPgLike("kingbase", in)
+	want := `SELECT * FROM "ldf_server"."t_user" LIMIT 1`
+	if out != want {
+		t.Fatalf("unexpected sanitize output:\nIN:   %s\nOUT:  %s\nWANT: %s", in, out, want)
+	}
+}
+
+func TestSanitizeSQLForPgLike_DoesNotTouchEscapedQuotesInsideIdentifier(t *testing.T) {
+	in := `SELECT "a""b" FROM "t""x"`
+	out := sanitizeSQLForPgLike("postgres", in)
+	if out != in {
+		t.Fatalf("should keep valid escaped quotes inside identifier:\nIN:  %s\nOUT: %s", in, out)
+	}
+}
+
+func TestSanitizeSQLForPgLike_DoesNotTouchDollarQuotedStrings(t *testing.T) {
+	in := "SELECT $$\"\"ldf_server\"\"$$, \"\"ldf_server\"\""
+	out := sanitizeSQLForPgLike("postgres", in)
+	want := "SELECT $$\"\"ldf_server\"\"$$, \"ldf_server\""
+	if out != want {
+		t.Fatalf("unexpected sanitize output for dollar quoted string:\nIN:   %s\nOUT:  %s\nWANT: %s", in, out, want)
+	}
+}
+
+func TestSanitizeSQLForPgLike_DoesNotModifyOtherDBTypes(t *testing.T) {
+	in := `SELECT * FROM ""ldf_server""`
+	out := sanitizeSQLForPgLike("mysql", in)
+	if out != in {
+		t.Fatalf("non-PG-like db should not be sanitized:\nIN:  %s\nOUT: %s", in, out)
+	}
+}

--- a/internal/db/custom_impl.go
+++ b/internal/db/custom_impl.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -57,6 +58,20 @@ func (c *CustomDB) Ping() error {
 	return c.conn.PingContext(ctx)
 }
 
+func (c *CustomDB) QueryContext(ctx context.Context, query string) ([]map[string]interface{}, []string, error) {
+	if c.conn == nil {
+		return nil, nil, fmt.Errorf("connection not open")
+	}
+
+	rows, err := c.conn.QueryContext(ctx, query)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+
+	return scanRows(rows)
+}
+
 func (c *CustomDB) Query(query string) ([]map[string]interface{}, []string, error) {
 	if c.conn == nil {
 		return nil, nil, fmt.Errorf("connection not open")
@@ -94,6 +109,17 @@ func (c *CustomDB) Query(query string) ([]map[string]interface{}, []string, erro
 	}
 
 	return resultData, columns, nil
+}
+
+func (c *CustomDB) ExecContext(ctx context.Context, query string) (int64, error) {
+	if c.conn == nil {
+		return 0, fmt.Errorf("connection not open")
+	}
+	res, err := c.conn.ExecContext(ctx, query)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
 }
 
 func (c *CustomDB) Exec(query string) (int64, error) {

--- a/internal/db/dameng_impl.go
+++ b/internal/db/dameng_impl.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"net"
@@ -88,6 +89,20 @@ func (d *DamengDB) Ping() error {
 	return d.conn.PingContext(ctx)
 }
 
+func (d *DamengDB) QueryContext(ctx context.Context, query string) ([]map[string]interface{}, []string, error) {
+	if d.conn == nil {
+		return nil, nil, fmt.Errorf("connection not open")
+	}
+
+	rows, err := d.conn.QueryContext(ctx, query)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+
+	return scanRows(rows)
+}
+
 func (d *DamengDB) Query(query string) ([]map[string]interface{}, []string, error) {
 	if d.conn == nil {
 		return nil, nil, fmt.Errorf("connection not open")
@@ -125,6 +140,17 @@ func (d *DamengDB) Query(query string) ([]map[string]interface{}, []string, erro
 	}
 
 	return resultData, columns, nil
+}
+
+func (d *DamengDB) ExecContext(ctx context.Context, query string) (int64, error) {
+	if d.conn == nil {
+		return 0, fmt.Errorf("connection not open")
+	}
+	res, err := d.conn.ExecContext(ctx, query)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
 }
 
 func (d *DamengDB) Exec(query string) (int64, error) {

--- a/internal/db/scan_rows.go
+++ b/internal/db/scan_rows.go
@@ -1,0 +1,36 @@
+package db
+
+import "database/sql"
+
+func scanRows(rows *sql.Rows) ([]map[string]interface{}, []string, error) {
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resultData := make([]map[string]interface{}, 0)
+
+	for rows.Next() {
+		values := make([]interface{}, len(columns))
+		valuePtrs := make([]interface{}, len(columns))
+		for i := range columns {
+			valuePtrs[i] = &values[i]
+		}
+
+		if err := rows.Scan(valuePtrs...); err != nil {
+			continue
+		}
+
+		entry := make(map[string]interface{}, len(columns))
+		for i, col := range columns {
+			entry[col] = normalizeQueryValue(values[i])
+		}
+		resultData = append(resultData, entry)
+	}
+
+	if err := rows.Err(); err != nil {
+		return resultData, columns, err
+	}
+	return resultData, columns, nil
+}
+


### PR DESCRIPTION
🐛 fix(table): 修复虚拟表全选丢失并完善导出/筛选能力

- 表头自定义组件保留 width，virtual 模式下选择列正常显示
- 新增后端 ExportQuery，导出当前页/选中行避免长字段 IPC 截断
- 筛选支持更多操作符并统一 WHERE 生成逻辑
Close #57
Close #56

✨ feat(table-edit): 增加整行编辑面板，提升多字段/长文本编辑效率

- 支持选中行后一键打开编辑面板
- 全字段可编辑，长文本/JSON 友好输入与弹窗编辑
- 应用后写入本地变更，提交事务后落库

⚡️ perf(table): 表数据打开加速，主键/统计等耗时操作异步化

- DataViewer 主键列元数据异步拉取，首屏数据优先渲染
- 查询页增加结果集最大行数限制，减少大表全量返回
- DBQuery 引入 Context 超时，降低长查询对 UI 的阻塞风险
- 查询行数设置持久化保存
Closes #48 

✨ feat(db-ui): 修复金仓打开表报错并增强结果页编辑体验

- postgres/kingbase 查询前自动清洗 ""ident"" 形式的非法标识符
- 结果表支持单元格弹窗编辑，提升 JSON/长文本可编辑性
- 修复查询结果表头与数据列宽度不对齐问题
Closes #49
