### PR TITLE
feat(datagrid): 统一筛选条件首条/且/或逻辑选择框宽度

### DIFF
--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -3384,22 +3384,17 @@ const DataGrid: React.FC<DataGridProps> = ({
                        <Checkbox
                            checked={cond.enabled !== false}
                            onChange={e => updateFilter(cond.id, 'enabled', e.target.checked)}
-                           style={{ marginTop: 6 }}
+                            style={{ marginTop: 6, flex: '0 0 auto', whiteSpace: 'nowrap' }}
                        >
                            启用
                        </Checkbox>
-                       {condIndex === 0 ? (
-                           <div style={{ width: 96, marginTop: 7, textAlign: 'center', fontSize: 12, color: '#8c8c8c' }}>
-                               首条
-                           </div>
-                       ) : (
-                           <Select
-                               style={{ width: 96 }}
-                               value={cond.logic === 'OR' ? 'OR' : 'AND'}
-                               onChange={v => updateFilter(cond.id, 'logic', v)}
-                               options={filterLogicOptions as any}
-                           />
-                       )}
+                        <Select
+                            style={{ width: 96, minWidth: 96, maxWidth: 96, flex: '0 0 96px' }}
+                            value={condIndex === 0 ? '__FIRST__' : (cond.logic === 'OR' ? 'OR' : 'AND')}
+                            onChange={v => updateFilter(cond.id, 'logic', v)}
+                            options={condIndex === 0 ? [{ value: '__FIRST__', label: '首条' }] : (filterLogicOptions as any)}
+                            disabled={condIndex === 0}
+                        />
                         <Select
                             style={{ width: 180 }}
                             value={cond.column}


### PR DESCRIPTION
## 变更说明

本 PR 主要修复数据表多条件筛选场景下，首条条件与后续“且 / 或”逻辑选择框样式不一致，以及非最大化窗口下逻辑选择框宽度不统一的问题，提升筛选区域的视觉一致性。

## 主要改动

- 将首条条件的占位展示改为与后续一致的禁用态选择框
- 为“首条 / 且 / 或”逻辑选择框设置固定宽度与固定收缩策略
- 调整“启用”复选框样式，避免窄窗口下被挤压换行

## 验证情况

- 本地已通过前端构建
- 已在多条件筛选场景下验证“首条 / 且 / 或”三种状态宽度一致
- 未涉及后端逻辑与查询执行链路改动