### PR TITLE
fix(ui)旧版UI左侧列表无法通过鼠标扩大问题修复

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -685,3 +685,9 @@ body[data-theme='dark'] .gonavi-query-editor-column-token {
 body[data-theme='dark'] .gonavi-query-editor-db-token {
   color: #c4b5fd;
 }
+
+/* Legacy sidebar resize bounds — mirror v2 .gn-v2-app-sider so Ant Design inline width locks do not collapse drag range. */
+body[data-ui-version="legacy"] .ant-layout-sider {
+  min-width: 232px !important;
+  max-width: 420px !important;
+}

--- a/frontend/src/App.tool-center.test.ts
+++ b/frontend/src/App.tool-center.test.ts
@@ -6,6 +6,10 @@ const appSource = readFileSync(
   fileURLToPath(new globalThis.URL('./App.tsx', import.meta.url)),
   'utf8',
 );
+const appCss = readFileSync(
+  fileURLToPath(new globalThis.URL('./App.css', import.meta.url)),
+  'utf8',
+);
 const linuxCJKFontBannerSource = readFileSync(
   fileURLToPath(new globalThis.URL('./components/LinuxCJKFontBanner.tsx', import.meta.url)),
   'utf8',
@@ -114,6 +118,10 @@ describe('tool center menu entries', () => {
     expect(appSource).toContain('resolveSidebarResizeBounds(siderRef.current)');
     expect(appSource).toContain('ghostRef.current.style.left = `${startGuideLeft}px`;');
     expect(appSource).toContain('ghostRef.current.style.left = `${startGuideLeft + (newWidth - startWidth)}px`;');
+  });
+
+  it('keeps legacy sidebar resize bounds aligned with the v2 sider CSS limits', () => {
+    expect(appCss).toMatch(/body\[data-ui-version="legacy"\]\s+\.ant-layout-sider\s*\{[^}]*min-width:\s*232px\s*!important;[^}]*max-width:\s*420px\s*!important;/s);
   });
 
   it('keeps connection modal warm-mounted while leaving the other heavyweight modals conditional', () => {


### PR DESCRIPTION
Windows11使用旧版UI时，发现左侧列表不能拖拽扩大，排查是CSS宽度限制问题，尝试修复，第一次PR，有什么需要补充的见谅，后续还想模仿dataGrip实现一些比较常用的快捷键。
<img width="768" height="576" alt="修复前效果" src="https://github.com/user-attachments/assets/e01da36a-1edb-4ad8-b278-513e4f790c02" />
<img width="768" height="576" alt="修复后" src="https://github.com/user-attachments/assets/4679e1ba-4d4d-4b1e-ab51-a98ec8c3ed1a" />
