### PR TITLE
fix(oceanbase): reduce Oracle long-query bad connection failures

### DIFF
--- a/frontend/src/utils/sqlErrorSemantics.test.ts
+++ b/frontend/src/utils/sqlErrorSemantics.test.ts
@@ -37,6 +37,13 @@ describe('formatSqlExecutionError', () => {
     expect(formatted).toContain('Raw error: driver returned unexpected status 123');
   });
 
+  it('recognizes driver bad connection during SQL execution as timeout semantics', () => {
+    const formatted = formatSqlExecutionError('第 1 条语句执行失败：driver: bad connection');
+
+    expect(formatted).toContain('Semantic meaning: Query timed out or was canceled');
+    expect(formatted).toContain('Raw error: 第 1 条语句执行失败：driver: bad connection');
+  });
+
   it('recognizes localized connection-timeout wrappers as timeout semantics', () => {
     const translate = (key: string, params?: Record<string, unknown>) => {
       if (key === 'query_editor.sql_error.wrapper.semantic_line') {

--- a/frontend/src/utils/sqlErrorSemantics.ts
+++ b/frontend/src/utils/sqlErrorSemantics.ts
@@ -135,6 +135,7 @@ const SQL_ERROR_RULES: SqlErrorSemanticRule[] = [
       /context cancelled/i,
       /timeout/i,
       /timed out/i,
+      /driver:\s*bad connection/i,
     ],
   },
   {

--- a/internal/app/db_context.go
+++ b/internal/app/db_context.go
@@ -9,6 +9,8 @@ import (
 	"GoNavi-Wails/internal/db"
 )
 
+const defaultOceanBaseOracleQueryTimeoutSeconds = 120
+
 func normalizeRunConfig(config connection.ConnectionConfig, dbName string) connection.ConnectionConfig {
 	runConfig := config
 	name := strings.TrimSpace(dbName)
@@ -53,6 +55,10 @@ func applyOceanBaseOracleCurrentSchemaInit(config connection.ConnectionConfig, s
 	normalizedSchema := strings.TrimSpace(schema)
 	if normalizedSchema == "" {
 		return config
+	}
+	if config.Timeout <= 0 {
+		// OceanBase Oracle 查询经常需要经过 OBProxy/Oracle driver 的读等待；默认 30s 容易把慢查询误报成 driver: bad connection。
+		config.Timeout = defaultOceanBaseOracleQueryTimeoutSeconds
 	}
 	values, err := url.ParseQuery(strings.TrimSpace(config.ConnectionParams))
 	if err != nil {

--- a/internal/app/db_context_oceanbase_oracle_test.go
+++ b/internal/app/db_context_oceanbase_oracle_test.go
@@ -20,6 +20,9 @@ func TestNormalizeRunConfig_OceanBaseOracleAddsCurrentSchemaInit(t *testing.T) {
 	if runConfig.Database != "OBORCL" {
 		t.Fatalf("expected OceanBase Oracle service name to stay OBORCL, got %q", runConfig.Database)
 	}
+	if runConfig.Timeout != defaultOceanBaseOracleQueryTimeoutSeconds {
+		t.Fatalf("expected OceanBase Oracle default query timeout %d, got %d", defaultOceanBaseOracleQueryTimeoutSeconds, runConfig.Timeout)
+	}
 	values, err := url.ParseQuery(runConfig.ConnectionParams)
 	if err != nil {
 		t.Fatalf("unexpected connection params parse error: %v", err)
@@ -30,17 +33,21 @@ func TestNormalizeRunConfig_OceanBaseOracleAddsCurrentSchemaInit(t *testing.T) {
 	}
 }
 
-func TestNormalizeRunConfig_OceanBaseOraclePreservesExistingInit(t *testing.T) {
+func TestNormalizeRunConfig_OceanBaseOraclePreservesExplicitTimeoutAndExistingInit(t *testing.T) {
 	t.Parallel()
 
 	config := connection.ConnectionConfig{
 		Type:              "oceanbase",
 		Database:          "OBORCL",
 		OceanBaseProtocol: "oracle",
+		Timeout:           45,
 		ConnectionParams:  "init=ALTER+SESSION+SET+NLS_DATE_FORMAT%3D%27YYYY-MM-DD%27&timeout=10s",
 	}
 	runConfig := normalizeRunConfig(config, "sbdev")
 
+	if runConfig.Timeout != 45 {
+		t.Fatalf("expected explicit timeout to be preserved, got %d", runConfig.Timeout)
+	}
 	values, err := url.ParseQuery(runConfig.ConnectionParams)
 	if err != nil {
 		t.Fatalf("unexpected connection params parse error: %v", err)


### PR DESCRIPTION
## Summary

- For OceanBase Oracle protocol queries with no explicit timeout, use a longer 120s runtime timeout once a schema is selected.
- Preserve explicit user-configured timeouts.
- Classify `driver: bad connection` from SQL execution as timeout/cancel semantics in the query editor error formatter, so long-query read timeouts are not shown as an unmatched generic database error.
- Add Go and Vitest regression coverage.

## Why

OceanBase Oracle long queries can surface as `driver: bad connection` when the driver or OBProxy closes the connection during read wait. The default 30s timeout is too short for normal diagnostic/data-check queries in Oracle mode, and the UI previously treated this error as an unknown generic failure.

This keeps normal explicit timeout control while making the default behavior less brittle for OceanBase Oracle tenants.