### PR TITLE
ci: add publish-to-winget action

### DIFF
--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -1,13 +1,15 @@
 name: Publish to WinGet
 on:
-  release:
-    types: [released]
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
     inputs:
       release_tag:
         required: true
         description: 'Tag of release you want to publish'
         type: string
+
 jobs:
   publish:
     runs-on: windows-latest
@@ -15,7 +17,6 @@ jobs:
       - uses: vedantmgoyal9/winget-releaser@v2
         with:
           identifier: Syngnat.GoNavi
-          installers-regex: 'windows-(amd64|arm64)\.exe$'
-          release-tag: ${{ inputs.release_tag || github.event.release.tag_name }}
-          # Make sure that the WINGET_TOKEN has the permissions for the repo, workflow, and pull_request.
+          installers-regex: 'GoNavi-windows-(amd64|arm64)\.exe$'
+          release-tag: ${{ inputs.release_tag || github.ref_name }}
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Related: #55 

### 修改

- 新增 `WinGet` 发布 action

### PS

- 需要额外准备一个 `WINGET_TOKEN`（最低权限：repo, workflow, pull_request）用于发布 `WinGet`。
-  第一次提交时，可能需要手动确认 Publisher，winget-pkgs 的 bot 会在 PR 里提示：“Please confirm you are the publisher”。你只需要点一下按钮即可。之后所有版本更新都会自动通过，不再需要人工确认。（这一点来源于 AI 知识）