### PR TITLE
🐛 fix(connection-modal): 修复连接配置输入框自动首字母大写问题

### DIFF
--- a/frontend/src/components/ConnectionModal.tsx
+++ b/frontend/src/components/ConnectionModal.tsx
@@ -19,6 +19,20 @@ const CONNECTION_MODAL_WIDTH = 960;
 const CONNECTION_MODAL_BODY_HEIGHT = 620;
 const STEP1_SIDEBAR_DIVIDER_DARK = 'rgba(255, 255, 255, 0.16)';
 const STEP1_SIDEBAR_DIVIDER_LIGHT = 'rgba(0, 0, 0, 0.08)';
+const noAutoCapInputProps = {
+  autoCapitalize: 'none' as const,
+  autoCorrect: 'off' as const,
+  spellCheck: false,
+};
+
+const applyNoAutoCapAttributes = (element: Element) => {
+  if (!(element instanceof HTMLInputElement) && !(element instanceof HTMLTextAreaElement)) {
+    return;
+  }
+  element.setAttribute('autocapitalize', 'none');
+  element.setAttribute('autocorrect', 'off');
+  element.setAttribute('spellcheck', 'false');
+};
 
 type ConnectionSecretKey =
   | 'primaryPassword'
@@ -196,6 +210,23 @@ const ConnectionModal: React.FC<{
       marginTop: 12,
       border: darkMode ? '1px solid rgba(255, 255, 255, 0.16)' : '1px solid rgba(0, 0, 0, 0.06)',
   };
+
+  useEffect(() => {
+      if (!open) return;
+      const applyForConnectionModal = () => {
+          document
+              .querySelectorAll('.connection-modal-wrap input, .connection-modal-wrap textarea')
+              .forEach(applyNoAutoCapAttributes);
+      };
+      applyForConnectionModal();
+      const observer = new MutationObserver(() => {
+          applyForConnectionModal();
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+      return () => {
+          observer.disconnect();
+      };
+  }, [open]);
 
 
   const modalShellStyle = useMemo(() => ({
@@ -2072,7 +2103,7 @@ const ConnectionModal: React.FC<{
               <div style={{ ...modalMutedTextStyle, marginBottom: 16 }}>常用参数集中在左侧，优先完成连接建立所需的最小输入。</div>
 
               <Form.Item name="name" label="连接名称">
-                  <Input placeholder="例如：本地测试库" />
+                  <Input {...noAutoCapInputProps} placeholder="例如：本地测试库" />
               </Form.Item>
 
               {!isCustom && (
@@ -2082,7 +2113,7 @@ const ConnectionModal: React.FC<{
                           label="连接 URI（可复制粘贴）"
                           help="支持从参数生成、复制到剪贴板，或粘贴后一键解析回填参数"
                       >
-                          <Input.TextArea rows={3} placeholder={getUriPlaceholder()} />
+                          <Input.TextArea {...noAutoCapInputProps} rows={3} placeholder={getUriPlaceholder()} />
                       </Form.Item>
                       <Space size={8} style={{ marginBottom: uriFeedback ? 12 : 16 }} wrap>
                           <Button onClick={handleGenerateURI}>生成 URI</Button>
@@ -2112,10 +2143,10 @@ const ConnectionModal: React.FC<{
               {isCustom ? (
                   <>
                       <Form.Item name="driver" label="驱动名称 (Driver Name)" rules={[{ required: true, message: '请输入驱动名称' }]} help="已支持: mysql, postgres, sqlite, oracle, dm, kingbase">
-                          <Input placeholder="例如: mysql, postgres" />
+                          <Input {...noAutoCapInputProps} placeholder="例如: mysql, postgres" />
                       </Form.Item>
                       <Form.Item name="dsn" label="连接字符串 (DSN)" rules={[createCustomDsnRule()]}>
-                          <Input.TextArea rows={4} placeholder="例如: user:pass@tcp(localhost:3306)/dbname?charset=utf8" />
+                          <Input.TextArea {...noAutoCapInputProps} rows={4} placeholder="例如: user:pass@tcp(localhost:3306)/dbname?charset=utf8" />
                       </Form.Item>
                       {renderStoredSecretControls({
                           fieldName: 'dsn',
@@ -2135,6 +2166,7 @@ const ConnectionModal: React.FC<{
                               style={{ marginBottom: 0 }}
                           >
                               <Input
+                                  {...noAutoCapInputProps}
                                   placeholder={isFileDb ? (dbType === 'duckdb' ? '/path/to/db.duckdb' : '/path/to/db.sqlite') : 'localhost'}
                               />
                           </Form.Item>
@@ -2162,7 +2194,7 @@ const ConnectionModal: React.FC<{
                               label="默认连接数据库（可选）"
                               help="留空会自动尝试 postgres、template1、与当前用户名同名数据库"
                           >
-                              <Input placeholder="例如：appdb" />
+                              <Input {...noAutoCapInputProps} placeholder="例如：appdb" />
                           </Form.Item>
                       )}
 
@@ -2173,7 +2205,7 @@ const ConnectionModal: React.FC<{
                               rules={[createUriAwareRequiredRule('请输入 Oracle 服务名（例如 ORCLPDB1）')]}
                               help="请填写监听器注册的 SERVICE_NAME（不是用户名）。例如：ORCLPDB1"
                           >
-                              <Input placeholder="例如：ORCLPDB1" />
+                              <Input {...noAutoCapInputProps} placeholder="例如：ORCLPDB1" />
                           </Form.Item>
                       )}
 
@@ -2198,10 +2230,10 @@ const ConnectionModal: React.FC<{
                                       </Form.Item>
                                       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 16 }}>
                                           <Form.Item name="mysqlReplicaUser" label="从库用户名（可选）" style={{ marginBottom: 0 }}>
-                                              <Input placeholder="留空沿用主库用户名" />
+                                              <Input {...noAutoCapInputProps} placeholder="留空沿用主库用户名" />
                                           </Form.Item>
                                           <Form.Item name="mysqlReplicaPassword" label="从库密码（可选）" style={{ marginBottom: 0 }}>
-                                              <Input.Password placeholder="留空沿用主库密码" />
+                                              <Input.Password {...noAutoCapInputProps} placeholder="留空沿用主库密码" />
                                           </Form.Item>
                                       </div>
                                       {renderStoredSecretControls({
@@ -2244,14 +2276,14 @@ const ConnectionModal: React.FC<{
                                       </Form.Item>
                                       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 16 }}>
                                           <Form.Item name="mongoReplicaSet" label="副本集名称（可选）" style={{ marginBottom: 0 }}>
-                                              <Input placeholder="例如：rs0" />
+                                              <Input {...noAutoCapInputProps} placeholder="例如：rs0" />
                                           </Form.Item>
                                           <Form.Item name="mongoReplicaUser" label="副本集用户名（可选）" style={{ marginBottom: 0 }}>
-                                              <Input placeholder="留空沿用主用户名" />
+                                              <Input {...noAutoCapInputProps} placeholder="留空沿用主用户名" />
                                           </Form.Item>
                                       </div>
                                       <Form.Item name="mongoReplicaPassword" label="副本集密码（可选）" style={{ marginBottom: 0 }}>
-                                          <Input.Password placeholder="留空沿用主密码" />
+                                          <Input.Password {...noAutoCapInputProps} placeholder="留空沿用主密码" />
                                       </Form.Item>
                                       {renderStoredSecretControls({
                                           fieldName: 'mongoReplicaPassword',
@@ -2295,7 +2327,7 @@ const ConnectionModal: React.FC<{
                               )}
                               <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 16 }}>
                                   <Form.Item name="mongoAuthSource" label="认证库 (authSource)" style={{ marginBottom: 0 }}>
-                                      <Input placeholder="默认使用 database 或 admin" />
+                                      <Input {...noAutoCapInputProps} placeholder="默认使用 database 或 admin" />
                                   </Form.Item>
                                   <Form.Item name="mongoReadPreference" label="读偏好 (readPreference)" style={{ marginBottom: 0 }}>
                                       <Select
@@ -2332,7 +2364,7 @@ const ConnectionModal: React.FC<{
                                   </Form.Item>
                               )}
                               <Form.Item name="password" label="密码 (可选)">
-                                  <Input.Password placeholder="Redis 密码（如果设置了 requirepass）" />
+                                  <Input.Password {...noAutoCapInputProps} placeholder="Redis 密码（如果设置了 requirepass）" />
                               </Form.Item>
                               {renderStoredSecretControls({
                                   fieldName: 'password',
@@ -2362,10 +2394,10 @@ const ConnectionModal: React.FC<{
                                   rules={dbType === 'mongodb' ? [] : [createUriAwareRequiredRule('请输入用户名')]}
                                   style={{ marginBottom: 0 }}
                               >
-                                  <Input />
+                                  <Input {...noAutoCapInputProps} />
                               </Form.Item>
                               <Form.Item name="password" label="密码" style={{ marginBottom: 0 }}>
-                                  <Input.Password />
+                                  <Input.Password {...noAutoCapInputProps} />
                               </Form.Item>
                               {dbType === 'mongodb' && (
                                   <Form.Item name="mongoAuthMechanism" label="验证方式" style={{ marginBottom: 0 }}>
@@ -2449,10 +2481,10 @@ const ConnectionModal: React.FC<{
                                   {dbType === 'dameng' && (
                                       <>
                                           <Form.Item name="sslCertPath" label="客户端证书路径 (SSL_CERT_PATH)" rules={[{ required: true, message: '达梦 SSL 需要证书路径' }]} style={{ marginBottom: 8 }}>
-                                              <Input placeholder="例如: C:\certs\client-cert.pem" />
+                                              <Input {...noAutoCapInputProps} placeholder="例如: C:\certs\client-cert.pem" />
                                           </Form.Item>
                                           <Form.Item name="sslKeyPath" label="客户端私钥路径 (SSL_KEY_PATH)" rules={[{ required: true, message: '达梦 SSL 需要私钥路径' }]} style={{ marginBottom: 8 }}>
-                                              <Input placeholder="例如: C:\certs\client-key.pem" />
+                                              <Input {...noAutoCapInputProps} placeholder="例如: C:\certs\client-key.pem" />
                                           </Form.Item>
                                       </>
                                   )}
@@ -2475,7 +2507,7 @@ const ConnectionModal: React.FC<{
                               <div style={tunnelSectionStyle}>
                               <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 120px', gap: 16 }}>
                                   <Form.Item name="sshHost" label="SSH 主机 (域名或IP)" rules={[{ required: useSSH, message: '请输入SSH主机' }]} style={{ flex: 1 }}>
-                                      <Input placeholder="例如: ssh.example.com 或 192.168.1.100" />
+                                      <Input {...noAutoCapInputProps} placeholder="例如: ssh.example.com 或 192.168.1.100" />
                                   </Form.Item>
                                   <Form.Item name="sshPort" label="端口" rules={[{ required: useSSH, message: '请输入SSH端口' }]} style={{ width: 100 }}>
                                       <InputNumber style={{ width: '100%' }} />
@@ -2483,16 +2515,16 @@ const ConnectionModal: React.FC<{
                               </div>
                               <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 16 }}>
                                   <Form.Item name="sshUser" label="SSH 用户" rules={[{ required: useSSH, message: '请输入SSH用户' }]} style={{ flex: 1 }}>
-                                      <Input placeholder="root" />
+                                      <Input {...noAutoCapInputProps} placeholder="root" />
                                   </Form.Item>
                                   <Form.Item name="sshPassword" label="SSH 密码" style={{ flex: 1 }}>
-                                      <Input.Password placeholder="密码" />
+                                      <Input.Password {...noAutoCapInputProps} placeholder="密码" />
                                       </Form.Item>
                                   </div>
                                   <Form.Item label="私钥路径 (可选)" help="例如: /Users/name/.ssh/id_rsa">
                                       <Space.Compact style={{ width: '100%' }}>
                                           <Form.Item name="sshKeyPath" noStyle>
-                                              <Input placeholder="绝对路径" />
+                                              <Input {...noAutoCapInputProps} placeholder="绝对路径" />
                                           </Form.Item>
                                           <Button onClick={handleSelectSSHKeyFile} loading={selectingSSHKey}>
                                               浏览...
@@ -2523,7 +2555,7 @@ const ConnectionModal: React.FC<{
                           ) : (
                               <div style={tunnelSectionStyle}>
                               <Form.Item name="proxyHost" label="代理主机" rules={[{ required: useProxy, message: '请输入代理主机' }]}>
-                                  <Input placeholder="例如: 127.0.0.1 或 proxy.company.com" />
+                                  <Input {...noAutoCapInputProps} placeholder="例如: 127.0.0.1 或 proxy.company.com" />
                               </Form.Item>
                               <div style={{ display: 'grid', gridTemplateColumns: '180px 120px', gap: 16 }}>
                                   <Form.Item name="proxyType" label="代理类型" rules={[{ required: useProxy, message: '请选择代理类型' }]} style={{ marginBottom: 0 }}>
@@ -2538,10 +2570,10 @@ const ConnectionModal: React.FC<{
                               </div>
                               <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 16 }}>
                                   <Form.Item name="proxyUser" label="代理用户名（可选）" style={{ flex: 1 }}>
-                                      <Input placeholder="留空表示无认证" />
+                                      <Input {...noAutoCapInputProps} placeholder="留空表示无认证" />
                                   </Form.Item>
                                   <Form.Item name="proxyPassword" label="代理密码（可选）" style={{ flex: 1 }}>
-                                      <Input.Password placeholder="留空表示无认证" />
+                                      <Input.Password {...noAutoCapInputProps} placeholder="留空表示无认证" />
                                       </Form.Item>
                                   </div>
                                   {renderStoredSecretControls({
@@ -2568,7 +2600,7 @@ const ConnectionModal: React.FC<{
                           <div style={tunnelSectionStyle}>
                               <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 120px', gap: 16 }}>
                                   <Form.Item name="httpTunnelHost" label="隧道主机" rules={[{ required: useHttpTunnel, message: '请输入隧道主机' }]} style={{ flex: 1 }}>
-                                      <Input placeholder="例如: tunnel.company.com 或 127.0.0.1" />
+                                      <Input {...noAutoCapInputProps} placeholder="例如: tunnel.company.com 或 127.0.0.1" />
                                   </Form.Item>
                                   <Form.Item name="httpTunnelPort" label="端口" rules={[{ required: useHttpTunnel, message: '请输入隧道端口' }]} style={{ width: 120 }}>
                                       <InputNumber style={{ width: '100%' }} min={1} max={65535} />
@@ -2576,10 +2608,10 @@ const ConnectionModal: React.FC<{
                               </div>
                               <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 16 }}>
                                   <Form.Item name="httpTunnelUser" label="隧道用户名（可选）" style={{ flex: 1 }}>
-                                      <Input placeholder="留空表示无认证" />
+                                      <Input {...noAutoCapInputProps} placeholder="留空表示无认证" />
                                   </Form.Item>
                                   <Form.Item name="httpTunnelPassword" label="隧道密码（可选）" style={{ flex: 1 }}>
-                                      <Input.Password placeholder="留空表示无认证" />
+                                      <Input.Password {...noAutoCapInputProps} placeholder="留空表示无认证" />
                                   </Form.Item>
                               </div>
                               {renderStoredSecretControls({
@@ -2791,7 +2823,7 @@ const ConnectionModal: React.FC<{
                   }
               }}
           >
-              <Form.Item name="type" hidden><Input /></Form.Item>
+              <Form.Item name="type" hidden><Input {...noAutoCapInputProps} /></Form.Item>
               {currentDriverUnavailableReason && (
                   <Alert
                       showIcon
@@ -3119,7 +3151,6 @@ const ConnectionModal: React.FC<{
 };
 
 export default ConnectionModal;
-
 
 
 


### PR DESCRIPTION
## 背景与问题
连接配置弹窗中，多个输入项在部分输入法/系统环境下会自动首字母大写，导致主机、用户名、库名、URI、路径等大小写敏感内容被意外改写，影响连接配置体验与正确性。

## 主要改动
- 在 `frontend/src/components/ConnectionModal.tsx` 新增统一输入属性，显式关闭：
  - `autoCapitalize`
  - `autoCorrect`
  - `spellCheck`
- 将上述属性应用到连接配置页内的文本输入组件（`Input` / `Input.Password` / `Input.TextArea`）。
- 增加弹窗级兜底处理：
  - 在弹窗打开后监听 DOM 变化；
  - 对动态出现的 `input/textarea`（如 `Select` 的搜索输入、`tags` 输入等）补齐禁用自动首字母大写属性，避免遗漏。

## 影响范围（功能点）
本次修复仅影响“连接配置弹窗”中的文本输入行为，具体包括：
1. 连接基础信息
   - 连接名称
   - 连接 URI（输入/粘贴/解析）
   - 自定义驱动名、DSN
2. 通用连接参数
   - 主机地址（Host）/ 文件路径
   - 数据库名（含 Oracle Service Name）
   - 用户名、密码
3. 拓扑与高级参数输入
   - MySQL 主从：从库用户名、从库密码
   - MongoDB 副本集：副本集名称、副本集用户名、副本集密码、authSource
   - Redis：密码
   - 代理/隧道：代理主机、代理用户名/密码、HTTP 隧道主机、隧道用户名/密码
   - SSH：SSH 主机、SSH 用户、SSH 密码、私钥路径
   - SSL（达梦）：证书路径、私钥路径
4. 选择器内可输入文本（重点）
   - “显示数据库”这类 `Select` 搜索输入
   - `tags` 模式下的手工输入（如附加节点 `host:port`）
5. 不受影响项
   - 数值输入控件（如端口、超时等 `InputNumber`）逻辑不变
   - 后端连接协议、字段结构与存储逻辑不变

## 验证方式
- 构建验证：在 `frontend` 目录执行 `npm run build` 通过。
- 手动验证建议：
  - 用户名/主机/库名/URI 输入不再被自动首字母大写；
  - “显示数据库”选择器搜索输入与 `tags` 输入保持原始大小写；
  - 密码字段保持 `password` 类型，仅关闭自动首字母大写/自动纠错/拼写检查；
  - 其他非文本输入行为不受影响。

## 截图说明（来自材料目录）
- 问题前：`问题1.png`、`问题2.png`、`问题3.png`

<img width="442" height="130" alt="问题1" src="https://github.com/user-attachments/assets/dd228697-6f5d-4298-a9b2-6b04b2641c72" />
<img width="396" height="157" alt="问题2" src="https://github.com/user-attachments/assets/e1ad53b4-ee11-4676-b67b-0700596794d0" />
<img width="428" height="147" alt="问题3" src="https://github.com/user-attachments/assets/add67a3b-d025-4a51-8220-7b113f2d9c13" />

---

- 修复后：`效果1.png`、`效果2.png`、`效果3.png`、`效果4-无影响项.png`
<img width="362" height="147" alt="效果1" src="https://github.com/user-attachments/assets/ddf135eb-7b6d-44c4-ad34-2623746f24e8" />
<img width="671" height="357" alt="效果2" src="https://github.com/user-attachments/assets/42fe9ba1-5cfe-4966-a6af-4fa413771a21" />
<img width="1276" height="186" alt="效果3" src="https://github.com/user-attachments/assets/2fa1a84c-4567-42e6-91a2-b82861e4dfeb" />
<img width="1390" height="706" alt="效果4-无影响项" src="https://github.com/user-attachments/assets/bea975f4-2011-40c6-8dc3-f521cb4ee48a" />


## 风险与回滚
- 风险较低，属于输入属性与前端交互修正。
- 如需回滚，可回退本 PR 对 `ConnectionModal.tsx` 的改动。