### PR TITLE
✨ feat(snippets): 添加代码片段管理工具入口

### DIFF
--- a/frontend/src/App.tool-center.test.ts
+++ b/frontend/src/App.tool-center.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const appSource = readFileSync(
+  fileURLToPath(new globalThis.URL('./App.tsx', import.meta.url)),
+  'utf8',
+);
+
+describe('tool center menu entries', () => {
+  it('exposes snippet management next to shortcut management', () => {
+    expect(appSource).toContain("key: 'snippet-settings'");
+    expect(appSource).toContain("title: '代码片段管理'");
+    expect(appSource).toContain('setIsSnippetModalOpen(true)');
+
+    const snippetIndex = appSource.indexOf("key: 'snippet-settings'");
+    const shortcutIndex = appSource.indexOf("key: 'shortcut-settings'", snippetIndex);
+    expect(snippetIndex).toBeGreaterThan(-1);
+    expect(shortcutIndex).toBeGreaterThan(snippetIndex);
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 ﻿import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { Layout, Button, ConfigProvider, theme, message, Modal, Spin, Slider, Progress, Switch, Input, InputNumber, Select, Segmented, Tooltip } from 'antd';
 import zhCN from 'antd/locale/zh_CN';
-import { PlusOutlined, ConsoleSqlOutlined, UploadOutlined, DownloadOutlined, CloudDownloadOutlined, BugOutlined, ToolOutlined, GlobalOutlined, InfoCircleOutlined, GithubOutlined, SkinOutlined, CheckOutlined, MinusOutlined, BorderOutlined, CloseOutlined, SettingOutlined, LinkOutlined, BgColorsOutlined, AppstoreOutlined, RobotOutlined, FolderOpenOutlined, HddOutlined, SafetyCertificateOutlined, SwitcherOutlined } from '@ant-design/icons';
+import { PlusOutlined, ConsoleSqlOutlined, UploadOutlined, DownloadOutlined, CloudDownloadOutlined, BugOutlined, ToolOutlined, GlobalOutlined, InfoCircleOutlined, GithubOutlined, SkinOutlined, CheckOutlined, MinusOutlined, BorderOutlined, CloseOutlined, SettingOutlined, LinkOutlined, BgColorsOutlined, AppstoreOutlined, RobotOutlined, FolderOpenOutlined, HddOutlined, SafetyCertificateOutlined, SwitcherOutlined, CodeOutlined } from '@ant-design/icons';
 import { BrowserOpenURL, Environment, EventsOn, Quit, WindowFullscreen, WindowGetPosition, WindowGetSize, WindowIsFullscreen, WindowIsMaximised, WindowIsMinimised, WindowIsNormal, WindowMaximise, WindowMinimise, WindowSetPosition, WindowSetSize, WindowUnfullscreen, WindowUnmaximise } from '../wailsjs/runtime';
 import Sidebar from './components/Sidebar';
 import TabManager from './components/TabManager';
@@ -3018,6 +3018,16 @@ function App() {
                   onClick: () => {
                     setIsToolsModalOpen(false);
                     setIsDataRootModalOpen(true);
+                  },
+                },
+                {
+                  key: 'snippet-settings',
+                  icon: <CodeOutlined />,
+                  title: '代码片段管理',
+                  description: '管理 SQL 代码片段和前缀补全。',
+                  onClick: () => {
+                    setIsToolsModalOpen(false);
+                    setIsSnippetModalOpen(true);
                   },
                 },
                 {


### PR DESCRIPTION
- 工具中心新增代码片段管理入口，与快捷键管理保持同级展示

- 复用现有 SnippetSettingsModal 打开逻辑，保留查询编辑器原入口

- 补充工具中心入口回归测试，防止菜单入口丢失

<img width="1345" height="877" alt="image" src="https://github.com/user-attachments/assets/a131211b-74da-4bf3-ab82-d37039e58d14" />


