### PR TITLE
🐛 fix(oracle-query): 修复 Oracle 表数据分页 SQL 兼容问题 refs #196

### DIFF
--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -10,7 +10,7 @@ import { useStore } from '../store';
 import type { ColumnDefinition } from '../types';
 import { v4 as uuidv4 } from 'uuid';
 import 'react-resizable/css/styles.css';
-import { buildOrderBySQL, buildWhereSQL, escapeLiteral, quoteIdentPart, quoteQualifiedIdent, withSortBufferTuningSQL, type FilterCondition } from '../utils/sql';
+import { buildOrderBySQL, buildPaginatedSelectSQL, buildWhereSQL, escapeLiteral, quoteIdentPart, quoteQualifiedIdent, withSortBufferTuningSQL, type FilterCondition } from '../utils/sql';
 import { isMacLikePlatform, normalizeOpacityForPlatform, resolveAppearanceValues } from '../utils/appearance';
 import { getDataSourceCapabilities } from '../utils/dataSourceCapabilities';
 
@@ -2447,18 +2447,18 @@ const DataGrid: React.FC<DataGridProps> = ({
       return clauses.join(' OR ');
   }, [pkColumns, tableName]);
 
-  const buildCurrentPageSql = useCallback((dbType: string) => {
+      const buildCurrentPageSql = useCallback((dbType: string) => {
       if (!tableName || !pagination) return '';
       const whereSQL = buildWhereSQL(dbType, filterConditions);
-      let sql = `SELECT * FROM ${quoteQualifiedIdent(dbType, tableName)} ${whereSQL}`;
-      sql += buildOrderBySQL(dbType, sortInfo, pkColumns);
+      const baseSql = `SELECT * FROM ${quoteQualifiedIdent(dbType, tableName)} ${whereSQL}`;
+      const orderBySQL = buildOrderBySQL(dbType, sortInfo, pkColumns);
       const normalizedType = String(dbType || '').trim().toLowerCase();
       const hasExplicitSort = !!sortInfo?.columnKey && (sortInfo?.order === 'ascend' || sortInfo?.order === 'descend');
+      const offset = (pagination.current - 1) * pagination.pageSize;
+      let sql = buildPaginatedSelectSQL(dbType, baseSql, orderBySQL, pagination.pageSize, offset);
       if (hasExplicitSort && (normalizedType === 'mysql' || normalizedType === 'mariadb')) {
           sql = withSortBufferTuningSQL(normalizedType, sql, 32 * 1024 * 1024);
       }
-      const offset = (pagination.current - 1) * pagination.pageSize;
-      sql += ` LIMIT ${pagination.pageSize} OFFSET ${offset}`;
       return sql;
   }, [tableName, pagination, filterConditions, sortInfo, pkColumns]);
 

--- a/frontend/src/components/DataViewer.tsx
+++ b/frontend/src/components/DataViewer.tsx
@@ -4,7 +4,7 @@ import { TabData, ColumnDefinition } from '../types';
 import { useStore } from '../store';
 import { DBQuery, DBGetColumns } from '../../wailsjs/go/app/App';
 import DataGrid, { GONAVI_ROW_KEY } from './DataGrid';
-import { buildOrderBySQL, buildWhereSQL, quoteIdentPart, quoteQualifiedIdent, withSortBufferTuningSQL, type FilterCondition } from '../utils/sql';
+import { buildOrderBySQL, buildPaginatedSelectSQL, buildWhereSQL, quoteIdentPart, quoteQualifiedIdent, withSortBufferTuningSQL, type FilterCondition } from '../utils/sql';
 import { buildMongoCountCommand, buildMongoFilter, buildMongoFindCommand, buildMongoSort } from '../utils/mongodb';
 import { getDataSourceCapabilities } from '../utils/dataSourceCapabilities';
 
@@ -455,7 +455,7 @@ const DataViewer: React.FC<{ tab: TabData }> = ({ tab }) => {
             if (pageRowCount > 0) {
                 const tailOffset = Math.max(0, totalRows - (offset + pageRowCount));
                 if (tailOffset < offset) {
-                    sql = `${baseSql}${reverseOrderSQL} LIMIT ${pageRowCount} OFFSET ${tailOffset}`;
+                    sql = buildPaginatedSelectSQL(dbType, baseSql, reverseOrderSQL, pageRowCount, tailOffset);
                     useClickHouseReversePagination = true;
                     clickHouseReverseLimit = pageRowCount;
                     clickHouseReverseHasMore = currentPage < totalPages;
@@ -464,7 +464,7 @@ const DataViewer: React.FC<{ tab: TabData }> = ({ tab }) => {
         }
         if (!useClickHouseReversePagination) {
             // 大表性能：打开表不阻塞在 COUNT(*)，先通过多取 1 条判断是否还有下一页；总数在后台统计并异步回填。
-            sql += ` LIMIT ${size + 1} OFFSET ${offset}`;
+            sql = buildPaginatedSelectSQL(dbType, baseSql, orderBySQL, size + 1, offset);
         }
     }
 
@@ -534,8 +534,7 @@ const DataViewer: React.FC<{ tab: TabData }> = ({ tab }) => {
 
             if (safeSelect) {
                 let fallbackSql = `SELECT ${safeSelect} FROM ${quoteQualifiedIdent(dbType, tableName)} ${whereSQL}`;
-                fallbackSql += buildOrderBySQL(dbType, sortInfo, pkColumns);
-                fallbackSql += ` LIMIT ${size + 1} OFFSET ${offset}`;
+                fallbackSql = buildPaginatedSelectSQL(dbType, fallbackSql, buildOrderBySQL(dbType, sortInfo, pkColumns), size + 1, offset);
                 executedSql = fallbackSql;
                 resData = await executeDataQuery(fallbackSql, '复杂类型降级重试');
             }

--- a/frontend/src/utils/sql.ts
+++ b/frontend/src/utils/sql.ts
@@ -134,6 +134,41 @@ export const buildOrderBySQL = (
   return '';
 };
 
+export const buildPaginatedSelectSQL = (
+  dbType: string,
+  baseSql: string,
+  orderBySQL: string,
+  limit: number,
+  offset: number,
+) => {
+  const normalizedType = String(dbType || '').trim().toLowerCase();
+  const safeLimit = Math.max(0, Math.floor(Number(limit) || 0));
+  const safeOffset = Math.max(0, Math.floor(Number(offset) || 0));
+  const base = String(baseSql || '').trim();
+  const orderBy = String(orderBySQL || '');
+
+  if (!base || safeLimit <= 0) {
+    return `${base}${orderBy}`;
+  }
+
+  switch (normalizedType) {
+    case 'oracle': {
+      const orderedSql = `${base}${orderBy}`;
+      const upperBound = safeOffset + safeLimit;
+      if (safeOffset <= 0) {
+        return `SELECT * FROM (${orderedSql}) WHERE ROWNUM <= ${upperBound}`;
+      }
+      return `SELECT * FROM (SELECT "__gonavi_page__".*, ROWNUM "__gonavi_rn__" FROM (${orderedSql}) "__gonavi_page__" WHERE ROWNUM <= ${upperBound}) WHERE "__gonavi_rn__" > ${safeOffset}`;
+    }
+    case 'sqlserver': {
+      const effectiveOrderBy = orderBy.trim() ? orderBy : ' ORDER BY (SELECT NULL)';
+      return `${base}${effectiveOrderBy} OFFSET ${safeOffset} ROWS FETCH NEXT ${safeLimit} ROWS ONLY`;
+    }
+    default:
+      return `${base}${orderBy} LIMIT ${safeLimit} OFFSET ${safeOffset}`;
+  }
+};
+
 export const parseListValues = (val: string) => {
   const raw = (val || '').trim();
   if (!raw) return [];


### PR DESCRIPTION
## 变更说明

  修复 Oracle 数据源在表数据浏览场景下生成错误分页 SQL，导致查询报 `ORA-00933` 的问题。

  ## 主要改动

  - 抽离按数据源类型生成分页查询 SQL 的通用逻辑
  - Oracle 改为使用兼容的分页语法，不再直接拼接 `LIMIT ... OFFSET`
  - DataViewer 表数据主查询改为复用统一分页 SQL 构造
  - DataGrid 当前页导出查询同步复用统一分页 SQL 构造
  - 保持其他支持 `LIMIT/OFFSET` 的数据源现有逻辑不变
  - 顺带兼容 SQL Server 等不支持 MySQL 风格分页语法的数据源

  ## 关联 Issue

  - refs #196

  ## 验证情况

  - 已通过前端构建验证
  - 已检查 Oracle 表数据页与当前页导出查询的分页 SQL 生成逻辑