### PR TITLE
fix(update): repair Go syntax in Windows update cleanup

### DIFF
--- a/internal/app/update_cleanup.go
+++ b/internal/app/update_cleanup.go
@@ -93,9 +93,9 @@ func resolveWindowsUpdateFinalTargetPath(currentTarget string, sourcePath string
 func isVersionedWindowsUpdatePackageName(name string) bool {
 	trimmed := strings.TrimSpace(name)
 	lower := strings.ToLower(trimmed)
-	return strings.HasPrefix(trimmed, "GoNavi-")
-		&& strings.Contains(trimmed, "-Windows-")
-		&& strings.HasSuffix(lower, ".exe")
+	return strings.HasPrefix(trimmed, "GoNavi-") &&
+		strings.Contains(trimmed, "-Windows-") &&
+		strings.HasSuffix(lower, ".exe")
 }
 
 func prepareWindowsStagedUpdateAsset(sourcePath string, stagedDir string) (string, error) {


### PR DESCRIPTION
## Summary

- Fix the Go multiline boolean expression in `isVersionedWindowsUpdatePackageName`.
- This should unblock the Dev Build and Docker Images workflows that failed on the merged updater follow-up commit.

## Why

The previous commit split a `return` boolean expression before the `&&` operators. Go inserts semicolons at line endings, so the expression must keep the binary operator at the end of each continued line.