### PR TITLE
fix: Add type definitions for Monaco editor module

### DIFF
--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,6 +1,9 @@
 /// <reference types="vite/client" />
 
-declare module 'monaco-editor/esm/nls.messages.zh-cn' { const messages: Record<string, string>; export default messages; }
+declare module 'monaco-editor/esm/nls.messages.zh-cn' {
+  const messages: Record<string, string>;
+  export default messages;
+}
 
 interface ImportMetaEnv {
   readonly VITE_GONAVI_ENABLE_MAC_WINDOW_DIAGNOSTICS?: string;

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 
-declare module 'monaco-editor/esm/nls.messages.zh-cn';
+declare module 'monaco-editor/esm/nls.messages.zh-cn' { const messages: Record<string, string>; export default messages; }
 
 interface ImportMetaEnv {
   readonly VITE_GONAVI_ENABLE_MAC_WINDOW_DIAGNOSTICS?: string;


### PR DESCRIPTION
### 问题背景
在 TypeScript 项目中，模块 'monaco-editor/esm/nls.messages.zh-cn' 的声明缺少类型定义，导致导入时得到 `any` 类型，这降低了类型安全性，可能引入潜在的类型错误。

### 修改内容
- 在 `frontend/src/vite-env.d.ts` 文件中，为模块 'monaco-editor/esm/nls.messages.zh-cn' 添加了具体的类型定义。
- 将空的声明替换为带有类型信息的声明，指定了 `messages` 为 `Record<string, string>` 类型，并默认导出。
- 这提高了类型安全性，确保 TypeScript 编译器能提供正确的类型检查，减少运行时错误风险，符合仓库的类型注解优化目标。

### 验证方式
- 此修改仅影响类型定义，不影响运行时行为，现有测试应继续通过。
- 建议通过运行 TypeScript 编译器（如 `tsc --noEmit`）验证类型定义正确性，确保无类型错误。
- 可手动检查导入该模块的代码，确认类型推断改善。

### 其他信息
- 无 breaking changes，不影响公共 API 或外部行为。
- 不需要更新文档。
- 无已知限制。