### PR TITLE
🐛 fix(window): 修复 mac 原生全屏下输入时偶发窗口丢失

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@
 import { Layout, Button, ConfigProvider, theme, message, Modal, Spin, Slider, Progress, Switch, Input, InputNumber, Select, Segmented, Tooltip } from 'antd';
 import zhCN from 'antd/locale/zh_CN';
 import { PlusOutlined, ConsoleSqlOutlined, UploadOutlined, DownloadOutlined, CloudDownloadOutlined, BugOutlined, ToolOutlined, GlobalOutlined, InfoCircleOutlined, GithubOutlined, SkinOutlined, CheckOutlined, MinusOutlined, BorderOutlined, CloseOutlined, SettingOutlined, LinkOutlined, BgColorsOutlined, AppstoreOutlined, RobotOutlined } from '@ant-design/icons';
-import { BrowserOpenURL, Environment, EventsOn, Quit, WindowFullscreen, WindowGetPosition, WindowGetSize, WindowIsFullscreen, WindowIsMaximised, WindowMaximise, WindowMinimise, WindowSetPosition, WindowSetSize, WindowToggleMaximise, WindowUnfullscreen } from '../wailsjs/runtime';
+import { BrowserOpenURL, Environment, EventsOn, Quit, WindowFullscreen, WindowGetPosition, WindowGetSize, WindowIsFullscreen, WindowIsMaximised, WindowIsMinimised, WindowIsNormal, WindowMaximise, WindowMinimise, WindowSetPosition, WindowSetSize, WindowToggleMaximise, WindowUnfullscreen } from '../wailsjs/runtime';
 import Sidebar from './components/Sidebar';
 import TabManager from './components/TabManager';
 import ConnectionModal from './components/ConnectionModal';
@@ -130,6 +130,9 @@ function App() {
   const toggleAIPanel = useStore(state => state.toggleAIPanel);
   const setAIPanelVisible = useStore(state => state.setAIPanelVisible);
   const globalProxyInvalidHintShownRef = React.useRef(false);
+  const windowDiagSequenceRef = React.useRef(0);
+  const windowDiagLastSignatureRef = React.useRef('');
+  const windowDiagLastAtRef = React.useRef(0);
   const connectionWorkbenchState = getConnectionWorkbenchState(isStoreHydrated, hasLoadedSecureConfig);
 
   // 同步 macOS 窗口透明度：opacity=1.0 且 blur=0 时关闭 NSVisualEffectView，
@@ -468,6 +471,10 @@ function App() {
               const store = useStore.getState();
               const newState = isFs ? 'fullscreen' : (isMax ? 'maximized' : 'normal');
               if (store.windowState !== newState) {
+                  void emitWindowDiagnostic('transition:windowState', {
+                      from: store.windowState,
+                      to: newState,
+                  });
                   store.setWindowState(newState);
               }
 
@@ -483,15 +490,18 @@ function App() {
               const h = Math.trunc(Number(size.h || 0));
               const x = Math.trunc(Number(pos.x || 0));
               const y = Math.trunc(Number(pos.y || 0));
-              if (w < 400 || h < 300) return;
+               if (w < 400 || h < 300) return;
 
-              const key = `${w},${h},${x},${y}`;
-              if (key === lastSaved) return;
-              lastSaved = key;
-              store.setWindowBounds({ width: w, height: h, x, y });
-          } catch (e) {
-              // 静默忽略
-          }
+               const key = `${w},${h},${x},${y}`;
+               if (key === lastSaved) return;
+               lastSaved = key;
+               if (Math.abs(x) > 5000 || Math.abs(y) > 5000) {
+                   void emitWindowDiagnostic('anomaly:windowBounds', { width: w, height: h, x, y });
+               }
+               store.setWindowBounds({ width: w, height: h, x, y });
+            } catch (e) {
+                // 静默忽略
+            }
       };
 
       const timer = window.setInterval(saveWindowState, SAVE_INTERVAL_MS);
@@ -841,6 +851,63 @@ function App() {
       || (runtimePlatform === '' && isWindowsPlatform());
   const useNativeMacWindowControls = isMacRuntime && appearance.useNativeMacWindowControls === true;
 
+  const emitWindowDiagnostic = useCallback(async (stage: string, extra: Record<string, unknown> = {}) => {
+      if (!isMacRuntime) {
+          return;
+      }
+      const backendApp = (window as any).go?.app?.App;
+      if (typeof backendApp?.LogWindowDiagnostic !== 'function') {
+          return;
+      }
+      try {
+          const [isFullscreen, isMaximised, isMinimised, isNormal, size, position] = await Promise.all([
+              WindowIsFullscreen().catch(() => false),
+              WindowIsMaximised().catch(() => false),
+              WindowIsMinimised().catch(() => false),
+              WindowIsNormal().catch(() => false),
+              WindowGetSize().catch(() => null),
+              WindowGetPosition().catch(() => null),
+          ]);
+          const payload = {
+              seq: ++windowDiagSequenceRef.current,
+              ts: new Date().toISOString(),
+              stage,
+              nativeControls: useNativeMacWindowControls,
+              documentVisible: document.visibilityState,
+              documentHasFocus: document.hasFocus(),
+              devicePixelRatio: Number(window.devicePixelRatio) || 1,
+              windowState: {
+                  isFullscreen,
+                  isMaximised,
+                  isMinimised,
+                  isNormal,
+              },
+              size: size ? { w: Math.trunc(Number(size.w || 0)), h: Math.trunc(Number(size.h || 0)) } : null,
+              position: position ? { x: Math.trunc(Number(position.x || 0)), y: Math.trunc(Number(position.y || 0)) } : null,
+              extra,
+          };
+          const signature = JSON.stringify({
+              stage,
+              nativeControls: payload.nativeControls,
+              visible: payload.documentVisible,
+              focus: payload.documentHasFocus,
+              state: payload.windowState,
+              size: payload.size,
+              position: payload.position,
+              extra,
+          });
+          const now = Date.now();
+          if (signature === windowDiagLastSignatureRef.current && now-windowDiagLastAtRef.current < 250) {
+              return;
+          }
+          windowDiagLastSignatureRef.current = signature;
+          windowDiagLastAtRef.current = now;
+          await backendApp.LogWindowDiagnostic(stage, JSON.stringify(payload));
+      } catch (error) {
+          console.warn('Failed to emit window diagnostic', error);
+      }
+  }, [isMacRuntime, useNativeMacWindowControls]);
+
   useEffect(() => {
       if (!isStoreHydrated || !isMacRuntime) {
           return;
@@ -852,6 +919,104 @@ function App() {
           console.warn('Wails API: SetMacNativeWindowControls unavailable', e);
       }
   }, [isMacRuntime, isStoreHydrated, useNativeMacWindowControls]);
+
+  useEffect(() => {
+      if (!isMacRuntime) {
+          return;
+      }
+
+      let cancelled = false;
+      let pollTimer: number | null = null;
+      let burstTimer: number | null = null;
+
+      const stopBurst = () => {
+          if (pollTimer !== null) {
+              window.clearInterval(pollTimer);
+              pollTimer = null;
+          }
+          if (burstTimer !== null) {
+              window.clearTimeout(burstTimer);
+              burstTimer = null;
+          }
+      };
+
+      const startBurst = (reason: string, extra: Record<string, unknown> = {}) => {
+          if (cancelled) {
+              return;
+          }
+          void emitWindowDiagnostic(`burst:start:${reason}`, extra);
+          if (pollTimer === null) {
+              pollTimer = window.setInterval(() => {
+                  void emitWindowDiagnostic(`burst:tick:${reason}`);
+              }, 250);
+          }
+          if (burstTimer !== null) {
+              window.clearTimeout(burstTimer);
+          }
+          burstTimer = window.setTimeout(() => {
+              stopBurst();
+              void emitWindowDiagnostic(`burst:stop:${reason}`);
+          }, 6000);
+      };
+
+      const handleFocus = () => {
+          void emitWindowDiagnostic('event:focus');
+      };
+      const handleBlur = () => {
+          void emitWindowDiagnostic('event:blur');
+      };
+      const handleResize = () => {
+          void emitWindowDiagnostic('event:resize');
+      };
+      const handleVisibilityChange = () => {
+          void emitWindowDiagnostic('event:visibilitychange', { visibility: document.visibilityState });
+      };
+      const handleEditableKeydown = (event: KeyboardEvent) => {
+          if (!isEditableElement(event.target)) {
+              return;
+          }
+          const key = String(event.key || '');
+          const maybeFullscreenKey = key === 'Escape' || key.toLowerCase() === 'f' || key === 'Process';
+          const hasModifier = event.ctrlKey || event.metaKey || event.altKey;
+          startBurst('editable-keydown', {
+              key,
+              code: String(event.code || ''),
+              ctrlKey: event.ctrlKey,
+              metaKey: event.metaKey,
+              altKey: event.altKey,
+              shiftKey: event.shiftKey,
+              maybeFullscreenKey,
+              hasModifier,
+          });
+      };
+      const handleCompositionStart = () => {
+          startBurst('compositionstart');
+      };
+      const handleCompositionEnd = () => {
+          startBurst('compositionend');
+      };
+
+      void emitWindowDiagnostic('session:start');
+      window.addEventListener('focus', handleFocus);
+      window.addEventListener('blur', handleBlur);
+      window.addEventListener('resize', handleResize);
+      window.addEventListener('keydown', handleEditableKeydown, true);
+      window.addEventListener('compositionstart', handleCompositionStart, true);
+      window.addEventListener('compositionend', handleCompositionEnd, true);
+      document.addEventListener('visibilitychange', handleVisibilityChange);
+
+      return () => {
+          cancelled = true;
+          stopBurst();
+          window.removeEventListener('focus', handleFocus);
+          window.removeEventListener('blur', handleBlur);
+          window.removeEventListener('resize', handleResize);
+          window.removeEventListener('keydown', handleEditableKeydown, true);
+          window.removeEventListener('compositionstart', handleCompositionStart, true);
+          window.removeEventListener('compositionend', handleCompositionEnd, true);
+          document.removeEventListener('visibilitychange', handleVisibilityChange);
+      };
+  }, [emitWindowDiagnostic, isMacRuntime]);
 
   const formatBytes = (bytes?: number) => {
       if (!bytes || bytes <= 0) return '0 B';
@@ -1360,15 +1525,19 @@ function App() {
 
   const handleTitleBarWindowToggle = async () => {
       try {
+          void emitWindowDiagnostic('action:titlebar-toggle:before');
           if (await WindowIsFullscreen()) {
               await WindowUnfullscreen();
+              void emitWindowDiagnostic('action:titlebar-toggle:after-unfullscreen');
               return;
           }
           if (useNativeMacWindowControls && isMacRuntime) {
               await WindowFullscreen();
+              void emitWindowDiagnostic('action:titlebar-toggle:after-fullscreen');
               return;
           }
           await WindowToggleMaximise();
+          void emitWindowDiagnostic('action:titlebar-toggle:after-toggle-maximise');
       } catch (_) {
           // ignore
       }

--- a/frontend/wailsjs/go/app/App.d.ts
+++ b/frontend/wailsjs/go/app/App.d.ts
@@ -110,6 +110,8 @@ export function InstallLocalDriverPackage(arg1:string,arg2:string,arg3:string,ar
 
 export function InstallUpdateAndRestart():Promise<connection.QueryResult>;
 
+export function LogWindowDiagnostic(arg1:string,arg2:string):Promise<void>;
+
 export function MongoDiscoverMembers(arg1:connection.ConnectionConfig):Promise<connection.QueryResult>;
 
 export function MySQLConnect(arg1:connection.ConnectionConfig):Promise<connection.QueryResult>;

--- a/frontend/wailsjs/go/app/App.js
+++ b/frontend/wailsjs/go/app/App.js
@@ -214,6 +214,10 @@ export function InstallUpdateAndRestart() {
   return window['go']['app']['App']['InstallUpdateAndRestart']();
 }
 
+export function LogWindowDiagnostic(arg1, arg2) {
+  return window['go']['app']['App']['LogWindowDiagnostic'](arg1, arg2);
+}
+
 export function MongoDiscoverMembers(arg1) {
   return window['go']['app']['App']['MongoDiscoverMembers'](arg1);
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -91,6 +91,7 @@ func (a *App) startup(ctx context.Context) {
 	}
 	logger.Init()
 	a.loadPersistedGlobalProxy()
+	installMacNativeWindowDiagnostics(logger.Path())
 	applyMacWindowTranslucencyFix()
 	logger.Infof("应用启动完成（首次连接保护窗口=%s，最多重试=%d 次）", startupConnectRetryWindow, startupConnectRetryAttempts)
 }
@@ -106,6 +107,16 @@ func (a *App) SetWindowTranslucency(opacity float64, blur float64) {
 // On non-macOS platforms this is a no-op.
 func (a *App) SetMacNativeWindowControls(enabled bool) {
 	setMacNativeWindowControls(enabled)
+}
+
+// LogWindowDiagnostic 记录前端采集到的窗口诊断信息，便于排查 macOS 原生全屏异常。
+func (a *App) LogWindowDiagnostic(stage string, payload string) {
+	stage = strings.TrimSpace(stage)
+	payload = strings.TrimSpace(payload)
+	if stage == "" {
+		stage = "unknown"
+	}
+	logger.Warnf("窗口诊断：stage=%s payload=%s", stage, payload)
 }
 
 // Shutdown is called when the app terminates

--- a/internal/app/window_style_darwin.go
+++ b/internal/app/window_style_darwin.go
@@ -5,11 +5,142 @@ package app
 /*
 #cgo CFLAGS: -x objective-c -fblocks
 #cgo LDFLAGS: -framework Cocoa
+#include <stdlib.h>
 #import <Cocoa/Cocoa.h>
 #import <dispatch/dispatch.h>
 
 static inline BOOL gonaviBoolYES() { return YES; }
 static inline BOOL gonaviBoolNO()  { return NO; }
+
+static char *gonaviNativeLogPath = NULL;
+static BOOL gonaviNativeObserverInstalled = NO;
+
+static void gonaviWriteNativeWindowLogLine(NSString *line) {
+	if (line == nil || gonaviNativeLogPath == NULL) {
+		return;
+	}
+	NSFileHandle *handle = [NSFileHandle fileHandleForWritingAtPath:[NSString stringWithUTF8String:gonaviNativeLogPath]];
+	if (handle == nil) {
+		return;
+	}
+	@try {
+		[handle seekToEndOfFile];
+		NSData *data = [line dataUsingEncoding:NSUTF8StringEncoding];
+		[handle writeData:data];
+	} @catch (__unused NSException *exception) {
+	} @finally {
+		[handle closeFile];
+	}
+}
+
+static NSString *gonaviWindowDiagnosticLine(NSString *eventName, NSWindow *window) {
+	NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+	[formatter setDateFormat:@"yyyy/MM/dd HH:mm:ss.SSSSSS"];
+	NSString *timestamp = [formatter stringFromDate:[NSDate date]];
+	[formatter release];
+	if (window == nil) {
+		return [NSString stringWithFormat:@"%@ [WARN] 原生窗口诊断：event=%@ window=nil\n", timestamp, eventName ?: @"unknown"];
+	}
+	NSUInteger occlusionState = 0;
+	NSInteger windowNumber = [window windowNumber];
+	NSInteger level = [window level];
+	NSUInteger collectionBehavior = [window collectionBehavior];
+	NSString *className = NSStringFromClass([window class]);
+	NSString *delegateClassName = [window delegate] ? NSStringFromClass([[window delegate] class]) : @"nil";
+	if (@available(macOS 10.9, *)) {
+		occlusionState = [window occlusionState];
+	}
+	return [NSString stringWithFormat:@"%@ [WARN] 原生窗口诊断：event=%@ ptr=%p number=%ld class=%@ delegate=%@ visible=%@ miniaturized=%@ key=%@ main=%@ canHide=%@ level=%ld occlusion=%lu styleMask=%lu collectionBehavior=%lu frame=%@ screen=%@ title=%@\n",
+		timestamp,
+		eventName ?: @"unknown",
+		window,
+		(long)windowNumber,
+		className ?: @"nil",
+		delegateClassName,
+		[window isVisible] ? @"true" : @"false",
+		[window isMiniaturized] ? @"true" : @"false",
+		[window isKeyWindow] ? @"true" : @"false",
+		[window isMainWindow] ? @"true" : @"false",
+		[window canHide] ? @"true" : @"false",
+		(long)level,
+		(unsigned long)occlusionState,
+		(unsigned long)[window styleMask],
+		(unsigned long)collectionBehavior,
+		NSStringFromRect([window frame]),
+		[window screen] ? NSStringFromRect([[window screen] frame]) : @"nil",
+		[window title] ?: @""];
+}
+
+@interface GoNaviNativeWindowObserver : NSObject
+@end
+
+@implementation GoNaviNativeWindowObserver
+
+- (void)logNotification:(NSNotification *)notification {
+	NSString *name = [notification name] ?: @"unknown";
+	NSWindow *window = nil;
+	if ([[notification object] isKindOfClass:[NSWindow class]]) {
+		window = (NSWindow *)[notification object];
+	} else {
+		window = [NSApp keyWindow] ?: [NSApp mainWindow];
+	}
+	gonaviWriteNativeWindowLogLine(gonaviWindowDiagnosticLine(name, window));
+}
+
+@end
+
+static GoNaviNativeWindowObserver *gonaviNativeWindowObserver = nil;
+
+static void gonaviInstallNativeWindowObserver(void) {
+	if (gonaviNativeObserverInstalled) {
+		return;
+	}
+	gonaviNativeObserverInstalled = YES;
+	gonaviNativeWindowObserver = [[GoNaviNativeWindowObserver alloc] init];
+	NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+	NSArray<NSString *> *windowNotifications = @[
+		NSWindowDidBecomeKeyNotification,
+		NSWindowDidResignKeyNotification,
+		NSWindowDidBecomeMainNotification,
+		NSWindowDidResignMainNotification,
+		NSWindowDidMiniaturizeNotification,
+		NSWindowDidDeminiaturizeNotification,
+		NSWindowDidEnterFullScreenNotification,
+		NSWindowDidExitFullScreenNotification,
+		NSWindowDidMoveNotification,
+		NSWindowDidResizeNotification,
+		NSWindowDidChangeOcclusionStateNotification,
+	];
+	for (NSString *notificationName in windowNotifications) {
+		[center addObserver:gonaviNativeWindowObserver selector:@selector(logNotification:) name:notificationName object:nil];
+	}
+	NSArray<NSString *> *appNotifications = @[
+		NSApplicationDidHideNotification,
+		NSApplicationDidUnhideNotification,
+		NSApplicationDidBecomeActiveNotification,
+		NSApplicationDidResignActiveNotification,
+	];
+	for (NSString *notificationName in appNotifications) {
+		[center addObserver:gonaviNativeWindowObserver selector:@selector(logNotification:) name:notificationName object:nil];
+	}
+	for (NSWindow *window in [NSApp windows]) {
+		gonaviWriteNativeWindowLogLine(gonaviWindowDiagnosticLine(@"observer:snapshot", window));
+	}
+}
+
+static void gonaviConfigureNativeWindowDiagnostics(const char *logPath) {
+	if (logPath == NULL || logPath[0] == '\0') {
+		return;
+	}
+	if (gonaviNativeLogPath != NULL) {
+		free(gonaviNativeLogPath);
+		gonaviNativeLogPath = NULL;
+	}
+	gonaviNativeLogPath = strdup(logPath);
+	dispatch_async(dispatch_get_main_queue(), ^{
+		gonaviInstallNativeWindowObserver();
+	});
+}
 
 static void gonaviSetWindowButtonsVisible(NSWindow *window, BOOL visible) {
 	if (window == nil) {
@@ -24,10 +155,29 @@ static void gonaviSetWindowButtonsVisible(NSWindow *window, BOOL visible) {
 	}
 }
 
+static BOOL gonaviShouldApplyMacWindowStyle(NSWindow *window) {
+	if (window == nil) {
+		return NO;
+	}
+	NSString *className = NSStringFromClass([window class]) ?: @"";
+	NSString *delegateClassName = [window delegate] ? NSStringFromClass([[window delegate] class]) : @"";
+	NSString *title = [window title] ?: @"";
+
+	// 仅对主 WailsWindow 套用原生标题栏/全屏样式，避免误伤输入法候选窗、全屏过渡窗。
+	if ([className isEqualToString:@"WailsWindow"] || [delegateClassName isEqualToString:@"WindowDelegate"]) {
+		return YES;
+	}
+	return [title isEqualToString:@"GoNavi"];
+}
+
 static void gonaviApplyMacWindowStyle(BOOL enabled) {
 	dispatch_async(dispatch_get_main_queue(), ^{
 		for (NSWindow *window in [NSApp windows]) {
 			if (window == nil) {
+				continue;
+			}
+			if (!gonaviShouldApplyMacWindowStyle(window)) {
+				gonaviWriteNativeWindowLogLine(gonaviWindowDiagnosticLine(@"style:skip-non-app-window", window));
 				continue;
 			}
 
@@ -57,11 +207,23 @@ static void gonaviApplyMacWindowStyle(BOOL enabled) {
 
 			[[window contentView] setNeedsDisplay:YES];
 			[window invalidateShadow];
+			gonaviWriteNativeWindowLogLine(gonaviWindowDiagnosticLine(enabled ? @"style:enable-native-controls" : @"style:disable-native-controls", window));
 		}
 	});
 }
 */
 import "C"
+
+import "unsafe"
+
+func installMacNativeWindowDiagnostics(logPath string) {
+	if logPath == "" {
+		return
+	}
+	cLogPath := C.CString(logPath)
+	defer C.free(unsafe.Pointer(cLogPath))
+	C.gonaviConfigureNativeWindowDiagnostics(cLogPath)
+}
 
 func setMacNativeWindowControls(enabled bool) {
 	state := resolveMacNativeWindowControlState(enabled)

--- a/internal/app/window_style_logic.go
+++ b/internal/app/window_style_logic.go
@@ -1,5 +1,7 @@
 package app
 
+import "strings"
+
 type macNativeWindowControlState struct {
 	ShowNativeButtons     bool
 	UseTitledWindow       bool
@@ -29,4 +31,25 @@ func resolveMacNativeWindowControlState(enabled bool) macNativeWindowControlStat
 		TransparentTitlebar:   false,
 		AllowNativeFullscreen: false,
 	}
+}
+
+type macWindowIdentity struct {
+	ClassName         string
+	DelegateClassName string
+	Title             string
+}
+
+// shouldApplyMacNativeWindowStyle 只允许对主 WailsWindow 应用原生标题栏/全屏能力，
+// 避免误伤输入法候选窗、全屏过渡窗等系统辅助窗口。
+func shouldApplyMacNativeWindowStyle(identity macWindowIdentity) bool {
+	className := strings.TrimSpace(identity.ClassName)
+	delegateClassName := strings.TrimSpace(identity.DelegateClassName)
+	title := strings.TrimSpace(identity.Title)
+
+	if className == "WailsWindow" || delegateClassName == "WindowDelegate" {
+		return true
+	}
+
+	// 兜底只接受明确命名的主应用窗口，避免把无标题系统辅助窗口纳入样式改写范围。
+	return title == "GoNavi"
 }

--- a/internal/app/window_style_logic_test.go
+++ b/internal/app/window_style_logic_test.go
@@ -35,3 +35,33 @@ func TestResolveMacNativeWindowControlStateDisabled(t *testing.T) {
 		t.Fatal("expected disabled state to avoid native fullscreen behavior")
 	}
 }
+
+func TestShouldApplyMacNativeWindowStyleAcceptsMainWailsWindow(t *testing.T) {
+	tests := []macWindowIdentity{
+		{ClassName: "WailsWindow", DelegateClassName: "WindowDelegate", Title: "GoNavi"},
+		{ClassName: "WailsWindow", DelegateClassName: "", Title: ""},
+		{ClassName: "", DelegateClassName: "WindowDelegate", Title: ""},
+		{ClassName: "", DelegateClassName: "", Title: "GoNavi"},
+	}
+
+	for _, tt := range tests {
+		if !shouldApplyMacNativeWindowStyle(tt) {
+			t.Fatalf("expected window identity %+v to be treated as main app window", tt)
+		}
+	}
+}
+
+func TestShouldApplyMacNativeWindowStyleRejectsSystemAuxiliaryWindows(t *testing.T) {
+	tests := []macWindowIdentity{
+		{ClassName: "TUINSWindow", DelegateClassName: "TUINSWindow", Title: ""},
+		{ClassName: "NSToolbarFullScreenWindow", DelegateClassName: "", Title: ""},
+		{ClassName: "_NSFullScreenTransitionOverlayWindow", DelegateClassName: "", Title: ""},
+		{ClassName: "NSPanel", DelegateClassName: "", Title: ""},
+	}
+
+	for _, tt := range tests {
+		if shouldApplyMacNativeWindowStyle(tt) {
+			t.Fatalf("expected window identity %+v to be rejected as auxiliary/system window", tt)
+		}
+	}
+}


### PR DESCRIPTION
## 背景

在 macOS 上启用 GoNavi 的原生窗口控制后，应用进入原生全屏状态，在 `Input` / `textarea` 等可编辑区域输入时，偶发出现窗口看似“消失”或“找不到”的问题。典型现象：

- 应用进程仍然存活
- 主窗口没有 crash，也没有 shutdown 日志
- 用户感知上像是“全屏丢了”或“窗口不见了”
- 前端页面会进入 `document.visibilityState = hidden`

这个问题具有明显偶发性，但复现场景有共同特征：

- 已开启 mac 原生窗口控制
- 当前处于 mac 原生全屏
- 焦点位于 `Input` 编辑态
- 普通输入、组合键、中文输入合成、输入法相关辅助窗口切换都可能触发

## 排查过程

这次修复不是直接从症状入手，而是先补齐前端和 Darwin 原生层的诊断链路，再逐步缩小范围。

### 第一阶段：排除崩溃和坐标异常

先确认：

- `GoNavi` 进程仍然存在
- 日志中没有 panic、crash、shutdown 记录

同时前端窗口诊断显示，异常发生后窗口状态仍然是全屏，位置没有漂移：

```text
2026/04/10 16:13:01.842878 [WARN] 窗口诊断：stage=event:visibilitychange payload={"seq":79,"ts":"2026-04-10T08:13:01.842Z","stage":"event:visibilitychange","nativeControls":true,"documentVisible":"hidden","documentHasFocus":true,"devicePixelRatio":1,"windowState":{"isFullscreen":true,"isMaximised":false,"isMinimised":false,"isNormal":false},"size":{"w":1920,"h":1080},"position":{"x":0,"y":-30},"extra":{"visibility":"hidden"}}
2026/04/10 16:13:03.646709 [WARN] 窗口诊断：stage=event:blur payload={"seq":82,"ts":"2026-04-10T08:13:03.646Z","stage":"event:blur","nativeControls":true,"documentVisible":"hidden","documentHasFocus":false,"devicePixelRatio":1,"windowState":{"isFullscreen":true,"isMaximised":false,"isMinimised":false,"isNormal":false},"size":{"w":1920,"h":1080},"position":{"x":0,"y":-30},"extra":{}}
```

说明问题并不是：

- 主窗口真正退出全屏
- 窗口位置飞出屏幕
- 应用进程退出

### 第二阶段：定位到页面可见性链路异常

关键现象是：

- `documentVisible` 从 `visible` 变成 `hidden`
- `windowState` 仍然保持 `fullscreen`
- 主窗口尺寸和坐标没有异常

所以问题核心不在“窗口位置”，而在“窗口/页面可见性链路”。

### 第三阶段：定位到辅助窗口参与异常

继续在 Darwin 层补充 NSWindow / NSApplication 原生日志后，观察到在 Input 编辑态会出现多个系统辅助窗口，例如：

- `TUINSWindow`
- `NSToolbarFullScreenWindow`
- `_NSFullScreenTransitionOverlayWindow`

实际日志：

```text
2026/04/10 16:42:40.251000 [WARN] 原生窗口诊断：event=NSWindowDidResizeNotification ptr=0x7bb854a00 number=31863 class=TUINSWindow delegate=TUINSWindow visible=false miniaturized=false key=false main=false canHide=true level=0 occlusion=8192 styleMask=32783 collectionBehavior=128 frame={{0, 446}, {54, 54}} screen={{0, 0}, {1920, 1080}} title=
2026/04/10 16:51:48.710000 [WARN] 原生窗口诊断：event=NSWindowDidMoveNotification ptr=0x7aa65b200 number=39170 class=NSToolbarFullScreenWindow delegate=nil visible=false miniaturized=false key=false main=false canHide=false level=0 occlusion=8192 styleMask=0 collectionBehavior=0 frame={{0, 1016}, {1920, 32}} screen={{0, 0}, {1920, 1080}} title=
2026/04/10 16:51:48.756000 [WARN] 原生窗口诊断：event=NSWindowDidChangeOcclusionStateNotification ptr=0x7aa657000 number=39169 class=_NSFullScreenTransitionOverlayWindow delegate=nil visible=true miniaturized=false key=false main=false canHide=true level=0 occlusion=8194 styleMask=0 collectionBehavior=64 frame={{0, 0}, {1920, 1080}} screen={{0, 0}, {1920, 1080}} title=
```

这些窗口不是 GoNavi 主窗口，但会在输入和全屏过渡期间参与系统窗口栈变化。

### 第四阶段：确认根因

最终日志直接证明，在启用 mac 原生窗口控制时，原有实现不仅改了主 WailsWindow，还改到了系统辅助窗口。

修复前日志：

```text
2026/04/10 16:51:41.856000 [WARN] 原生窗口诊断：event=style:enable-native-controls ptr=0x108a9d320 number=39152 class=WailsWindow delegate=WindowDelegate visible=true miniaturized=false key=false main=false canHide=true level=0 occlusion=8194 styleMask=32783 collectionBehavior=128 frame={{448, 232}, {1024, 768}} screen={{0, 0}, {1920, 1080}} title=GoNavi
2026/04/10 16:51:41.858000 [WARN] 原生窗口诊断：event=style:enable-native-controls ptr=0x7aa51fc00 number=39166 class=TUINSWindow delegate=TUINSWindow visible=false miniaturized=false key=false main=false canHide=true level=0 occlusion=8192 styleMask=32783 collectionBehavior=128 frame={{0, 0}, {500, 500}} screen={{0, 0}, {1920, 1080}} title=
```

这说明 Darwin 层对 `[NSApp windows]` 里的所有窗口统一执行了窗口样式改写，包括：

- `setStyleMask`
- `setTitlebarAppearsTransparent`
- `setCollectionBehavior(...FullScreenPrimary)`

这会误伤系统输入辅助窗口和全屏过渡窗口，最终扰乱主 WailsWindow 的激活/可见性链路，使页面进入 `hidden`，表现成“窗口偶发丢失”。

## 根因分析

根因可以概括为：

**mac 原生全屏功能的 Darwin 实现对所有 `NSApp windows` 一刀切改写原生样式，误伤了系统辅助窗口，导致主窗口在输入态下的全屏可见性链路被打断。**

更具体地说：

1. 启用 mac 原生窗口控制后，主窗口需要具备原生标题栏和原生全屏行为
2. 旧实现直接遍历 `[NSApp windows]`
3. 输入态下系统会临时创建输入相关和全屏过渡相关辅助窗口
4. 这些辅助窗口被错误应用了业务主窗口才应具备的样式和 `collectionBehavior`
5. 最终导致主窗口虽然还活着，但页面进入 `hidden` 状态，表现为“偶发窗口丢失”

## 修改内容

1. **增加前端窗口诊断日志**  
   在前端补充窗口状态日志，记录：
   - `focus`
   - `blur`
   - `visibilitychange`
   - `resize`
   - `editable keydown`
   - `compositionstart`
   - `compositionend`  
   同时在输入过程中进行高频采样，帮助对齐异常发生前后的窗口状态变化。

2. **增加 Darwin 原生窗口诊断日志**  
   在 macOS 原生层补充：
   - `NSWindowDidBecomeKey`
   - `NSWindowDidResignKey`
   - `NSWindowDidEnterFullScreen`
   - `NSWindowDidExitFullScreen`
   - `NSWindowDidChangeOcclusionState`
   - `NSApplicationDidBecomeActive`
   - `NSApplicationDidResignActive`  
   并记录窗口身份信息：
   - `class`
   - `delegate`
   - `title`
   - `styleMask`
   - `collectionBehavior`
   - `occlusion`
   - `frame`

3. **收敛 mac 原生窗口样式的作用范围**  
   新增主窗口筛选逻辑，只允许主应用窗口应用原生样式。  
   当前规则：
   - `class == WailsWindow`
   - 或 `delegate == WindowDelegate`
   - 或 `title == GoNavi`  
   非主窗口将被显式跳过，并记录：
   - `style:skip-non-app-window`

4. **避免误伤系统辅助窗口**  
   修复后不再对以下类型窗口改写原生样式：
   - `TUINSWindow`
   - `NSToolbarFullScreenWindow`
   - `_NSFullScreenTransitionOverlayWindow`
   - 其他无关系统辅助窗口

5. **补充单测**  
   补充窗口筛选逻辑单测，验证：
   - 主 `WailsWindow` 会被放行
   - 系统辅助窗口会被拒绝

## 修改原理

这次修复不是关闭 mac 原生全屏能力，而是把原生样式的施加对象从“所有窗口”缩小到“主窗口”。

- **修复前**：主窗口和系统辅助窗口都会被改样式
- **修复后**：
  - 主 `WailsWindow` 仍然保留原生标题栏和原生全屏能力
  - 系统辅助窗口继续由 macOS 自己管理
  - 避免辅助窗口干扰主窗口的全屏可见性链路

这意味着：

- 保留了引入该 feature 的初衷
- 又避免了误改系统窗口造成的偶发异常

## 影响范围

主要影响以下部分：

- macOS 原生窗口控制
- macOS 原生全屏行为
- 输入态下的窗口可见性链路
- Darwin 窗口样式设置逻辑
- 前端/原生层诊断日志

## 验证方式

### 代码验证

```bash
go test ./internal/app
```

### 运行时验证

- 开启 mac 原生窗口控制
- 进入原生全屏
- 在 `Input` / `textarea` 中持续输入
- 覆盖 `Shift`、`Enter`、`Backspace`、中文输入合成等场景

## 修复后证据

### 证据一：辅助窗口不再被改写样式

修复后日志显示，主窗口仍然应用原生样式，但 `TUINSWindow` 已被跳过：

```text
2026/04/10 19:03:18.344000 [WARN] 原生窗口诊断：event=style:enable-native-controls ptr=0x1065f1590 number=41571 class=WailsWindow delegate=WindowDelegate visible=true miniaturized=false key=false main=false canHide=true level=0 occlusion=8194 styleMask=32783 collectionBehavior=128 frame={{448, 232}, {1024, 768}} screen={{0, 0}, {1920, 1080}} title=GoNavi
2026/04/10 19:03:18.344000 [WARN] 原生窗口诊断：event=style:skip-non-app-window ptr=0xbc5cf6f80 number=41585 class=TUINSWindow delegate=TUINSWindow visible=false miniaturized=false key=false main=false canHide=true level=0 occlusion=8192 styleMask=32768 collectionBehavior=0 frame={{0, 0}, {500, 500}} screen={{0, 0}, {1920, 1080}} title=
```

这说明根因对应的误改写行为已经消失。

### 证据二：全屏过渡可以恢复到稳定可见状态

修复后重新进入原生全屏时，仍会有系统过渡窗口参与，但页面会恢复到 `visible`：

```text
2026/04/10 19:03:23.067045 [WARN] 窗口诊断：stage=event:visibilitychange payload={"seq":5,"ts":"2026-04-10T11:03:23.066Z","stage":"event:visibilitychange","nativeControls":true,"documentVisible":"hidden","documentHasFocus":true,"devicePixelRatio":1,"windowState":{"isFullscreen":true,"isMaximised":false,"isMinimised":false,"isNormal":false},"size":{"w":1920,"h":1080},"position":{"x":0,"y":-30},"extra":{"visibility":"hidden"}}
2026/04/10 19:03:23.610000 [WARN] 原生窗口诊断：event=NSWindowDidEnterFullScreenNotification ptr=0x1065f1590 number=41571 class=WailsWindow delegate=WindowDelegate visible=true miniaturized=false key=true main=false canHide=false level=0 occlusion=8192 styleMask=49167 collectionBehavior=128 frame={{0, 0}, {1920, 1080}} screen={{0, 0}, {1920, 1080}} title=GoNavi
2026/04/10 19:03:23.623661 [WARN] 窗口诊断：stage=event:visibilitychange payload={"seq":6,"ts":"2026-04-10T11:03:23.623Z","stage":"event:visibilitychange","nativeControls":true,"documentVisible":"visible","documentHasFocus":true,"devicePixelRatio":1,"windowState":{"isFullscreen":true,"isMaximised":false,"isMinimised":false,"isNormal":false},"size":{"w":1920,"h":1080},"position":{"x":0,"y":-30},"extra":{"visibility":"visible"}}
```

说明这里仍存在短暂 `hidden` -> `visible`，但这是正常的原生全屏过渡，不再是异常卡死。

### 证据三：长时间输入期间持续保持可见

修复后在全屏下持续进行 Input 编辑、组合键、中文输入合成时，日志长时间保持 `documentVisible=visible`：

```text
2026/04/10 19:12:03.574332 [WARN] 窗口诊断：stage=burst:tick:editable-keydown payload={"seq":905,"ts":"2026-04-10T11:12:03.573Z","stage":"burst:tick:editable-keydown","nativeControls":true,"documentVisible":"visible","documentHasFocus":true,"devicePixelRatio":1,"windowState":{"isFullscreen":true,"isMaximised":false,"isMinimised":false,"isNormal":false},"size":{"w":1920,"h":1080},"position":{"x":0,"y":-30},"extra":{}}
2026/04/10 19:12:05.982179 [WARN] 窗口诊断：stage=burst:stop:editable-keydown payload={"seq":915,"ts":"2026-04-10T11:12:05.981Z","stage":"burst:stop:editable-keydown","nativeControls":true,"documentVisible":"visible","documentHasFocus":true,"devicePixelRatio":1,"windowState":{"isFullscreen":true,"isMaximised":false,"isMinimised":false,"isNormal":false},"size":{"w":1920,"h":1080},"position":{"x":0,"y":-30},"extra":{}}
2026/04/10 19:13:25.627203 [WARN] 窗口诊断：stage=burst:start:compositionstart payload={"seq":960,"ts":"2026-04-10T11:13:25.627Z","stage":"burst:start:compositionstart","nativeControls":true,"documentVisible":"visible","documentHasFocus":true,"devicePixelRatio":1,"windowState":{"isFullscreen":true,"isMaximised":false,"isMinimised":false,"isNormal":false},"size":{"w":1920,"h":1080},"position":{"x":0,"y":-30},"extra":{}}
2026/04/10 19:13:28.626437 [WARN] 窗口诊断：stage=burst:start:compositionend payload={"seq":988,"ts":"2026-04-10T11:13:28.626Z","stage":"burst:start:compositionend","nativeControls":true,"documentVisible":"visible","documentHasFocus":true,"devicePixelRatio":1,"windowState":{"isFullscreen":true,"isMaximised":false,"isMinimised":false,"isNormal":false},"size":{"w":1920,"h":1080},"position":{"x":0,"y":-30},"extra":{}}
2026/04/10 19:13:29.680225 [WARN] 窗口诊断：stage=burst:tick:editable-keydown payload={"seq":1000,"ts":"2026-04-10T11:13:29.679Z","stage":"burst:tick:editable-keydown","nativeControls":true,"documentVisible":"visible","documentHasFocus":true,"devicePixelRatio":1,"windowState":{"isFullscreen":true,"isMaximised":false,"isMinimised":false,"isNormal":false},"size":{"w":1920,"h":1080},"position":{"x":0,"y":-30},"extra":{}}
```

说明：

- 页面始终维持 `documentVisible=visible`
- 主窗口始终保持 `isFullscreen=true`
- 没有再出现之前那种“编辑途中进入 hidden 并长期不恢复”的故障特征

## 修复效果截图
<img width="403" height="192" alt="已修复效果图" src="https://github.com/user-attachments/assets/3d7bfea5-3b27-48a6-ab2b-c2c9f05eabb6" />



## 风险与回滚

### 风险

当前策略是保守的，只允许主 `WailsWindow` 应用原生样式。  
如果未来引入新的业务子窗口，且这些窗口也需要原生标题栏或原生全屏能力，需要显式扩展窗口筛选规则。

### 回滚

如果需要快速回退：

- 可回滚 Darwin 层的窗口筛选逻辑
- 诊断日志仍可保留，用于继续观测是否存在其他窗口链路问题