### PR TITLE
fix(editor): recover dropped printable Monaco input

### DIFF
--- a/frontend/src/components/MonacoEditor.tsx
+++ b/frontend/src/components/MonacoEditor.tsx
@@ -24,6 +24,14 @@ const sameEditorPosition = (left: any, right: any): boolean => (
   && Number(left?.column) === Number(right?.column)
 );
 
+const isSelectionEmpty = (selection: any): boolean => (
+  !selection
+  || (
+    Number(selection.startLineNumber) === Number(selection.endLineNumber)
+    && Number(selection.startColumn) === Number(selection.endColumn)
+  )
+);
+
 const stripSqlIdentifierQuotes = (value: string): string => {
   const text = String(value || '').trim();
   if (!text) return '';
@@ -194,6 +202,72 @@ const patchQueryEditorAiInlineRightArrowFallback = (editor: any, monaco: any) =>
   };
 };
 
+const installPrintableInputFallback = (editor: any, monaco: any) => {
+  const editorDomNode = editor?.getDomNode?.();
+  if (!editorDomNode || editor.__gonaviPrintableInputFallbackInstalled) {
+    return;
+  }
+  const input = editorDomNode.querySelector?.('textarea.inputarea, .inputarea textarea, textarea') as HTMLTextAreaElement | null;
+  if (!(input instanceof HTMLTextAreaElement)) {
+    return;
+  }
+  Object.defineProperty(editor, '__gonaviPrintableInputFallbackInstalled', {
+    value: true,
+    configurable: true,
+  });
+
+  const isReadOnly = (): boolean => {
+    try {
+      const optionId = monaco?.editor?.EditorOption?.readOnly;
+      return optionId !== undefined ? editor.getOption?.(optionId) === true : false;
+    } catch {
+      return false;
+    }
+  };
+
+  const handleBeforeInput = (event: InputEvent) => {
+    const text = String(event.data || '');
+    if (
+      event.defaultPrevented
+      || event.isComposing
+      || event.inputType !== 'insertText'
+      || !text
+      || text.length > 8
+      || isReadOnly()
+    ) {
+      return;
+    }
+
+    const selectionBefore = editor.getSelection?.();
+    if (!isSelectionEmpty(selectionBefore)) {
+      return;
+    }
+    const beforeValue = String(editor.getValue?.() ?? '');
+    const beforePosition = editor.getPosition?.();
+
+    window.setTimeout(() => {
+      const domNode = editor.getDomNode?.();
+      if (!(domNode instanceof HTMLElement) || !domNode.isConnected || isReadOnly()) {
+        return;
+      }
+      if (document.activeElement && !domNode.contains(document.activeElement)) {
+        return;
+      }
+      const afterValue = String(editor.getValue?.() ?? '');
+      const afterPosition = editor.getPosition?.();
+      if (afterValue !== beforeValue || !sameEditorPosition(beforePosition, afterPosition)) {
+        return;
+      }
+      editor.trigger?.('gonavi-printable-input-fallback', 'type', { text });
+    }, 16);
+  };
+
+  input.addEventListener('beforeinput', handleBeforeInput);
+  editor.onDidDispose?.(() => {
+    input.removeEventListener('beforeinput', handleBeforeInput);
+  });
+};
+
 export const registerGonaviMonacoThemes: BeforeMount = (monaco) => {
   if (transparentThemesRegistered) {
     return;
@@ -291,6 +365,7 @@ const MonacoEditor: React.FC<MonacoEditorProps> = ({
   const handleMount: OnMount = useCallback((editor, monaco) => {
     installOceanBaseOracleNavigationFallback(editor);
     patchQueryEditorAiInlineRightArrowFallback(editor, monaco);
+    installPrintableInputFallback(editor, monaco);
     onMount?.(editor, monaco);
   }, [onMount]);
 


### PR DESCRIPTION
## Summary

- Add a guarded `beforeinput` fallback for Monaco editors.
- When a plain printable insert event reaches Monaco but the editor value and cursor position do not change after the browser input tick, replays the text through Monaco's `type` command.
- Skips readonly editors, IME composition, non-text input types, non-empty selections, unfocused editors, and normal successful input.

## Why

Some users reported intermittent dropped keystrokes in the SQL editor, such as typing `sf` and the `s` occasionally not appearing. The existing configuration already disables Monaco `editContext`, but this adds a conservative recovery path for the rare case where the browser emits text input and Monaco does not apply it.