### PR TITLE
✨ feat(data-grid): 支持查询结果导出 INSERT SQL

### DIFF
--- a/frontend/src/components/DataExportDialog.tsx
+++ b/frontend/src/components/DataExportDialog.tsx
@@ -4,12 +4,17 @@ import { Form, InputNumber, Select, message } from 'antd';
 import { ExportOutlined } from '@ant-design/icons';
 import { t } from '../i18n';
 
-export type DataExportFormat = 'csv' | 'xlsx' | 'json' | 'md' | 'html';
+export type DataExportFormat = 'csv' | 'xlsx' | 'json' | 'md' | 'html' | 'sql';
 export type DataExportScope = 'selected' | 'page' | 'all' | 'filteredAll';
 
 export type DataExportFileOptions = {
   format: DataExportFormat;
   xlsxMaxRowsPerSheet?: number;
+  insertSQLDialect?: string;
+  insertSQLTargetTable?: string;
+  insertSQLColumnTypes?: Record<string, string>;
+  insertSQLTargetColumns?: Record<string, string>;
+  insertSQLAllowEmptyTargetTable?: boolean;
 };
 
 export type DataExportDialogValues = DataExportFileOptions & {
@@ -27,6 +32,7 @@ export type ShowDataExportDialogOptions = {
   title: string;
   scopeOptions: DataExportScopeOption[];
   initialValues?: Partial<DataExportDialogValues>;
+  allowInsertSql?: boolean;
   okText?: string;
 };
 
@@ -42,6 +48,17 @@ export const DATA_EXPORT_FORMAT_OPTIONS: Array<{ value: DataExportFormat; label:
   { value: 'html', label: 'HTML' },
 ];
 
+export const INSERT_SQL_EXPORT_FORMAT_OPTION: { value: DataExportFormat; label: string } = {
+  value: 'sql',
+  label: 'INSERT SQL',
+};
+
+const resolveFormatOptions = (allowInsertSql: boolean): Array<{ value: DataExportFormat; label: string }> => (
+  allowInsertSql
+    ? [...DATA_EXPORT_FORMAT_OPTIONS, INSERT_SQL_EXPORT_FORMAT_OPTION]
+    : DATA_EXPORT_FORMAT_OPTIONS
+);
+
 const resolveDefaultScope = (scopeOptions: DataExportScopeOption[], initialScope?: string): string => {
   const matchedInitial = scopeOptions.find((item) => item.value === initialScope && !item.disabled);
   if (matchedInitial) return String(matchedInitial.value);
@@ -52,8 +69,12 @@ const resolveDefaultScope = (scopeOptions: DataExportScopeOption[], initialScope
 const normalizeDialogValues = (
   scopeOptions: DataExportScopeOption[],
   initialValues?: Partial<DataExportDialogValues>,
+  allowInsertSql = false,
 ): DataExportDialogValues => {
-  const format = (initialValues?.format || DEFAULT_DATA_EXPORT_FORMAT) as DataExportFormat;
+  const requestedFormat = (initialValues?.format || DEFAULT_DATA_EXPORT_FORMAT) as DataExportFormat;
+  const format = resolveFormatOptions(allowInsertSql).some((item) => item.value === requestedFormat)
+    ? requestedFormat
+    : DEFAULT_DATA_EXPORT_FORMAT;
   const scope = resolveDefaultScope(scopeOptions, initialValues?.scope ? String(initialValues.scope) : undefined);
   const xlsxMaxRowsPerSheet = Number(initialValues?.xlsxMaxRowsPerSheet) > 0
     ? Math.min(MAX_XLSX_ROWS_PER_SHEET, Math.trunc(Number(initialValues?.xlsxMaxRowsPerSheet)))
@@ -68,8 +89,9 @@ const normalizeDialogValues = (
 const validateDialogValues = (
   values: DataExportDialogValues,
   scopeOptions: DataExportScopeOption[],
+  allowInsertSql = false,
 ): string | null => {
-  if (!DATA_EXPORT_FORMAT_OPTIONS.some((item) => item.value === values.format)) {
+  if (!resolveFormatOptions(allowInsertSql).some((item) => item.value === values.format)) {
     return t('data_export.dialog.validation.format_required');
   }
   if (scopeOptions.length > 0) {
@@ -95,9 +117,11 @@ const validateDialogValues = (
 const DataExportDialogContent: React.FC<{
   scopeOptions: DataExportScopeOption[];
   initialValues?: Partial<DataExportDialogValues>;
+  allowInsertSql?: boolean;
   onChange: (values: DataExportDialogValues) => void;
-}> = ({ scopeOptions, initialValues, onChange }) => {
-  const [values, setValues] = useState<DataExportDialogValues>(() => normalizeDialogValues(scopeOptions, initialValues));
+}> = ({ scopeOptions, initialValues, allowInsertSql = false, onChange }) => {
+  const [values, setValues] = useState<DataExportDialogValues>(() => normalizeDialogValues(scopeOptions, initialValues, allowInsertSql));
+  const formatOptions = useMemo(() => resolveFormatOptions(allowInsertSql), [allowInsertSql]);
 
   useEffect(() => {
     onChange(values);
@@ -114,7 +138,7 @@ const DataExportDialogContent: React.FC<{
         <Form.Item label={t('data_export.dialog.field.format')} style={{ marginBottom: 16 }}>
           <Select
             value={values.format}
-            options={DATA_EXPORT_FORMAT_OPTIONS}
+            options={formatOptions}
             onChange={(format) => setValues((prev) => ({ ...prev, format: format as DataExportFormat }))}
           />
         </Form.Item>
@@ -170,7 +194,8 @@ export async function showDataExportDialog(
   modal: ReturnType<typeof Modal.useModal>[0],
   options: ShowDataExportDialogOptions,
 ): Promise<DataExportDialogValues | null> {
-  const initialValues = normalizeDialogValues(options.scopeOptions, options.initialValues);
+  const allowInsertSql = options.allowInsertSql === true;
+  const initialValues = normalizeDialogValues(options.scopeOptions, options.initialValues, allowInsertSql);
 
   return new Promise((resolve) => {
     let resolved = false;
@@ -194,13 +219,14 @@ export async function showDataExportDialog(
         <DataExportDialogContent
           scopeOptions={options.scopeOptions}
           initialValues={initialValues}
+          allowInsertSql={allowInsertSql}
           onChange={(values) => {
             latestValues = values;
           }}
         />
       ),
       onOk: async () => {
-        const errorMessage = validateDialogValues(latestValues, options.scopeOptions);
+        const errorMessage = validateDialogValues(latestValues, options.scopeOptions, allowInsertSql);
         if (errorMessage) {
           void message.error(errorMessage);
           throw new Error(errorMessage);

--- a/frontend/src/components/DataGrid.ddl.test.tsx
+++ b/frontend/src/components/DataGrid.ddl.test.tsx
@@ -1732,7 +1732,7 @@ describe('DataGrid DDL interactions', () => {
     });
   });
 
-  it('exports query-result rows from in-memory data without rerunning ExportQuery', async () => {
+  it('exports query-result rows as INSERT SQL with an empty target table without rerunning ExportQuery', async () => {
     backendApp.ExportDataWithOptions.mockResolvedValue({ success: true });
     backendApp.ExportQueryWithOptions.mockResolvedValue({ success: true });
 
@@ -1761,7 +1761,7 @@ describe('DataGrid DDL interactions', () => {
     await waitForEffects();
 
     await act(async () => {
-      await renderer!.root.findByProps({ 'data-select-option': 'html' }).props.onClick();
+      await renderer!.root.findByProps({ 'data-select-option': 'sql' }).props.onClick();
     });
     await act(async () => {
       await renderer!.root.findByProps({ 'data-select-option': 'page' }).props.onClick();
@@ -1777,12 +1777,183 @@ describe('DataGrid DDL interactions', () => {
       ['owner'],
       'export',
       expect.objectContaining({
-        format: 'html',
+        format: 'sql',
+        insertSQLDialect: 'mysql',
+        insertSQLTargetTable: '',
+        insertSQLAllowEmptyTargetTable: true,
         totalRowsHint: 2,
         totalRowsKnown: true,
       }),
     );
     expect(backendApp.ExportQueryWithOptions).not.toHaveBeenCalled();
+  });
+
+  it('exports known-table query results as INSERT SQL', async () => {
+    backendApp.ExportDataWithOptions.mockResolvedValue({ success: true });
+    backendApp.DBGetColumns.mockResolvedValue({
+      success: true,
+      data: [
+        { name: 'id', type: 'int' },
+        { name: 'name', type: 'varchar' },
+      ],
+    });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <DataGrid
+          data={[
+            { __gonavi_row_key__: 'row-1', id: 1, name: "O'Brien" },
+            { __gonavi_row_key__: 'row-2', id: 2, name: null },
+          ]}
+          columnNames={['id', 'name']}
+          loading={false}
+          tableName="users"
+          exportScope="queryResult"
+          resultSql="SELECT id, name FROM users"
+          dbName="main"
+          connectionId="conn-1"
+        />,
+      );
+    });
+    await waitForEffects();
+
+    act(() => {
+      findButton(renderer!, t('data_grid.toolbar.export')).props.onClick();
+    });
+    await waitForEffects();
+
+    await act(async () => {
+      await renderer!.root.findByProps({ 'data-select-option': 'sql' }).props.onClick();
+    });
+    await act(async () => {
+      await renderer!.root.findByProps({ 'data-select-option': 'page' }).props.onClick();
+    });
+    await act(async () => {
+      await findButton(renderer!, '开始导出').props.onClick();
+    });
+    await waitForEffects();
+
+    expect(backendApp.ExportDataWithOptions).toHaveBeenCalledWith(
+      [
+        { id: 1, name: "O'Brien" },
+        { id: 2, name: null },
+      ],
+      ['id', 'name'],
+      'users',
+      expect.objectContaining({
+        format: 'sql',
+        insertSQLDialect: 'mysql',
+        insertSQLTargetTable: 'users',
+        totalRowsHint: 2,
+        totalRowsKnown: true,
+      }),
+    );
+  });
+
+  it('requeries all known-table rows when exporting INSERT SQL', async () => {
+    backendApp.ExportQueryWithOptions.mockResolvedValue({ success: true });
+    backendApp.DBGetColumns.mockResolvedValue({
+      success: true,
+      data: [{ name: 'id', type: 'int' }],
+    });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <DataGrid
+          data={[{ __gonavi_row_key__: 'row-1', id: 1 }]}
+          columnNames={['id']}
+          loading={false}
+          tableName="users"
+          exportScope="queryResult"
+          resultSql="SELECT id FROM users"
+          dbName="main"
+          connectionId="conn-1"
+        />,
+      );
+    });
+    await waitForEffects();
+
+    act(() => {
+      findButton(renderer!, t('data_grid.toolbar.export')).props.onClick();
+    });
+    await waitForEffects();
+
+    await act(async () => {
+      await renderer!.root.findByProps({ 'data-select-option': 'sql' }).props.onClick();
+    });
+    await act(async () => {
+      await findButton(renderer!, '开始导出').props.onClick();
+    });
+    await waitForEffects();
+
+    expect(backendApp.ExportQueryWithOptions).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'mysql', database: 'main' }),
+      'main',
+      'SELECT id FROM users',
+      'users',
+      expect.objectContaining({
+        format: 'sql',
+        insertSQLDialect: 'mysql',
+        insertSQLTargetTable: 'users',
+        totalRowsHint: 0,
+        totalRowsKnown: false,
+      }),
+    );
+    expect(backendApp.ExportDataWithOptions).not.toHaveBeenCalled();
+  });
+
+  it('exports unmatched query-result columns with an empty INSERT target table', async () => {
+    backendApp.ExportDataWithOptions.mockResolvedValue({ success: true });
+    backendApp.DBGetColumns.mockResolvedValue({
+      success: true,
+      data: [{ name: 'id', type: 'int' }],
+    });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <DataGrid
+          data={[{ __gonavi_row_key__: 'row-1', user_id: 1 }]}
+          columnNames={['user_id']}
+          loading={false}
+          tableName="users"
+          exportScope="queryResult"
+          resultSql="SELECT id AS user_id FROM users"
+          dbName="main"
+          connectionId="conn-1"
+        />,
+      );
+    });
+    await waitForEffects();
+
+    act(() => {
+      findButton(renderer!, t('data_grid.toolbar.export')).props.onClick();
+    });
+    await waitForEffects();
+
+    await act(async () => {
+      await renderer!.root.findByProps({ 'data-select-option': 'sql' }).props.onClick();
+    });
+    await act(async () => {
+      await renderer!.root.findByProps({ 'data-select-option': 'page' }).props.onClick();
+    });
+    await act(async () => {
+      await findButton(renderer!, '开始导出').props.onClick();
+    });
+    await waitForEffects();
+
+    expect(backendApp.ExportDataWithOptions).toHaveBeenCalledWith(
+      [{ user_id: 1 }],
+      ['user_id'],
+      'users',
+      expect.objectContaining({
+        format: 'sql',
+        insertSQLTargetTable: '',
+        insertSQLAllowEmptyTargetTable: true,
+      }),
+    );
   });
 
   it('copies loaded column data from the v2 column header context menu', async () => {

--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -973,31 +973,6 @@ const DataGrid: React.FC<DataGridProps> = ({
     });
   }, [resolveContextMenuPosition]);
 
-  // Helper to export specific data
-  const exportData = async (rows: any[], options: DataExportFileOptions) => {
-      const cleanRows = pickDataGridOutputRows(rows, displayOutputColumnNames);
-      const exportTitle = String(tableName || '').trim()
-          ? translateDataGrid('file.backend.dialog.export_table', { table: tableName })
-          : translateDataGrid('file.backend.dialog.export_data');
-      await runExportWithProgress({
-          title: exportTitle,
-          targetName: tableName || 'export',
-          format: options.format,
-          totalRows: cleanRows.length,
-          run: (jobId) => ExportDataWithOptions(
-              cleanRows,
-              displayOutputColumnNames,
-              tableName || 'export',
-              {
-                  ...options,
-                  jobId,
-                  totalRowsHint: cleanRows.length,
-                  totalRowsKnown: true,
-              } as any,
-          ),
-      });
-  };
-  
   const [sortInfo, setSortInfo] = useState<Array<{ columnKey: string, order: string, enabled?: boolean }>>([]);
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({});
   const mergedDisplayDataRef = useRef<Item[]>([]);
@@ -1045,6 +1020,82 @@ const DataGrid: React.FC<DataGridProps> = ({
       });
       return next;
   }, [displayColumnNames, columnMetaMap, columnTypeMapByLowerName]);
+
+  const insertSQLColumnTypes = useMemo(() => {
+      const next: Record<string, string> = {};
+      displayOutputColumnNames.forEach((columnName) => {
+          const normalizedName = String(columnName || '').trim();
+          if (!normalizedName) return;
+          const columnType = columnMetaMap[normalizedName]?.type
+              || columnMetaMapByLowerName[normalizedName.toLowerCase()]?.type
+              || columnTypeMapByLowerName[normalizedName.toLowerCase()]
+              || '';
+          next[normalizedName.toLowerCase()] = columnType;
+      });
+      return next;
+  }, [columnMetaMap, columnMetaMapByLowerName, columnTypeMapByLowerName, displayOutputColumnNames]);
+
+  const insertSQLTargetColumns = useMemo(() => {
+      const actualNameByLower = new Map<string, string>();
+      Object.keys(columnMetaMap).forEach((columnName) => {
+          const normalizedName = String(columnName || '').trim();
+          if (normalizedName) actualNameByLower.set(normalizedName.toLowerCase(), normalizedName);
+      });
+      const next: Record<string, string> = {};
+      displayOutputColumnNames.forEach((columnName) => {
+          const normalizedName = String(columnName || '').trim();
+          const actualName = actualNameByLower.get(normalizedName.toLowerCase());
+          if (normalizedName && actualName) {
+              next[normalizedName.toLowerCase()] = actualName;
+          }
+      });
+      return next;
+  }, [columnMetaMap, displayOutputColumnNames]);
+
+  const hasResolvedInsertSQLTarget = !!tableName
+      && Object.keys(insertSQLTargetColumns).length === displayOutputColumnNames.length;
+  const canExportInsertSQL = isQueryResultExport
+      && supportsCopyInsert
+      && displayOutputColumnNames.length > 0;
+
+  const buildBackendExportOptions = useCallback((options: DataExportFileOptions): DataExportFileOptions => {
+      if (options.format !== 'sql') {
+          return options;
+      }
+      return {
+          ...options,
+          insertSQLDialect: dbType,
+          insertSQLTargetTable: hasResolvedInsertSQLTarget ? String(tableName || '').trim() : '',
+          insertSQLColumnTypes,
+          insertSQLTargetColumns: hasResolvedInsertSQLTarget ? insertSQLTargetColumns : {},
+          insertSQLAllowEmptyTargetTable: !hasResolvedInsertSQLTarget,
+      };
+  }, [dbType, hasResolvedInsertSQLTarget, insertSQLColumnTypes, insertSQLTargetColumns, tableName]);
+
+  // Helper to export specific data
+  const exportData = async (rows: any[], options: DataExportFileOptions) => {
+      const cleanRows = pickDataGridOutputRows(rows, displayOutputColumnNames);
+      const exportTitle = String(tableName || '').trim()
+          ? translateDataGrid('file.backend.dialog.export_table', { table: tableName })
+          : translateDataGrid('file.backend.dialog.export_data');
+      await runExportWithProgress({
+          title: exportTitle,
+          targetName: tableName || 'export',
+          format: options.format,
+          totalRows: cleanRows.length,
+          run: (jobId) => ExportDataWithOptions(
+              cleanRows,
+              displayOutputColumnNames,
+              tableName || 'export',
+              {
+                  ...buildBackendExportOptions(options),
+                  jobId,
+                  totalRowsHint: cleanRows.length,
+                  totalRowsKnown: true,
+              } as any,
+          ),
+      });
+  };
 
   const normalizeCommitCellValue = useCallback(
       (columnName: string, value: any, mode: 'insert' | 'update') => {
@@ -3265,6 +3316,7 @@ const DataGrid: React.FC<DataGridProps> = ({
     buildCopyUpdateSQL,
     buildDataGridSelectBaseSql,
     buildEffectiveFilterConditions,
+    buildBackendExportOptions,
     buildOrderBySQL,
     buildPaginatedSelectSQL,
     buildRpcConnectionConfig,
@@ -3273,6 +3325,7 @@ const DataGrid: React.FC<DataGridProps> = ({
     buildWhereSQL,
     cellContextMenu,
     cellEditMode,
+    canExportInsertSQL,
     closeCellEditMode,
     columnMetaMap,
     columnMetaMapByLowerName,

--- a/frontend/src/components/useDataGridV2Actions.ts
+++ b/frontend/src/components/useDataGridV2Actions.ts
@@ -31,6 +31,7 @@ export const useDataGridV2Actions = (ctx: DataGridV2ActionsContext) => {
     buildCopyUpdateSQL,
     buildDataGridSelectBaseSql,
     buildEffectiveFilterConditions,
+    buildBackendExportOptions,
     buildOrderBySQL,
     buildPaginatedSelectSQL,
     buildRpcConnectionConfig,
@@ -39,6 +40,7 @@ export const useDataGridV2Actions = (ctx: DataGridV2ActionsContext) => {
     buildWhereSQL,
     cellContextMenu,
     cellEditMode,
+    canExportInsertSQL,
     closeCellEditMode,
     columnMetaMap,
     columnMetaMapByLowerName,
@@ -539,14 +541,14 @@ const handleV2ColumnHeaderContextMenuAction = useCallback((action: V2ColumnHeade
               sql,
               normalizedDefaultName || 'export',
               {
-                  ...options,
+                  ...buildBackendExportOptions(options),
                   jobId,
                   totalRowsHint: totalRowsKnown ? Number(totalRows) : 0,
                   totalRowsKnown,
               } as any,
           ),
       });
-  }, [buildConnConfig, dbName, resolveExportTitle, runExportWithProgress]);
+  }, [buildBackendExportOptions, buildConnConfig, dbName, resolveExportTitle, runExportWithProgress]);
 
   const buildPkWhereSql = useCallback((rows: any[], dbType: string) => {
       if (!tableName || pkColumns.length === 0) return '';
@@ -861,6 +863,7 @@ const handleV2ColumnHeaderContextMenuAction = useCallback((action: V2ColumnHeade
           const values = await showDataExportDialog(modal, {
               title: translateDataGrid('file.backend.dialog.export_query_result'),
               scopeOptions,
+              allowInsertSql: canExportInsertSQL,
               initialValues: {
                   ...commonInitialValues,
                   scope: (resultExportAllSql || resultSql) ? 'all' : (selectedCount > 0 ? 'selected' : 'page'),
@@ -926,9 +929,11 @@ const handleV2ColumnHeaderContextMenuAction = useCallback((action: V2ColumnHeade
   }, [
       addTab,
       buildAllRowsSql,
+      buildBackendExportOptions,
       buildConnConfig,
       buildCurrentPageSql,
       buildFilteredAllSql,
+      canExportInsertSQL,
       connectionId,
       dbName,
       displayData.length,

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -496,6 +496,11 @@ export namespace app {
 	    jobId?: string;
 	    totalRowsHint?: number;
 	    totalRowsKnown?: boolean;
+	    insertSQLDialect?: string;
+	    insertSQLTargetTable?: string;
+	    insertSQLColumnTypes?: Record<string, string>;
+	    insertSQLTargetColumns?: Record<string, string>;
+	    insertSQLAllowEmptyTargetTable?: boolean;
 	
 	    static createFrom(source: any = {}) {
 	        return new ExportFileOptions(source);
@@ -508,6 +513,11 @@ export namespace app {
 	        this.jobId = source["jobId"];
 	        this.totalRowsHint = source["totalRowsHint"];
 	        this.totalRowsKnown = source["totalRowsKnown"];
+	        this.insertSQLDialect = source["insertSQLDialect"];
+	        this.insertSQLTargetTable = source["insertSQLTargetTable"];
+	        this.insertSQLColumnTypes = source["insertSQLColumnTypes"];
+	        this.insertSQLTargetColumns = source["insertSQLTargetColumns"];
+	        this.insertSQLAllowEmptyTargetTable = source["insertSQLAllowEmptyTargetTable"];
 	    }
 	}
 	export class RedisExportKeysOptions {

--- a/internal/app/export_options.go
+++ b/internal/app/export_options.go
@@ -8,11 +8,16 @@ const (
 )
 
 type ExportFileOptions struct {
-	Format              string `json:"format"`
-	XLSXMaxRowsPerSheet int    `json:"xlsxMaxRowsPerSheet,omitempty"`
-	JobID               string `json:"jobId,omitempty"`
-	TotalRowsHint       int64  `json:"totalRowsHint,omitempty"`
-	TotalRowsKnown      bool   `json:"totalRowsKnown,omitempty"`
+	Format                         string            `json:"format"`
+	XLSXMaxRowsPerSheet            int               `json:"xlsxMaxRowsPerSheet,omitempty"`
+	JobID                          string            `json:"jobId,omitempty"`
+	TotalRowsHint                  int64             `json:"totalRowsHint,omitempty"`
+	TotalRowsKnown                 bool              `json:"totalRowsKnown,omitempty"`
+	InsertSQLDialect               string            `json:"insertSQLDialect,omitempty"`
+	InsertSQLTargetTable           string            `json:"insertSQLTargetTable,omitempty"`
+	InsertSQLColumnTypes           map[string]string `json:"insertSQLColumnTypes,omitempty"`
+	InsertSQLTargetColumns         map[string]string `json:"insertSQLTargetColumns,omitempty"`
+	InsertSQLAllowEmptyTargetTable bool              `json:"insertSQLAllowEmptyTargetTable,omitempty"`
 }
 
 func normalizeExportFileOptions(format string, options ExportFileOptions) ExportFileOptions {
@@ -21,11 +26,16 @@ func normalizeExportFileOptions(format string, options ExportFileOptions) Export
 		resolvedFormat = explicitFormat
 	}
 	return ExportFileOptions{
-		Format:              resolvedFormat,
-		XLSXMaxRowsPerSheet: normalizeXLSXRowsPerSheet(options.XLSXMaxRowsPerSheet),
-		JobID:               strings.TrimSpace(options.JobID),
-		TotalRowsHint:       normalizeExportTotalRowsHint(options.TotalRowsHint, options.TotalRowsKnown),
-		TotalRowsKnown:      options.TotalRowsKnown,
+		Format:                         resolvedFormat,
+		XLSXMaxRowsPerSheet:            normalizeXLSXRowsPerSheet(options.XLSXMaxRowsPerSheet),
+		JobID:                          strings.TrimSpace(options.JobID),
+		TotalRowsHint:                  normalizeExportTotalRowsHint(options.TotalRowsHint, options.TotalRowsKnown),
+		TotalRowsKnown:                 options.TotalRowsKnown,
+		InsertSQLDialect:               strings.ToLower(strings.TrimSpace(options.InsertSQLDialect)),
+		InsertSQLTargetTable:           strings.TrimSpace(options.InsertSQLTargetTable),
+		InsertSQLColumnTypes:           options.InsertSQLColumnTypes,
+		InsertSQLTargetColumns:         options.InsertSQLTargetColumns,
+		InsertSQLAllowEmptyTargetTable: options.InsertSQLAllowEmptyTargetTable,
 	}
 }
 

--- a/internal/app/methods_file.go
+++ b/internal/app/methods_file.go
@@ -3800,6 +3800,9 @@ func formatSQLValue(dbType string, v interface{}) string {
 
 	switch val := v.(type) {
 	case bool:
+		if isPgLikeBooleanDBType(dbType) {
+			return booleanSQLLiteral(val)
+		}
 		if val {
 			return "1"
 		}
@@ -4041,6 +4044,22 @@ func (a *App) ExportQueryWithOptions(config connection.ConnectionConfig, dbName 
 	if err != nil {
 		reporter.Error(0, err.Error())
 		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	if format == "sql" {
+		options.InsertSQLDialect = resolveDDLDBType(runConfig)
+		options.InsertSQLTargetTable = resolveChangeTargetTableName(runConfig, dbName, options.InsertSQLTargetTable)
+		if options.InsertSQLTargetTable != "" {
+			schemaName, pureTableName := normalizeSchemaAndTable(runConfig, dbName, options.InsertSQLTargetTable)
+			if defs, colErr := dbInst.GetColumns(schemaName, pureTableName); colErr == nil {
+				options.InsertSQLColumnTypes = buildImportColumnTypeMap(defs)
+				options.InsertSQLTargetColumns = make(map[string]string, len(defs))
+				for _, def := range defs {
+					if key := normalizeColumnName(def.Name); key != "" {
+						options.InsertSQLTargetColumns[key] = strings.TrimSpace(def.Name)
+					}
+				}
+			}
+		}
 	}
 
 	query = sanitizeSQLForPgLike(resolveDDLDBType(config), query)
@@ -4517,6 +4536,7 @@ type sqlInsertExportConsumer struct {
 	quotedCols    []string
 	columnList    string
 	columnTypes   []string
+	targetColumns map[string]string
 	valueBuf      []string
 	rowCount      int64
 	mode          sqlInsertExportMode
@@ -4549,7 +4569,15 @@ func (c *sqlInsertExportConsumer) SetColumns(columns []string) error {
 	c.columnTypes = make([]string, len(columns))
 	c.valueBuf = make([]string, len(columns))
 	for _, column := range columns {
-		c.quotedCols = append(c.quotedCols, quoteIdentByType(c.dbType, column))
+		targetColumn := column
+		if len(c.targetColumns) > 0 {
+			mappedColumn, ok := c.targetColumns[normalizeColumnName(column)]
+			if !ok || strings.TrimSpace(mappedColumn) == "" {
+				return fmt.Errorf("query result column %q does not match the INSERT target table", column)
+			}
+			targetColumn = mappedColumn
+		}
+		c.quotedCols = append(c.quotedCols, quoteIdentByType(c.dbType, targetColumn))
 	}
 	for i, column := range columns {
 		c.columnTypes[i] = c.columnTypeMap[normalizeColumnName(column)]
@@ -4663,6 +4691,62 @@ func (c *sqlInsertExportConsumer) Flush() error {
 	return nil
 }
 
+type sqlInsertExportFileWriter struct {
+	writer   *bufio.Writer
+	consumer *sqlInsertExportConsumer
+	closed   bool
+}
+
+func newSQLInsertExportFileWriter(f *os.File, options ExportFileOptions) (*sqlInsertExportFileWriter, error) {
+	dialect := strings.TrimSpace(options.InsertSQLDialect)
+	targetTable := strings.TrimSpace(options.InsertSQLTargetTable)
+	if dialect == "" {
+		return nil, fmt.Errorf("INSERT SQL export requires a database dialect")
+	}
+	if targetTable == "" && !options.InsertSQLAllowEmptyTargetTable {
+		return nil, fmt.Errorf("INSERT SQL export requires a target table")
+	}
+	quotedTable := quoteQualifiedIdentByType(dialect, "<table_name>")
+	if targetTable != "" {
+		quotedTable = quoteQualifiedIdentByType(dialect, targetTable)
+	}
+
+	writer := bufio.NewWriterSize(f, 1024*1024)
+	return &sqlInsertExportFileWriter{
+		writer: writer,
+		consumer: &sqlInsertExportConsumer{
+			w:             writer,
+			dbType:        dialect,
+			quotedTable:   quotedTable,
+			columnTypeMap: options.InsertSQLColumnTypes,
+			targetColumns: options.InsertSQLTargetColumns,
+		},
+	}, nil
+}
+
+func (w *sqlInsertExportFileWriter) SetColumns(columns []string) error {
+	return w.consumer.SetColumns(columns)
+}
+
+func (w *sqlInsertExportFileWriter) ConsumeRow(row map[string]interface{}) error {
+	return w.consumer.ConsumeRow(row)
+}
+
+func (w *sqlInsertExportFileWriter) ConsumeRowValues(values []interface{}) error {
+	return w.consumer.ConsumeRowValues(values)
+}
+
+func (w *sqlInsertExportFileWriter) Close() error {
+	if w == nil || w.closed {
+		return nil
+	}
+	w.closed = true
+	if err := w.consumer.Flush(); err != nil {
+		return err
+	}
+	return w.writer.Flush()
+}
+
 func resolveExportColumns(columns []string, data []map[string]interface{}) []string {
 	if len(columns) > 0 || len(data) == 0 {
 		return columns
@@ -4694,6 +4778,8 @@ func newExportFileWriter(f *os.File, options ExportFileOptions) (exportFileWrite
 		return newHTMLExportFileWriter(f), nil
 	case "xlsx":
 		return newXLSXExportFileWriter(f, options.XLSXMaxRowsPerSheet)
+	case "sql":
+		return newSQLInsertExportFileWriter(f, options)
 	default:
 		return nil, fmt.Errorf("unsupported format: %s", options.Format)
 	}

--- a/internal/app/methods_file_export_test.go
+++ b/internal/app/methods_file_export_test.go
@@ -581,6 +581,211 @@ func TestExportQueryResultToFile_UsesStreamQueryPath(t *testing.T) {
 	}
 }
 
+func TestExportQueryResultToFile_WritesInsertSQLForKnownTargetTable(t *testing.T) {
+	f, err := os.CreateTemp("", "gonavi-export-insert-*.sql")
+	if err != nil {
+		t.Fatalf("创建临时文件失败: %v", err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	fake := &fakeValueStreamExportDB{
+		streamCols: []string{"id", "name"},
+		streamValues: [][]interface{}{
+			{1, "O'Brien"},
+			{2, nil},
+		},
+	}
+
+	rowCount, columns, err := exportQueryResultToFile(
+		f,
+		fake,
+		connection.ConnectionConfig{Type: "mysql", Timeout: 10},
+		"SELECT id, name FROM users",
+		ExportFileOptions{
+			Format:               "sql",
+			InsertSQLDialect:     "mysql",
+			InsertSQLTargetTable: "users",
+		},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("exportQueryResultToFile 返回错误: %v", err)
+	}
+	if rowCount != 2 {
+		t.Fatalf("导出行数异常，want=2 got=%d", rowCount)
+	}
+	if len(columns) != 2 || columns[0] != "id" || columns[1] != "name" {
+		t.Fatalf("导出列异常，got=%v", columns)
+	}
+
+	contentBytes, err := os.ReadFile(f.Name())
+	if err != nil {
+		t.Fatalf("读取导出文件失败: %v", err)
+	}
+	content := string(contentBytes)
+	want := "INSERT INTO `users` (`id`, `name`) VALUES (1, 'O''Brien'),\n(2, NULL);\n"
+	if content != want {
+		t.Fatalf("INSERT SQL 导出内容异常，want=%q got=%q", want, content)
+	}
+}
+
+func TestExportQueryResultToFile_WritesInsertSQLWithEmptyTargetTable(t *testing.T) {
+	f, err := os.CreateTemp("", "gonavi-export-insert-empty-target-*.sql")
+	if err != nil {
+		t.Fatalf("创建临时文件失败: %v", err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	fake := &fakeValueStreamExportDB{
+		streamCols: []string{"user_id", "role_name"},
+		streamValues: [][]interface{}{
+			{1, "admin"},
+		},
+	}
+
+	_, _, err = exportQueryResultToFile(
+		f,
+		fake,
+		connection.ConnectionConfig{Type: "mysql", Timeout: 10},
+		"SELECT u.id AS user_id, r.name AS role_name FROM users u JOIN roles r ON r.id = u.role_id",
+		ExportFileOptions{
+			Format:                         "sql",
+			InsertSQLDialect:               "mysql",
+			InsertSQLAllowEmptyTargetTable: true,
+		},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("exportQueryResultToFile 返回错误: %v", err)
+	}
+
+	contentBytes, err := os.ReadFile(f.Name())
+	if err != nil {
+		t.Fatalf("读取导出文件失败: %v", err)
+	}
+	want := "INSERT INTO `<table_name>` (`user_id`, `role_name`) VALUES (1, 'admin');\n"
+	if string(contentBytes) != want {
+		t.Fatalf("空目标表 INSERT SQL 导出内容异常，want=%q got=%q", want, string(contentBytes))
+	}
+}
+
+func TestExportQueryResultToFile_WritesPostgresBooleanWithPlaceholderTable(t *testing.T) {
+	f, err := os.CreateTemp("", "gonavi-export-insert-postgres-placeholder-*.sql")
+	if err != nil {
+		t.Fatalf("创建临时文件失败: %v", err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	fake := &fakeValueStreamExportDB{
+		streamCols:   []string{"active"},
+		streamValues: [][]interface{}{{true}},
+	}
+
+	_, _, err = exportQueryResultToFile(
+		f,
+		fake,
+		connection.ConnectionConfig{Type: "postgres", Timeout: 10},
+		"SELECT u.active FROM users u JOIN roles r ON r.id = u.role_id",
+		ExportFileOptions{
+			Format:                         "sql",
+			InsertSQLDialect:               "postgres",
+			InsertSQLAllowEmptyTargetTable: true,
+		},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("exportQueryResultToFile 返回错误: %v", err)
+	}
+
+	contentBytes, err := os.ReadFile(f.Name())
+	if err != nil {
+		t.Fatalf("读取导出文件失败: %v", err)
+	}
+	want := "INSERT INTO \"<table_name>\" (\"active\") VALUES (true);\n"
+	if string(contentBytes) != want {
+		t.Fatalf("PostgreSQL 占位表布尔值导出异常，want=%q got=%q", want, string(contentBytes))
+	}
+}
+
+func TestExportQueryResultToFile_UsesColumnTypesForInsertSQLLiterals(t *testing.T) {
+	f, err := os.CreateTemp("", "gonavi-export-insert-types-*.sql")
+	if err != nil {
+		t.Fatalf("创建临时文件失败: %v", err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	fake := &fakeValueStreamExportDB{
+		streamCols: []string{"active", "archived"},
+		streamValues: [][]interface{}{
+			{true, false},
+		},
+	}
+
+	_, _, err = exportQueryResultToFile(
+		f,
+		fake,
+		connection.ConnectionConfig{Type: "postgres", Timeout: 10},
+		"SELECT active, archived FROM public.users",
+		ExportFileOptions{
+			Format:               "sql",
+			InsertSQLDialect:     "postgres",
+			InsertSQLTargetTable: "public.users",
+			InsertSQLColumnTypes: map[string]string{
+				"active":   "boolean",
+				"archived": "bool",
+			},
+		},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("exportQueryResultToFile 返回错误: %v", err)
+	}
+
+	contentBytes, err := os.ReadFile(f.Name())
+	if err != nil {
+		t.Fatalf("读取导出文件失败: %v", err)
+	}
+	want := "INSERT INTO \"public\".\"users\" (\"active\", \"archived\") VALUES (true, false);\n"
+	if string(contentBytes) != want {
+		t.Fatalf("布尔字段 INSERT SQL 导出内容异常，want=%q got=%q", want, string(contentBytes))
+	}
+}
+
+func TestExportQueryResultToFile_RejectsColumnsOutsideInsertTargetTable(t *testing.T) {
+	f, err := os.CreateTemp("", "gonavi-export-insert-mismatch-*.sql")
+	if err != nil {
+		t.Fatalf("创建临时文件失败: %v", err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	fake := &fakeValueStreamExportDB{
+		streamCols:   []string{"user_id"},
+		streamValues: [][]interface{}{{1}},
+	}
+
+	_, _, err = exportQueryResultToFile(
+		f,
+		fake,
+		connection.ConnectionConfig{Type: "mysql", Timeout: 10},
+		"SELECT id AS user_id FROM users",
+		ExportFileOptions{
+			Format:                 "sql",
+			InsertSQLDialect:       "mysql",
+			InsertSQLTargetTable:   "users",
+			InsertSQLTargetColumns: map[string]string{"id": "id"},
+		},
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), `query result column "user_id" does not match`) {
+		t.Fatalf("列别名不匹配时应拒绝 INSERT SQL 导出，err=%v", err)
+	}
+}
+
 func TestExportQueryResultToFile_UsesValueStreamPathWhenAvailable(t *testing.T) {
 	f, err := os.CreateTemp("", "gonavi-export-stream-values-*.csv")
 	if err != nil {


### PR DESCRIPTION
## 背景

查询结果导出当前支持 XLSX、CSV、JSON、Markdown 和 HTML，但缺少可直接用于数据迁移或备份的 INSERT SQL 格式。

Closes #652

## 变更点

- 查询结果导出弹窗新增 `INSERT SQL` 格式
- 支持导出选中行、当前页和重新查询后的全部结果
- 单表查询自动使用真实表名、字段名和字段类型
- 连表、聚合或字段别名无法映射唯一目标表时，使用按数据库方言引用的 `<table_name>` 占位符
- 复用现有流式导出和批量 INSERT 生成逻辑，避免大结果集全部进入前端内存
- 补充 PostgreSQL 布尔值、NULL、字符串转义和字段映射校验

## 影响范围

- 查询结果数据网格的导出弹窗
- 通用文件导出选项和后端流式 writer
- 不改变现有表级 SQL Dump、CSV、XLSX 等导出行为

## 验证

- `npm run test -- src/components/DataGrid.ddl.test.tsx`：52 项通过
- `npx tsc --noEmit`：通过
- `go test ./internal/app -run 'Export|DumpTableSQL|FormatImportSQLValue' -count=1`：通过

## 风险与回滚

- 无法识别目标表时生成的是带 `<table_name>` 占位符的 SQL 模板，执行前需要替换目标表名
- 回滚该提交即可恢复原有导出格式列表和 writer 行为