### PR TITLE
🔧 fix(postgres): 修复含大写字母的表名查询报错 relation does not exist

### DIFF
--- a/frontend/src/utils/sql.ts
+++ b/frontend/src/utils/sql.ts
@@ -23,6 +23,8 @@ const needsQuote = (ident: string): boolean => {
   if (!ident) return false;
   // 如果包含特殊字符（非字母、数字、下划线）则需要引号
   if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(ident)) return true;
+  // PostgreSQL 会将未加引号的标识符折叠为小写，含大写字母时必须加引号
+  if (/[A-Z]/.test(ident)) return true;
   // 常见 SQL 保留字列表（简化版）
   const reserved = ['select', 'from', 'where', 'table', 'index', 'user', 'order', 'group', 'by', 'limit', 'offset', 'and', 'or', 'not', 'null', 'true', 'false', 'key', 'primary', 'foreign', 'references', 'default', 'constraint', 'create', 'drop', 'alter', 'insert', 'update', 'delete', 'set', 'values', 'into', 'join', 'left', 'right', 'inner', 'outer', 'on', 'as', 'is', 'in', 'like', 'between', 'case', 'when', 'then', 'else', 'end', 'having', 'distinct', 'all', 'any', 'exists', 'union', 'except', 'intersect'];
   return reserved.includes(ident.toLowerCase());


### PR DESCRIPTION
PostgreSQL 会将未加双引号的标识符自动折叠为小写，导致如 Blog 表在查询时
变为 public.blog，触发 relation "public.blog" does not exist 错误。

在 needsQuote 中增加大写字母检测，确保含大写的标识符被双引号包裹。
同时修复 KingBase 的相同问题（共用同一逻辑分支）。