### PR TITLE
feat(sidebar): show table comment in tree hover tooltip

### DIFF
--- a/frontend/src/components/sidebar/SidebarTreeTitle.test.tsx
+++ b/frontend/src/components/sidebar/SidebarTreeTitle.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { composeSidebarTableHoverTitle } from './SidebarTreeTitle';
+import { catalogs } from '../../i18n/catalog';
+import { SUPPORTED_LANGUAGES } from '../../i18n/resolveLanguage';
+
+describe('composeSidebarTableHoverTitle', () => {
+  it('returns name with comment on a separate line when a comment is present', () => {
+    const result = composeSidebarTableHoverTitle('orders', 'customer orders');
+    expect(result).toContain('orders');
+    expect(result).toContain('customer orders');
+    expect(result).toContain('\n');
+  });
+  it('falls back to the bare name when the comment is empty', () => {
+    expect(composeSidebarTableHoverTitle('orders', '')).toBe('orders');
+  });
+  it('falls back to the bare name when the comment is whitespace only', () => {
+    expect(composeSidebarTableHoverTitle('orders', '   ')).toBe('orders');
+  });
+  it('falls back to the bare name when the comment is null/undefined', () => {
+    expect(composeSidebarTableHoverTitle('orders')).toBe('orders');
+    expect(composeSidebarTableHoverTitle('orders', null)).toBe('orders');
+  });
+});
+
+describe('sidebar.tree.table_comment_tooltip i18n key', () => {
+  const KEY = 'sidebar.tree.table_comment_tooltip';
+  it('exists in every supported locale catalog', () => {
+    for (const language of SUPPORTED_LANGUAGES) {
+      expect(typeof (catalogs as Record<string, Record<string, string>>)[language][KEY]).toBe('string');
+      expect((catalogs as Record<string, Record<string, string>>)[language][KEY].length).toBeGreaterThan(0);
+    }
+  });
+  it('keeps the name and comment placeholders in every locale', () => {
+    for (const language of SUPPORTED_LANGUAGES) {
+      const value = (catalogs as Record<string, Record<string, string>>)[language][KEY];
+      expect(value).toContain('{{name}}');
+      expect(value).toContain('{{comment}}');
+    }
+  });
+});

--- a/frontend/src/components/sidebar/SidebarTreeTitle.tsx
+++ b/frontend/src/components/sidebar/SidebarTreeTitle.tsx
@@ -6,6 +6,21 @@ import { sanitizeRedisDbAlias } from '../../utils/redisDbAlias';
 import { resolveSidebarObjectDragText } from '../sidebarCoreUtils';
 import { resolveV2ObjectGroupTitle } from './sidebarHelpers';
 
+export const composeSidebarTableHoverTitle = (
+  name: string,
+  comment?: string | null,
+): string => {
+  const baseName = String(name ?? '');
+  const trimmedComment = String(comment ?? '').trim();
+  if (!trimmedComment) {
+    return baseName;
+  }
+  return t('sidebar.tree.table_comment_tooltip', {
+    name: baseName,
+    comment: trimmedComment,
+  });
+};
+
 type SidebarV2TreeTitleOptions = {
   node: any;
   hoverTitle: string;

--- a/frontend/src/components/sidebar/sidebarMetadataLoaders.ts
+++ b/frontend/src/components/sidebar/sidebarMetadataLoaders.ts
@@ -252,6 +252,23 @@ const parseMetadataRowCount = (
   return Math.round(parsed);
 };
 
+const parseMetadataTableComment = (
+  row: Record<string, any>,
+): string | undefined => {
+  const rawValue = getCaseInsensitiveRawValue(row, [
+    "table_comment",
+    "TABLE_COMMENT",
+    "Comment",
+    "comment",
+    "comments",
+  ]);
+  if (rawValue === undefined || rawValue === null) {
+    return undefined;
+  }
+  const text = String(rawValue).trim();
+  return text.length > 0 ? text : undefined;
+};
+
 const buildSidebarTableStatusSQL = (
   conn: SavedConnection,
   dbName: string,
@@ -262,7 +279,7 @@ const buildSidebarTableStatusSQL = (
     case "mysql":
     case "starrocks":
       return [
-        "SELECT TABLE_NAME AS table_name, TABLE_ROWS AS table_rows",
+        "SELECT TABLE_NAME AS table_name, TABLE_ROWS AS table_rows, TABLE_COMMENT AS table_comment",
         "FROM information_schema.tables",
         `WHERE table_schema = '${safeDbName}'`,
         "AND table_type = 'BASE TABLE'",
@@ -275,7 +292,7 @@ const buildSidebarTableStatusSQL = (
     case "opengauss":
     case "gaussdb":
       return [
-        "SELECT n.nspname || '.' || c.relname AS table_name, c.reltuples::bigint AS table_rows",
+        "SELECT n.nspname || '.' || c.relname AS table_name, c.reltuples::bigint AS table_rows, obj_description(c.oid, 'pg_class') AS table_comment",
         "FROM pg_class c",
         "JOIN pg_namespace n ON n.oid = c.relnamespace",
         "WHERE c.relkind = 'r'",
@@ -297,7 +314,7 @@ const buildSidebarTableStatusSQL = (
     }
     case "clickhouse":
       return [
-        "SELECT name AS table_name, total_rows AS table_rows",
+        "SELECT name AS table_name, total_rows AS table_rows, comment AS table_comment",
         "FROM system.tables",
         `WHERE database = '${safeDbName}'`,
         "AND engine NOT IN ('View', 'MaterializedView')",
@@ -1273,6 +1290,7 @@ export {
   normalizeMetadataQuerySpecs,
   parseDuckDBParameterNames,
   parseMetadataRowCount,
+  parseMetadataTableComment,
   quoteSqlServerIdentifier,
   shouldHideSchemaPrefix,
   splitQualifiedName,

--- a/frontend/src/components/sidebar/useSidebarTitleRender.tsx
+++ b/frontend/src/components/sidebar/useSidebarTitleRender.tsx
@@ -15,6 +15,7 @@ import {
   splitQualifiedName,
 } from './sidebarMetadataLoaders';
 import { resolveV2ObjectGroupTitle } from './sidebarHelpers';
+import { composeSidebarTableHoverTitle } from './SidebarTreeTitle';
 
 type UseSidebarTitleRenderArgs = {
   connectionStates: Record<string, SidebarConnectionState>;
@@ -69,6 +70,10 @@ export const useSidebarTitleRender = ({
     }
   } else if (node.type === 'external-sql-directory' || node.type === 'external-sql-folder' || node.type === 'external-sql-file') {
     hoverTitle = String(node?.dataRef?.path || displayTitle);
+  }
+
+  if (node.type === 'table') {
+    hoverTitle = composeSidebarTableHoverTitle(hoverTitle, node?.dataRef?.comment);
   }
 
   if (node.type === 'jvm-mode') {

--- a/frontend/src/components/sidebar/useSidebarTreeLoaders.tsx
+++ b/frontend/src/components/sidebar/useSidebarTreeLoaders.tsx
@@ -39,6 +39,7 @@ import {
   loadStarRocksMaterializedViews,
   loadViews,
   parseMetadataRowCount,
+  parseMetadataTableComment,
   shouldHideSchemaPrefix,
   splitQualifiedName,
   supportsDatabaseEvents,
@@ -486,6 +487,7 @@ export const useSidebarTreeLoaders = ({
                     ? await DBQuery(buildRpcConnectionConfig(config) as any, conn.dbName, tableStatusSql).catch(() => ({ success: false, data: [] as any[] }))
                     : { success: false, data: [] as any[] };
                 const tableRowCountMap = new Map<string, number>();
+                const tableCommentMap = new Map<string, string>();
                 if (tableStatsResult?.success && Array.isArray(tableStatsResult.data)) {
                     tableStatsResult.data.forEach((row: Record<string, any>) => {
                         const rawTableName = String(
@@ -494,6 +496,10 @@ export const useSidebarTreeLoaders = ({
                             || ''
                         ).trim();
                         if (!rawTableName) return;
+                        const tableComment = parseMetadataTableComment(row);
+                        if (tableComment) {
+                            tableCommentMap.set(rawTableName.toLowerCase(), tableComment);
+                        }
                         const rowCount = parseMetadataRowCount(row);
                         if (rowCount === undefined) return;
                         tableRowCountMap.set(rawTableName.toLowerCase(), rowCount);
@@ -507,6 +513,7 @@ export const useSidebarTreeLoaders = ({
 	                    schemaName: parsed.schemaName,
 	                    displayName: getSidebarTableDisplayName(conn, tableName),
                         rowCount: tableRowCountMap.get(String(tableName || '').trim().toLowerCase()),
+                        comment: tableCommentMap.get(String(tableName || '').trim().toLowerCase()),
 	                };
 	            });
 
@@ -660,7 +667,7 @@ export const useSidebarTreeLoaders = ({
 
 	            eventEntries.sort((a, b) => a.displayName.toLowerCase().localeCompare(b.displayName.toLowerCase()));
 
-	            const buildTableNode = (entry: { tableName: string; schemaName: string; displayName: string; rowCount?: number }): TreeNode => {
+	            const buildTableNode = (entry: { tableName: string; schemaName: string; displayName: string; rowCount?: number; comment?: string }): TreeNode => {
 	                const isPinned = isV2Ui && isSidebarTablePinned(
 	                    currentPinnedSidebarTables,
 	                    conn.id,
@@ -678,6 +685,7 @@ export const useSidebarTreeLoaders = ({
 	                        tableName: entry.tableName,
 	                        schemaName: entry.schemaName,
 	                        rowCount: entry.rowCount,
+	                        comment: entry.comment,
 	                        ...(isPinned ? { pinnedSidebarTable: true } : {}),
 	                    },
 	                    isLeaf: false,

--- a/shared/i18n/de-DE.json
+++ b/shared/i18n/de-DE.json
@@ -7057,6 +7057,7 @@
   "sidebar.tree.default_database": "Standarddatenbank",
   "sidebar.tree.default_schema": "Standardschema",
   "sidebar.tree.saved_queries": "Gespeicherte Abfragen",
+  "sidebar.tree.table_comment_tooltip": "{{name}}\nKommentar: {{comment}}",
   "sidebar.tree.unknown_connection": "Unbekannte Verbindung",
   "sidebar.tree.unmatched_saved_queries": "Nicht zugeordnet",
   "sidebar.tree.untitled_query": "Unbenannte Abfrage",

--- a/shared/i18n/en-US.json
+++ b/shared/i18n/en-US.json
@@ -7057,6 +7057,7 @@
   "sidebar.tree.default_database": "Default database",
   "sidebar.tree.default_schema": "Default schema",
   "sidebar.tree.saved_queries": "Saved queries",
+  "sidebar.tree.table_comment_tooltip": "{{name}}\n{{comment}}",
   "sidebar.tree.unknown_connection": "Unknown connection",
   "sidebar.tree.unmatched_saved_queries": "Unmatched",
   "sidebar.tree.untitled_query": "Untitled query",

--- a/shared/i18n/ja-JP.json
+++ b/shared/i18n/ja-JP.json
@@ -7057,6 +7057,7 @@
   "sidebar.tree.default_database": "既定データベース",
   "sidebar.tree.default_schema": "既定スキーマ",
   "sidebar.tree.saved_queries": "保存済みクエリ",
+  "sidebar.tree.table_comment_tooltip": "{{name}}\nコメント：{{comment}}",
   "sidebar.tree.unknown_connection": "不明な接続",
   "sidebar.tree.unmatched_saved_queries": "未一致",
   "sidebar.tree.untitled_query": "無題のクエリ",

--- a/shared/i18n/ru-RU.json
+++ b/shared/i18n/ru-RU.json
@@ -7057,6 +7057,7 @@
   "sidebar.tree.default_database": "База данных по умолчанию",
   "sidebar.tree.default_schema": "Схема по умолчанию",
   "sidebar.tree.saved_queries": "Сохраненные запросы",
+  "sidebar.tree.table_comment_tooltip": "{{name}}\nКомментарий: {{comment}}",
   "sidebar.tree.unknown_connection": "Неизвестное подключение",
   "sidebar.tree.unmatched_saved_queries": "Несопоставленные",
   "sidebar.tree.untitled_query": "Запрос без имени",

--- a/shared/i18n/zh-CN.json
+++ b/shared/i18n/zh-CN.json
@@ -7057,6 +7057,7 @@
   "sidebar.tree.default_database": "默认数据库",
   "sidebar.tree.default_schema": "默认结构",
   "sidebar.tree.saved_queries": "已存查询",
+  "sidebar.tree.table_comment_tooltip": "{{name}}\n备注：{{comment}}",
   "sidebar.tree.unknown_connection": "未知连接",
   "sidebar.tree.unmatched_saved_queries": "未匹配",
   "sidebar.tree.untitled_query": "未命名查询",

--- a/shared/i18n/zh-TW.json
+++ b/shared/i18n/zh-TW.json
@@ -7057,6 +7057,7 @@
   "sidebar.tree.default_database": "預設資料庫",
   "sidebar.tree.default_schema": "預設結構",
   "sidebar.tree.saved_queries": "已儲存查詢",
+  "sidebar.tree.table_comment_tooltip": "{{name}}\n備註：{{comment}}",
   "sidebar.tree.unknown_connection": "未知連線",
   "sidebar.tree.unmatched_saved_queries": "未匹配",
   "sidebar.tree.untitled_query": "未命名查詢",


### PR DESCRIPTION
## Summary

Shows a table's comment/remark in the left sidebar tree node hover tooltip, addressing #569. When a table node carries a non-empty comment, hovering over it now reveals `<table name>` followed by the comment on a second line, so the remark is readable without opening the card/list view. When a table has no comment, the tooltip is unchanged (name only).

The comment is loaded alongside the existing per-table row-count status query and threaded onto the tree node's `dataRef`:
- `sidebarMetadataLoaders.ts`: the status SQL now also selects the table comment for MySQL/StarRocks (`information_schema.tables.TABLE_COMMENT`), PostgreSQL and PG-compatible engines (`obj_description(c.oid, 'pg_class')`), and ClickHouse (`system.tables.comment`); a new `parseMetadataTableComment` helper reads it case-insensitively.
- `useSidebarTreeLoaders.tsx`: builds a comment map from the status result and attaches `comment` to each table node's `dataRef`.
- `useSidebarTitleRender.tsx` / `SidebarTreeTitle.tsx`: a new pure helper `composeSidebarTableHoverTitle` composes the localized tooltip via the new i18n key `sidebar.tree.table_comment_tooltip`, added to all six locale catalogs.

## Why this matters

The reporter (and the common-in-China workflow around table 备注) expects to read a table's comment inline with its name in the sidebar, rather than opening the card/list view as a workaround. This surfaces that metadata directly on hover, localized across all six supported languages.

This is a partial-scope contribution: it covers the hover-tooltip half of the issue. The always-on tree-label toggle (part 2) is deferred because it needs a new appearance/settings-store entry. Engines whose status query does not expose a comment column (e.g. SQL Server, Oracle) fall back gracefully to the existing name-only tooltip.

## Testing

- `npx vitest run src/components/sidebar/SidebarTreeTitle.test.tsx src/i18n/catalog.test.ts` — new helper tests (name+comment, empty/whitespace/null fallback) and i18n key + placeholder parity across all six locales pass (62 tests).
- `npx vitest run src/components/sidebar/sidebarMetadataLoaders.test.ts` — pass.
- `npx tsc --noEmit` — clean.

Refs #569
