### PR TITLE
⚡️ perf(ob-oracle): 使用 FETCH FIRST 优化查询性能 + 精简 Monaco Worker

### DIFF
--- a/frontend/src/components/MonacoEditor.tsx
+++ b/frontend/src/components/MonacoEditor.tsx
@@ -25,9 +25,6 @@ type MonacoWorkerFactory = () => Worker;
 interface MonacoWorkerFactories {
   editor: MonacoWorkerFactory;
   json: MonacoWorkerFactory;
-  css: MonacoWorkerFactory;
-  html: MonacoWorkerFactory;
-  typescript: MonacoWorkerFactory;
 }
 
 export const installMonacoWorkerEnvironment = (
@@ -568,17 +565,11 @@ const ensureMonacoConfigured = (): Promise<void> => {
         import('monaco-editor'),
         import('monaco-editor/esm/vs/editor/editor.worker?worker'),
         import('monaco-editor/esm/vs/language/json/json.worker?worker'),
-        import('monaco-editor/esm/vs/language/css/css.worker?worker'),
-        import('monaco-editor/esm/vs/language/html/html.worker?worker'),
-        import('monaco-editor/esm/vs/language/typescript/ts.worker?worker'),
       ]))
-      .then(([monaco, editorWorker, jsonWorker, cssWorker, htmlWorker, typescriptWorker]) => {
+      .then(([monaco, editorWorker, jsonWorker]) => {
         installMonacoWorkerEnvironment(globalThis as unknown as Record<string, any>, {
           editor: () => new editorWorker.default(),
           json: () => new jsonWorker.default(),
-          css: () => new cssWorker.default(),
-          html: () => new htmlWorker.default(),
-          typescript: () => new typescriptWorker.default(),
         });
         loader.config({ monaco });
       });

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -7021,7 +7021,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
             let anyLimitApplied = false;
             const executablePlans = statementPlans.map((plan) => {
                 if (!Number.isFinite(maxRowsForLimit) || maxRowsForLimit <= 0) return plan;
-                const result = applyQueryAutoLimit(plan.executedSql, normalizedDbType, maxRowsForLimit, driver);
+                const result = applyQueryAutoLimit(plan.executedSql, normalizedDbType, maxRowsForLimit, driver, oceanBaseOracleConnection);
                 if (result.applied) anyLimitApplied = true;
                 return { ...plan, executedSql: result.sql };
             });

--- a/frontend/src/utils/queryAutoLimit.ts
+++ b/frontend/src/utils/queryAutoLimit.ts
@@ -357,6 +357,7 @@ export const applyQueryAutoLimit = (
   dbType: string,
   maxRows: number,
   driver = '',
+  oceanBaseOracle = false,
 ): { sql: string; applied: boolean; maxRows: number } => {
   if (!Number.isFinite(maxRows) || maxRows <= 0) return { sql, applied: false, maxRows };
   const normalizedType = String(resolveSqlDialect(dbType || 'mysql', driver)).toLowerCase();
@@ -395,6 +396,10 @@ export const applyQueryAutoLimit = (
     // Oracle-compatible databases reject NEXTVAL/CURRVAL when the ROWNUM cap
     // moves the original SELECT into a subquery.
     if (hasOracleSequencePseudoColumn(main)) return { sql, applied: false, maxRows };
+    // OceanBase Oracle 模式支持 FETCH FIRST，优化器可做谓词下推避免全表扫描
+    if (oceanBaseOracle) {
+      return { sql: `${main.trimEnd()} FETCH FIRST ${maxRows} ROWS ONLY${tail}`, applied: true, maxRows };
+    }
     return { sql: `${buildPaginatedSelectSQL(normalizedType, main, '', maxRows, 0)}${tail}`, applied: true, maxRows };
   }
 

--- a/frontend/src/utils/queryResultPagination.ts
+++ b/frontend/src/utils/queryResultPagination.ts
@@ -171,12 +171,14 @@ export const buildQueryResultPageSql = (params: {
     oceanBaseProtocol: params.oceanBaseProtocol || '',
   });
   const orderBySql = buildOrderBySQL(dialect, params.sortInfo || []);
+  const isOceanBaseOracle = params.oceanBaseProtocol === 'oracle' && dialect === 'oracle';
   return buildPaginatedSelectSQL(
     dialect,
     resolveWrappedBaseSql(dialect, params.baseSql),
     orderBySql,
     limit,
     offset,
+    isOceanBaseOracle,
   );
 };
 

--- a/frontend/src/utils/sql.ts
+++ b/frontend/src/utils/sql.ts
@@ -299,6 +299,7 @@ export const buildPaginatedSelectSQL = (
   orderBySQL: string,
   limit: number,
   offset: number,
+  oceanBaseOracle = false,
 ) => {
   const normalizedType = String(dbType || '').trim().toLowerCase();
   const safeLimit = Math.max(0, Math.floor(Number(limit) || 0));
@@ -315,6 +316,9 @@ export const buildPaginatedSelectSQL = (
     case 'dameng': {
       const orderedSql = `${base}${orderBy}`;
       const upperBound = safeOffset + safeLimit;
+      if (oceanBaseOracle && safeOffset <= 0) {
+        return `${orderedSql} FETCH FIRST ${upperBound} ROWS ONLY`;
+      }
       if (safeOffset <= 0) {
         return `SELECT * FROM (${orderedSql}) WHERE ROWNUM <= ${upperBound}`;
       }


### PR DESCRIPTION
- applyQueryAutoLimit: OB Oracle 模式使用 FETCH FIRST N ROWS ONLY 替代 ROWNUM 子查询包装，优化器可做谓词下推避免全表扫描
- buildPaginatedSelectSQL: 首页分页同样使用 FETCH FIRST
- queryResultPagination: 传递 oceanBaseOracle 标志到分页函数
- MonacoEditor: 移除未使用的 css/html/typescript Worker，减少启动开销 和内存占用（SQL 编辑器只需 editor + json worker）