### PR TITLE
统一筛选条件首条/且/或逻辑选择框宽度

### DIFF
--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -3384,22 +3384,17 @@ const DataGrid: React.FC<DataGridProps> = ({
                        <Checkbox
                            checked={cond.enabled !== false}
                            onChange={e => updateFilter(cond.id, 'enabled', e.target.checked)}
-                           style={{ marginTop: 6 }}
+                            style={{ marginTop: 6, flex: '0 0 auto', whiteSpace: 'nowrap' }}
                        >
                            启用
                        </Checkbox>
-                       {condIndex === 0 ? (
-                           <div style={{ width: 96, marginTop: 7, textAlign: 'center', fontSize: 12, color: '#8c8c8c' }}>
-                               首条
-                           </div>
-                       ) : (
-                           <Select
-                               style={{ width: 96 }}
-                               value={cond.logic === 'OR' ? 'OR' : 'AND'}
-                               onChange={v => updateFilter(cond.id, 'logic', v)}
-                               options={filterLogicOptions as any}
-                           />
-                       )}
+                        <Select
+                            style={{ width: 96, minWidth: 96, maxWidth: 96, flex: '0 0 96px' }}
+                            value={condIndex === 0 ? '__FIRST__' : (cond.logic === 'OR' ? 'OR' : 'AND')}
+                            onChange={v => updateFilter(cond.id, 'logic', v)}
+                            options={condIndex === 0 ? [{ value: '__FIRST__', label: '首条' }] : (filterLogicOptions as any)}
+                            disabled={condIndex === 0}
+                        />
                         <Select
                             style={{ width: 180 }}
                             value={cond.column}


### PR DESCRIPTION
## 背景
- 多条件筛选时，首条条件与后续“且/或”逻辑选择框的外观不一致。
- 在非最大化窗口下，逻辑选择框还会出现长度不统一的问题，影响界面整洁度。

## 变更内容
- 将首条条件的占位展示改为与后续一致的禁用态选择框。
- 为“首条 / 且 / 或”逻辑选择框设置固定宽度与固定收缩策略。
- 调整“启用”复选框样式，避免窄窗口下被挤压换行。

## 影响范围
- 仅影响数据表筛选区条件行的前端展示。
- 不涉及筛选逻辑、查询执行链路和后端行为。

## 验证方式
- 执行 `cd frontend && npm run build`，构建通过。
- 手动验证多条件筛选场景下“首条 / 且 / 或”三种状态宽度一致。

## 风险与回滚
- 风险较低，仅为前端样式调整。
- 如需回滚，可直接回退本 PR 对 `frontend/src/components/DataGrid.tsx` 的修改。