### PR TITLE
✨ feat(tab): 支持鼠标中键关闭标签页

### DIFF
--- a/frontend/src/components/TabManager.hover.test.tsx
+++ b/frontend/src/components/TabManager.hover.test.tsx
@@ -9,6 +9,7 @@ import {
   resolveTabHoverTitle,
   shouldShowV2ConnectionLabel,
   TabHoverInfo,
+  isMiddleMouseButton,
   stopTabHoverDragPropagation,
 } from './TabManager';
 import { setCurrentLanguage } from '../i18n';
@@ -53,6 +54,12 @@ afterEach(() => {
 });
 
 describe('TabManager hover info', () => {
+  it('recognizes only the auxiliary middle mouse button for tab closing', () => {
+    expect(isMiddleMouseButton(1)).toBe(true);
+    expect(isMiddleMouseButton(0)).toBe(false);
+    expect(isMiddleMouseButton(2)).toBe(false);
+  });
+
   it('memoizes the tab workbench so parent-only modal state does not repaint open tabs', () => {
     const source = readFileSync(new URL('./TabManager.tsx', import.meta.url), 'utf8');
 
@@ -320,6 +327,10 @@ describe('TabManager hover info', () => {
   it('wires hover card tab-switch and drag-blocking handlers with selectable text styles', () => {
     const source = readFileSync(new URL('./TabManager.tsx', import.meta.url), 'utf8');
 
+    expect(source).toContain('onMouseDown={handleTabLabelMouseDown}');
+    expect(source).toContain('onAuxClick={handleTabLabelAuxClick}');
+    expect(source).toContain('event.stopPropagation();');
+    expect(source).toContain('onClose();');
     expect(source).toContain('onPointerDown={stopTabHoverDragPropagation}');
     expect(source).toContain('onPointerUp={stopTabHoverDragPropagation}');
     expect(source).toContain('onPointerDownCapture={stopTabHoverDragPropagation}');
@@ -374,8 +385,8 @@ describe('TabManager hover info', () => {
     expect(source).toContain('clearSQLFileTabDraft(tab.id)');
     expect(source).toContain('closeTabsWithSQLFilePrompt([id], () => closeTab(id))');
     expect(source).toContain('closeTabsWithSQLFilePrompt(getCloseOtherTabIds(tabs, tab.id), () => closeOtherTabs(tab.id))');
-    expect(source).toContain('closeTabsWithSQLFilePrompt(getCloseTabsToLeftIds(tabs, tab.id), () => closeTabsToLeft(tab.id))');
-    expect(source).toContain('closeTabsWithSQLFilePrompt(getCloseTabsToRightIds(tabs, tab.id), () => closeTabsToRight(tab.id))');
+    expect(source).toContain('closeTabsWithSQLFilePrompt(getCloseTabsToLeftIds(dockedTabs, tab.id), () => closeTabsToLeft(tab.id))');
+    expect(source).toContain('closeTabsWithSQLFilePrompt(getCloseTabsToRightIds(dockedTabs, tab.id), () => closeTabsToRight(tab.id))');
     expect(source).toContain('closeTabsWithSQLFilePrompt(tabs.map((item) => item.id), () => closeAllTabs())');
   });
 

--- a/frontend/src/components/TabManager.tsx
+++ b/frontend/src/components/TabManager.tsx
@@ -358,6 +358,8 @@ type SortableTabLabelProps = {
   onClose?: () => void;
 };
 
+export const isMiddleMouseButton = (button: number): boolean => button === 1;
+
 const renderV2TabDisplayPart = (part: TabDisplayPart) => {
   if (part.key === 'kind') {
     return (
@@ -399,6 +401,19 @@ const SortableTabLabel: React.FC<SortableTabLabelProps> = ({
     setIsTabMenuOpen(true);
   };
 
+  const handleTabLabelMouseDown = (event: React.MouseEvent<HTMLElement>) => {
+    if (!onClose || !isMiddleMouseButton(event.button)) return;
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  const handleTabLabelAuxClick = (event: React.MouseEvent<HTMLElement>) => {
+    if (!onClose || !isMiddleMouseButton(event.button)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    onClose();
+  };
+
   const handleTabMenuOpenChange = (open: boolean) => {
     setIsTabMenuOpen(open);
     setIsHoverInfoOpen(false);
@@ -414,6 +429,8 @@ const SortableTabLabel: React.FC<SortableTabLabelProps> = ({
     <span
       className={`tab-dnd-label${isV2Ui ? ' gn-v2-tab-label' : ''}${showSecondaryLine ? ' gn-v2-tab-label-double' : ''}${tabDisplayPartCount >= 4 ? ' gn-v2-tab-label-rich' : ''}`}
       onContextMenu={handleTabLabelContextMenu}
+      onMouseDown={handleTabLabelMouseDown}
+      onAuxClick={handleTabLabelAuxClick}
       title={isV2Ui ? undefined : displayTitle}
     >
       {isV2Ui ? (


### PR DESCRIPTION
## 背景与问题

当前主工作区标签仅支持关闭按钮和右键菜单关闭，无法使用常见的鼠标中键快速关闭标签页。

Closes #661

## 变更点

- 在标签标题上识别鼠标中键操作
- 在 `mousedown` 阶段阻止中键默认滚动行为
- 在 `auxclick` 阶段复用现有标签关闭回调
- 中键关闭外部 SQL 文件时继续执行未保存修改确认
- 修正左右关闭测试使用的标签范围为当前停靠标签 `dockedTabs`
- 增加中键按键判定和事件绑定回归测试

## 影响范围

- 同时支持 legacy 和 v2 主标签栏
- 不影响左键切换、右键菜单和标签拖拽
- 普通查询标签直接关闭；外部 SQL 文件标签仍遵循现有保存确认流程

## 验证方式

- `npm test -- --run src/components/TabManager.hover.test.tsx`：20/20 通过
- `npx tsc --noEmit`：通过
- `git diff --check`：通过