### PR TITLE
🐛 fix(postgres): 修复 LIKE 'pg_%' 误匹配 pg开头的非系统 schema

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -853,7 +853,7 @@ const Sidebar: React.FC<{ onEditConnection?: (conn: SavedConnection) => void }> 
           case 'highgo':
           case 'vastbase':
           case 'opengauss':
-              return [{ sql: `SELECT schemaname AS schema_name, viewname AS view_name FROM pg_catalog.pg_views WHERE schemaname != 'information_schema' AND schemaname NOT LIKE 'pg_%' ORDER BY schemaname, viewname` }];
+              return [{ sql: `SELECT schemaname AS schema_name, viewname AS view_name FROM pg_catalog.pg_views WHERE schemaname != 'information_schema' AND schemaname NOT LIKE 'pg|_%' ESCAPE '|' ORDER BY schemaname, viewname` }];
           case 'sqlserver': {
               const safeDb = quoteSqlServerIdentifier(dbName || 'master');
               return [{ sql: `SELECT s.name AS schema_name, v.name AS view_name FROM ${safeDb}.sys.views v JOIN ${safeDb}.sys.schemas s ON v.schema_id = s.schema_id ORDER BY s.name, v.name` }];
@@ -898,7 +898,7 @@ const Sidebar: React.FC<{ onEditConnection?: (conn: SavedConnection) => void }> 
           case 'highgo':
           case 'vastbase':
           case 'opengauss':
-              return [{ sql: `SELECT DISTINCT event_object_schema AS schema_name, event_object_table AS table_name, trigger_name FROM information_schema.triggers WHERE trigger_schema NOT IN ('pg_catalog', 'information_schema') AND trigger_schema NOT LIKE 'pg_%' ORDER BY event_object_schema, event_object_table, trigger_name` }];
+              return [{ sql: `SELECT DISTINCT event_object_schema AS schema_name, event_object_table AS table_name, trigger_name FROM information_schema.triggers WHERE trigger_schema NOT IN ('pg_catalog', 'information_schema') AND trigger_schema NOT LIKE 'pg|_%' ESCAPE '|' ORDER BY event_object_schema, event_object_table, trigger_name` }];
           case 'sqlserver': {
               const safeDb = quoteSqlServerIdentifier(dbName || 'master');
               return [{ sql: `SELECT s.name AS schema_name, t.name AS table_name, tr.name AS trigger_name FROM ${safeDb}.sys.triggers tr JOIN ${safeDb}.sys.tables t ON tr.parent_id = t.object_id JOIN ${safeDb}.sys.schemas s ON t.schema_id = s.schema_id WHERE tr.parent_class = 1 ORDER BY s.name, t.name, tr.name` }];
@@ -949,15 +949,15 @@ const Sidebar: React.FC<{ onEditConnection?: (conn: SavedConnection) => void }> 
               return normalizeMetadataQuerySpecs([
                   {
                       // PostgreSQL 11+ / 部分 PG-like：通过 prokind 区分 FUNCTION/PROCEDURE
-                      sql: `SELECT n.nspname AS schema_name, p.proname AS routine_name, CASE WHEN p.prokind = 'p' THEN 'PROCEDURE' ELSE 'FUNCTION' END AS routine_type FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid WHERE n.nspname NOT IN ('pg_catalog', 'information_schema') AND n.nspname NOT LIKE 'pg_%' ORDER BY n.nspname, routine_type, p.proname`,
+                      sql: `SELECT n.nspname AS schema_name, p.proname AS routine_name, CASE WHEN p.prokind = 'p' THEN 'PROCEDURE' ELSE 'FUNCTION' END AS routine_type FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid WHERE n.nspname NOT IN ('pg_catalog', 'information_schema') AND n.nspname NOT LIKE 'pg|_%' ESCAPE '|' ORDER BY n.nspname, routine_type, p.proname`,
                   },
                   {
                       // PostgreSQL 10 / 不支持 prokind 的兼容路径
-                      sql: `SELECT r.routine_schema AS schema_name, r.routine_name AS routine_name, COALESCE(NULLIF(UPPER(r.routine_type), ''), 'FUNCTION') AS routine_type FROM information_schema.routines r WHERE r.routine_schema NOT IN ('pg_catalog', 'information_schema') AND r.routine_schema NOT LIKE 'pg_%' ORDER BY r.routine_schema, routine_type, r.routine_name`,
+                      sql: `SELECT r.routine_schema AS schema_name, r.routine_name AS routine_name, COALESCE(NULLIF(UPPER(r.routine_type), ''), 'FUNCTION') AS routine_type FROM information_schema.routines r WHERE r.routine_schema NOT IN ('pg_catalog', 'information_schema') AND r.routine_schema NOT LIKE 'pg|_%' ESCAPE '|' ORDER BY r.routine_schema, routine_type, r.routine_name`,
                   },
                   {
                       // 最后兜底：仅函数列表，确保 prokind/routines 视图异常时仍可展示
-                      sql: `SELECT n.nspname AS schema_name, p.proname AS routine_name, 'FUNCTION' AS routine_type FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid WHERE n.nspname NOT IN ('pg_catalog', 'information_schema') AND n.nspname NOT LIKE 'pg_%' ORDER BY n.nspname, p.proname`,
+                      sql: `SELECT n.nspname AS schema_name, p.proname AS routine_name, 'FUNCTION' AS routine_type FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid WHERE n.nspname NOT IN ('pg_catalog', 'information_schema') AND n.nspname NOT LIKE 'pg|_%' ESCAPE '|' ORDER BY n.nspname, p.proname`,
                   },
               ]);
           case 'sqlserver': {

--- a/internal/db/highgo_impl.go
+++ b/internal/db/highgo_impl.go
@@ -212,7 +212,7 @@ func (h *HighGoDB) GetDatabases() ([]string, error) {
 }
 
 func (h *HighGoDB) GetTables(dbName string) ([]string, error) {
-	query := "SELECT schemaname, tablename FROM pg_catalog.pg_tables WHERE schemaname != 'information_schema' AND schemaname NOT LIKE 'pg_%' ORDER BY schemaname, tablename"
+	query := "SELECT schemaname, tablename FROM pg_catalog.pg_tables WHERE schemaname != 'information_schema' AND schemaname NOT LIKE 'pg|_%' ESCAPE '|' ORDER BY schemaname, tablename"
 	data, _, err := h.Query(query)
 	if err != nil {
 		return nil, err
@@ -514,7 +514,7 @@ func (h *HighGoDB) GetAllColumns(dbName string) ([]connection.ColumnDefinitionWi
 SELECT table_schema, table_name, column_name, data_type
 FROM information_schema.columns
 WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
-  AND table_schema NOT LIKE 'pg_%'
+  AND table_schema NOT LIKE 'pg|_%' ESCAPE '|'
 ORDER BY table_schema, table_name, ordinal_position`
 
 	data, _, err := h.Query(query)

--- a/internal/db/kingbase_impl.go
+++ b/internal/db/kingbase_impl.go
@@ -211,7 +211,7 @@ func (k *KingbaseDB) getSearchPathStr() string {
 
 	query := `SELECT nspname FROM pg_namespace
 		WHERE nspname NOT IN ('pg_catalog', 'information_schema')
-		  AND nspname NOT LIKE 'pg_%'
+		  AND nspname NOT LIKE 'pg|_%' ESCAPE '|'
 		ORDER BY nspname`
 
 	rows, err := k.conn.Query(query)
@@ -400,7 +400,7 @@ func (k *KingbaseDB) GetTables(dbName string) ([]string, error) {
 		FROM information_schema.tables
 		WHERE table_type = 'BASE TABLE'
 		  AND table_schema NOT IN ('pg_catalog', 'information_schema')
-		  AND table_schema NOT LIKE 'pg_%'
+		  AND table_schema NOT LIKE 'pg|_%' ESCAPE '|'
 		ORDER BY table_schema, table_name`
 
 	data, _, err := k.Query(query)
@@ -999,7 +999,7 @@ func (k *KingbaseDB) GetAllColumns(dbName string) ([]connection.ColumnDefinition
 		SELECT table_schema, table_name, column_name, data_type
 		FROM information_schema.columns
 		WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
-		  AND table_schema NOT LIKE 'pg_%'
+		  AND table_schema NOT LIKE 'pg|_%' ESCAPE '|'
 		ORDER BY table_schema, table_name, ordinal_position`
 
 	data, _, err := k.Query(query)

--- a/internal/db/optional_driver_agent_impl.go
+++ b/internal/db/optional_driver_agent_impl.go
@@ -608,7 +608,7 @@ func (d *OptionalDriverAgentDB) ensureKingbaseSearchPath(config connection.Conne
 func (d *OptionalDriverAgentDB) listKingbaseSchemas(ctx context.Context) ([]string, error) {
 	query := `SELECT nspname FROM pg_namespace
 		WHERE nspname NOT IN ('pg_catalog', 'information_schema')
-		  AND nspname NOT LIKE 'pg_%'
+		  AND nspname NOT LIKE 'pg|_%' ESCAPE '|'
 		ORDER BY nspname`
 	rows, _, err := d.QueryContext(ctx, query)
 	if err != nil {

--- a/internal/db/postgres_impl.go
+++ b/internal/db/postgres_impl.go
@@ -285,7 +285,7 @@ func (p *PostgresDB) GetDatabases() ([]string, error) {
 }
 
 func (p *PostgresDB) GetTables(dbName string) ([]string, error) {
-	query := "SELECT schemaname, tablename FROM pg_catalog.pg_tables WHERE schemaname != 'information_schema' AND schemaname NOT LIKE 'pg_%' ORDER BY schemaname, tablename"
+	query := "SELECT schemaname, tablename FROM pg_catalog.pg_tables WHERE schemaname != 'information_schema' AND schemaname NOT LIKE 'pg|_%' ESCAPE '|' ORDER BY schemaname, tablename"
 	data, _, err := p.Query(query)
 	if err != nil {
 		return nil, err
@@ -594,7 +594,7 @@ func (p *PostgresDB) GetAllColumns(dbName string) ([]connection.ColumnDefinition
 SELECT table_schema, table_name, column_name, data_type
 FROM information_schema.columns
 WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
-  AND table_schema NOT LIKE 'pg_%'
+  AND table_schema NOT LIKE 'pg|_%' ESCAPE '|'
 ORDER BY table_schema, table_name, ordinal_position`
 
 	data, _, err := p.Query(query)
@@ -692,7 +692,7 @@ func (p *PostgresDB) queryUserSchemas() []string {
 
 	query := `SELECT nspname FROM pg_namespace
 		WHERE nspname NOT IN ('pg_catalog', 'information_schema')
-		  AND nspname NOT LIKE 'pg_%'
+		  AND nspname NOT LIKE 'pg|_%' ESCAPE '|'
 		ORDER BY nspname`
 
 	rows, err := p.conn.Query(query)

--- a/internal/db/vastbase_impl.go
+++ b/internal/db/vastbase_impl.go
@@ -211,7 +211,7 @@ func (v *VastbaseDB) GetDatabases() ([]string, error) {
 }
 
 func (v *VastbaseDB) GetTables(dbName string) ([]string, error) {
-	query := "SELECT schemaname, tablename FROM pg_catalog.pg_tables WHERE schemaname != 'information_schema' AND schemaname NOT LIKE 'pg_%' ORDER BY schemaname, tablename"
+	query := "SELECT schemaname, tablename FROM pg_catalog.pg_tables WHERE schemaname != 'information_schema' AND schemaname NOT LIKE 'pg|_%' ESCAPE '|' ORDER BY schemaname, tablename"
 	data, _, err := v.Query(query)
 	if err != nil {
 		return nil, err
@@ -513,7 +513,7 @@ func (v *VastbaseDB) GetAllColumns(dbName string) ([]connection.ColumnDefinition
 SELECT table_schema, table_name, column_name, data_type
 FROM information_schema.columns
 WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
-  AND table_schema NOT LIKE 'pg_%'
+  AND table_schema NOT LIKE 'pg|_%' ESCAPE '|'
 ORDER BY table_schema, table_name, ordinal_position`
 
 	data, _, err := v.Query(query)


### PR DESCRIPTION
LIKE 模式中 '_' 是单字符通配符，'pg_%' 不仅匹配 pg_catalog/pg_toast， 还会匹配到以 'pg' 开头的 schema，导致这些 schema 下的表被 GetTables 漏掉，侧边栏不显示 schema 分组。 改用 LIKE 'pg|_%' ESCAPE '|'，'_' 仅匹配字面量下划线。