### PR TITLE
🐛 fix(installer): 修复 MSI 更新后快捷方式图标失效

### DIFF
--- a/build/windows/installer.wxs
+++ b/build/windows/installer.wxs
@@ -31,17 +31,17 @@
             Source="$(var.SourceExe)"
             Name="GoNavi.exe"
             KeyPath="yes">
+        <!-- Keep shortcut icons bound to the stable executable path. Referencing the MSI Icon table
+             can leave Windows shell caches pointing at the removed product cache after a major upgrade. -->
         <Shortcut Id="StartMenuShortcut"
                   Directory="ProgramMenuFolder"
                   Name="$(var.ProductName)"
                   WorkingDirectory="INSTALLFOLDER"
-                  Icon="GoNaviIcon"
                   Advertise="no" />
         <Shortcut Id="DesktopShortcut"
                   Directory="DesktopFolder"
                   Name="$(var.ProductName)"
                   WorkingDirectory="INSTALLFOLDER"
-                  Icon="GoNaviIcon"
                   Advertise="no" />
       </File>
       <File Id="GoNaviMsiInstallMarker"

--- a/tools/windows-release-artifacts.test.py
+++ b/tools/windows-release-artifacts.test.py
@@ -72,8 +72,17 @@ class WindowsReleaseArtifactsTest(unittest.TestCase):
         self.assertIsNotNone(package.find("wix:MediaTemplate", ns))
         self.assertIsNotNone(package.find("wix:Property[@Id='ARPPRODUCTICON']", ns))
         self.assertIsNotNone(package.find("wix:SetProperty[@Id='ARPINSTALLLOCATION']", ns))
-        self.assertIsNotNone(package.find(".//wix:Shortcut[@Id='StartMenuShortcut']", ns))
-        self.assertIsNotNone(package.find(".//wix:Shortcut[@Id='DesktopShortcut']", ns))
+        executable = package.find(".//wix:File[@Id='GoNaviExe']", ns)
+        self.assertIsNotNone(executable)
+        assert executable is not None
+        start_menu_shortcut = executable.find("wix:Shortcut[@Id='StartMenuShortcut']", ns)
+        self.assertIsNotNone(start_menu_shortcut)
+        assert start_menu_shortcut is not None
+        self.assertNotIn("Icon", start_menu_shortcut.attrib)
+        desktop_shortcut = executable.find("wix:Shortcut[@Id='DesktopShortcut']", ns)
+        self.assertIsNotNone(desktop_shortcut)
+        assert desktop_shortcut is not None
+        self.assertNotIn("Icon", desktop_shortcut.attrib)
         marker = package.find(".//wix:RegistryValue[@Name='InstallType']", ns)
         self.assertIsNotNone(marker)
         assert marker is not None


### PR DESCRIPTION
## 背景与问题

通过 MSI 执行 Major Upgrade 后，开始菜单快捷方式可能变成白板图标。快捷方式显式引用 MSI `Icon` 表时，Windows Shell 图标缓存可能继续指向升级时已移除的旧产品缓存。

## 变更点

- 移除开始菜单和桌面快捷方式对 MSI `Icon` 表的显式引用
- 让非 advertised shortcut 直接继承目标 `GoNavi.exe` 的内嵌图标
- 保留 `ARPPRODUCTICON`，不影响“应用和功能”中的产品图标
- 增加安装产物回归测试，确保快捷方式嵌套在 `GoNaviExe` 下且不再声明 `Icon`

## 影响范围

仅调整 Windows MSI 安装后的快捷方式图标来源，不修改安装路径、启动目标、升级、卸载或 Portable EXE 行为。

## 验证方式

- `python tools/windows-release-artifacts.test.py`
- `git diff --check`
- 验证本地 Windows EXE 可正常提取内嵌图标

本地未安装 WiX CLI，完整的旧 MSI → 新 MSI 覆盖升级冒烟测试交由 CI 产物进一步确认。