### PR TITLE
fix(query-result): show capped result counts as exact totals

### DIFF
--- a/frontend/src/utils/queryResultPagination.test.ts
+++ b/frontend/src/utils/queryResultPagination.test.ts
@@ -26,6 +26,25 @@ describe('queryResultPagination', () => {
     });
   });
 
+  it('treats query-editor injected LIMIT as a capped page rather than an uncounted total', () => {
+    const page = createInitialQueryResultPagination({
+      executedSql: 'SELECT id, name FROM users LIMIT 500',
+      exportSql: 'SELECT id, name FROM users',
+      dbType: 'mysql',
+      returnedRowCount: 500,
+      fallbackPageSize: 500,
+    });
+
+    expect(page).toMatchObject({
+      current: 1,
+      pageSize: 500,
+      total: 500,
+      totalKnown: true,
+      baseSql: 'SELECT id, name FROM users',
+      exportAllSql: 'SELECT id, name FROM users',
+    });
+  });
+
   it('builds the next page SQL with one lookahead row', () => {
     expect(buildQueryResultPageSql({
       baseSql: 'SELECT id FROM users',

--- a/frontend/src/utils/queryResultPagination.ts
+++ b/frontend/src/utils/queryResultPagination.ts
@@ -22,6 +22,14 @@ const normalizePositiveInteger = (value: unknown): number => {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
 };
 
+const normalizeSqlForComparison = (sql: string): string => (
+  String(sql || '')
+    .replace(/\s+/g, ' ')
+    .replace(/;+\s*$/g, '')
+    .trim()
+    .toLowerCase()
+);
+
 const parseTopLevelLimit = (sql: string): LimitInfo | null => {
   const { main } = splitSqlTail(sql);
   const limitPos = findTopLevelKeyword(main, 'limit');
@@ -58,6 +66,14 @@ const stripExplicitLimitForExport = (sql: string): string => {
   const parsed = parseTopLevelLimit(sql);
   if (parsed?.baseSql) return parsed.baseSql;
   return splitSqlTail(sql).main.trim();
+};
+
+const wasLimitAppliedByQueryEditorCap = (executedSql: string, exportSql: string): boolean => {
+  const executed = String(executedSql || '').trim();
+  const exportable = String(exportSql || '').trim();
+  if (!executed || !exportable) return false;
+  if (normalizeSqlForComparison(executed) === normalizeSqlForComparison(exportable)) return false;
+  return normalizeSqlForComparison(stripExplicitLimitForExport(executed)) === normalizeSqlForComparison(stripExplicitLimitForExport(exportable));
 };
 
 const resolveWrappedBaseSql = (dbType: string, baseSql: string): string => {
@@ -146,11 +162,14 @@ export const createInitialQueryResultPagination = (params: {
   const exportAllSql = exportSql && getLeadingKeyword(exportSql) === 'select'
     ? stripExplicitLimitForExport(exportSql)
     : stripExplicitLimitForExport(executedSql);
-  const totalState = resolveQueryResultPaginationTotal({
-    current,
-    pageSize,
-    rowCount: returnedRowCount,
-  });
+  const autoLimitCap = current === 1 && wasLimitAppliedByQueryEditorCap(executedSql, exportSql);
+  const totalState = autoLimitCap
+    ? { total: returnedRowCount, totalKnown: true }
+    : resolveQueryResultPaginationTotal({
+      current,
+      pageSize,
+      rowCount: returnedRowCount,
+    });
 
   return {
     current,


### PR DESCRIPTION
## Summary

- Detect when the SQL editor added a `LIMIT` cap for max-rows protection instead of the user writing an explicit limit.
- Show the returned capped page count as an exact current result size instead of displaying `总数未统计` for the first page.
- Add regression coverage for capped first-page SQL results.

## Why

When a user selects a max rows value such as 500, the query editor can execute `SELECT ... LIMIT 500` while retaining the original SQL for export. That is a capped result, not an unknown total-count pagination state. Showing `当前500条/总数未统计` is confusing; this change treats that case as `500/500` for the current capped result set.