### PR TITLE
fix(oceanbase): tolerate Oracle sequence metadata differences

### DIFF
--- a/internal/app/methods_db_objects.go
+++ b/internal/app/methods_db_objects.go
@@ -417,9 +417,16 @@ func buildObjectSequenceMetadataQueries(dbType string, dbName string) []objectMe
 	switch dbType {
 	case "oracle", "dameng":
 		if strings.TrimSpace(dbName) == "" {
-			return []objectMetadataQuerySpec{{sql: "SELECT SEQUENCE_NAME AS sequence_name FROM USER_SEQUENCES ORDER BY SEQUENCE_NAME"}}
+			return []objectMetadataQuerySpec{
+				{sql: "SELECT * FROM USER_SEQUENCES ORDER BY SEQUENCE_NAME"},
+				{sql: "SELECT OBJECT_NAME AS sequence_name FROM USER_OBJECTS WHERE OBJECT_TYPE = 'SEQUENCE' ORDER BY OBJECT_NAME"},
+			}
 		}
-		return []objectMetadataQuerySpec{{sql: fmt.Sprintf("SELECT SEQUENCE_OWNER AS schema_name, SEQUENCE_NAME AS sequence_name FROM ALL_SEQUENCES WHERE SEQUENCE_OWNER = '%s' ORDER BY SEQUENCE_NAME", strings.ToUpper(safeDbName))}}
+		owner := strings.ToUpper(safeDbName)
+		return []objectMetadataQuerySpec{
+			{sql: fmt.Sprintf("SELECT * FROM ALL_SEQUENCES WHERE SEQUENCE_OWNER = '%s' ORDER BY SEQUENCE_NAME", owner)},
+			{sql: fmt.Sprintf("SELECT OWNER AS schema_name, OBJECT_NAME AS sequence_name FROM ALL_OBJECTS WHERE OWNER = '%s' AND OBJECT_TYPE = 'SEQUENCE' ORDER BY OBJECT_NAME", owner)},
+		}
 	default:
 		return nil
 	}

--- a/internal/app/methods_db_objects_sequence_test.go
+++ b/internal/app/methods_db_objects_sequence_test.go
@@ -1,0 +1,39 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildObjectSequenceMetadataQueriesOracleUsesWildcardAndObjectFallback(t *testing.T) {
+	t.Parallel()
+
+	specs := buildObjectSequenceMetadataQueries("oracle", "sbdev")
+	if len(specs) != 2 {
+		t.Fatalf("expected 2 Oracle sequence metadata queries, got %d", len(specs))
+	}
+	if !strings.Contains(specs[0].sql, "SELECT * FROM ALL_SEQUENCES") {
+		t.Fatalf("expected ALL_SEQUENCES wildcard query, got %q", specs[0].sql)
+	}
+	if strings.Contains(specs[0].sql, "LAST_NUMBER") || strings.Contains(specs[0].sql, "ORDER_FLAG") {
+		t.Fatalf("query should not enumerate optional sequence columns: %q", specs[0].sql)
+	}
+	if !strings.Contains(specs[1].sql, "ALL_OBJECTS") || !strings.Contains(specs[1].sql, "OBJECT_TYPE = 'SEQUENCE'") {
+		t.Fatalf("expected ALL_OBJECTS fallback query, got %q", specs[1].sql)
+	}
+}
+
+func TestBuildObjectSequenceMetadataQueriesOracleUserFallbacks(t *testing.T) {
+	t.Parallel()
+
+	specs := buildObjectSequenceMetadataQueries("oracle", "")
+	if len(specs) != 2 {
+		t.Fatalf("expected 2 Oracle user sequence metadata queries, got %d", len(specs))
+	}
+	if specs[0].sql != "SELECT * FROM USER_SEQUENCES ORDER BY SEQUENCE_NAME" {
+		t.Fatalf("unexpected USER_SEQUENCES query: %q", specs[0].sql)
+	}
+	if !strings.Contains(specs[1].sql, "USER_OBJECTS") || !strings.Contains(specs[1].sql, "OBJECT_TYPE = 'SEQUENCE'") {
+		t.Fatalf("expected USER_OBJECTS fallback query, got %q", specs[1].sql)
+	}
+}


### PR DESCRIPTION
## Summary

- Make Oracle/Dameng sequence metadata discovery use `SELECT *` from `USER_SEQUENCES` / `ALL_SEQUENCES` rather than enumerating a narrow column list.
- Add `USER_OBJECTS` / `ALL_OBJECTS` sequence fallbacks so the object tree can still list sequences when a compatibility view omits sequence-detail columns.
- Add regression tests for the fallback query generation.

## Why

OceanBase Oracle compatibility views can differ from full Oracle dictionary views. Enumerating sequence columns such as optional flags can make sequence discovery fail with invalid identifier errors. Listing sequences should remain tolerant, then use whichever detail columns are available.