### PR TITLE
✨ feat(single-instance): 支持跨平台单实例启动与窗口唤醒

### DIFF
--- a/internal/singleinstance/lock_unix.go
+++ b/internal/singleinstance/lock_unix.go
@@ -1,0 +1,62 @@
+//go:build unix
+
+package singleinstance
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+type unixLock struct {
+	file *os.File
+	name string
+}
+
+func lockFilePath(name string) string {
+	return filepath.Join(runtimeDir(), normalizeName(name)+".single.lock")
+}
+
+func acquireLock(name string) (platformLock, error) {
+	path := lockFilePath(name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("create single-instance lock dir: %w", err)
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open single-instance lock file: %w", err)
+	}
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		_ = file.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return nil, &lockHeldError{name: name}
+		}
+		return nil, fmt.Errorf("flock single-instance lock: %w", err)
+	}
+	// 写入 PID 便于人工排查；不依赖它做正确性判断。
+	_, _ = file.Seek(0, 0)
+	_ = file.Truncate(0)
+	_, _ = file.WriteString(fmt.Sprintf("%d\n", os.Getpid()))
+	return &unixLock{file: file, name: name}, nil
+}
+
+func (l *unixLock) Release() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+	// 故意不删除锁文件，避免 unlink+flock 竞态导致双主实例。
+	// 进程退出时 OS 会自动释放 flock。
+	removeEndpoint(l.name)
+	_ = unix.Flock(int(l.file.Fd()), unix.LOCK_UN)
+	err := l.file.Close()
+	l.file = nil
+	if err != nil && !strings.Contains(err.Error(), "file already closed") {
+		return err
+	}
+	return nil
+}

--- a/internal/singleinstance/lock_unix_test.go
+++ b/internal/singleinstance/lock_unix_test.go
@@ -1,0 +1,44 @@
+//go:build unix
+
+package singleinstance
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRuntimeDirIsStableAcrossLauncherEnvironment(t *testing.T) {
+	want := runtimeDir()
+	t.Setenv("XDG_RUNTIME_DIR", filepath.Join(t.TempDir(), "xdg-runtime"))
+	t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "tmp"))
+	if got := runtimeDir(); got != want {
+		t.Fatalf("runtime dir changed with launcher environment: %q != %q", got, want)
+	}
+}
+
+func TestFileLockReleaseKeepsStableLockFile(t *testing.T) {
+	name := uniqueName(t)
+	path := lockFilePath(name)
+	_ = os.Remove(path)
+	t.Cleanup(func() { _ = os.Remove(path) })
+
+	first := Acquire(name, nil)
+	if !first.Acquired {
+		t.Fatalf("first acquire failed: %v", first.AcquireErr)
+	}
+	if err := first.Handle.Close(); err != nil {
+		t.Fatalf("close first handle: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stable lock file disappeared after release: %v", err)
+	}
+
+	second := Acquire(name, nil)
+	if !second.Acquired {
+		t.Fatalf("re-acquire failed: %v", second.AcquireErr)
+	}
+	if err := second.Handle.Close(); err != nil {
+		t.Fatalf("close second handle: %v", err)
+	}
+}

--- a/internal/singleinstance/lock_windows.go
+++ b/internal/singleinstance/lock_windows.go
@@ -1,0 +1,57 @@
+//go:build windows
+
+package singleinstance
+
+import (
+	"errors"
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+type windowsLock struct {
+	handle windows.Handle
+	name   string
+}
+
+func acquireLock(name string) (platformLock, error) {
+	mutexName := "Local\\GoNaviSingleInstance-" + normalizeName(name)
+	namePtr, err := windows.UTF16PtrFromString(mutexName)
+	if err != nil {
+		return nil, fmt.Errorf("encode mutex name: %w", err)
+	}
+
+	handle, createErr := windows.CreateMutex(nil, false, namePtr)
+	if createErr != nil {
+		// 已存在：当前进程不是主实例。
+		if errors.Is(createErr, windows.ERROR_ALREADY_EXISTS) {
+			if handle != 0 {
+				_ = windows.CloseHandle(handle)
+			}
+			return nil, &lockHeldError{name: name}
+		}
+		// 权限不足也视为已被占用（例如更高权限实例已持有）。
+		if errors.Is(createErr, windows.ERROR_ACCESS_DENIED) {
+			return nil, &lockHeldError{name: name}
+		}
+		return nil, fmt.Errorf("CreateMutex: %w", createErr)
+	}
+
+	return &windowsLock{handle: handle, name: name}, nil
+}
+
+func (l *windowsLock) Release() error {
+	if l == nil || l.handle == 0 {
+		return nil
+	}
+	removeEndpoint(l.name)
+	err := windows.CloseHandle(l.handle)
+	l.handle = 0
+	if err != nil {
+		return fmt.Errorf("CloseHandle mutex: %w", err)
+	}
+	return nil
+}
+
+// mutexReleaserName 保留兼容占位，供测试/调试引用。
+func mutexReleaserName() string { return "" }

--- a/internal/singleinstance/lock_windows_test.go
+++ b/internal/singleinstance/lock_windows_test.go
@@ -1,0 +1,74 @@
+//go:build windows
+
+package singleinstance
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+const windowsDelayedListenerHelperEnvironment = "GONAVI_SINGLEINSTANCE_DELAYED_HELPER"
+
+func TestWindowsSecondProcessWaitsForDelayedPrimaryListener(t *testing.T) {
+	if os.Getenv(windowsDelayedListenerHelperEnvironment) == "1" {
+		name := os.Getenv("GONAVI_SINGLEINSTANCE_TEST_NAME")
+		result := Acquire(name, []string{"child.sql"})
+		if result.Acquired {
+			t.Fatal("helper unexpectedly became the primary instance")
+		}
+		if result.AcquireErr != nil {
+			t.Fatalf("helper lock error: %v", result.AcquireErr)
+		}
+		if result.NotifyErr != nil {
+			t.Fatalf("helper notification error: %v", result.NotifyErr)
+		}
+		return
+	}
+
+	name := uniqueName(t) + "-process"
+	_ = os.Remove(endpointFilePath(name))
+	primary := Acquire(name, nil)
+	if !primary.Acquired {
+		t.Fatalf("primary acquire failed: %v", primary.AcquireErr)
+	}
+	defer primary.Handle.Close()
+
+	command := exec.Command(os.Args[0], "-test.run=^TestWindowsSecondProcessWaitsForDelayedPrimaryListener$")
+	command.Env = append(os.Environ(),
+		windowsDelayedListenerHelperEnvironment+"=1",
+		"GONAVI_SINGLEINSTANCE_TEST_NAME="+name,
+	)
+	var output bytes.Buffer
+	command.Stdout = &output
+	command.Stderr = &output
+	if err := command.Start(); err != nil {
+		t.Fatalf("start helper process: %v", err)
+	}
+
+	// 故意扩大 Acquire -> Listen 的冷启动窗口，证明第二进程会等待 IPC
+	// 就绪，而不是通知失败后成为新主实例或直接丢失激活请求。
+	time.Sleep(150 * time.Millisecond)
+	received := make(chan ActivationMessage, 1)
+	if err := primary.Handle.Listen(name, func(message ActivationMessage) error {
+		received <- message
+		return nil
+	}); err != nil {
+		_ = command.Process.Kill()
+		t.Fatalf("listen failed: %v", err)
+	}
+	if err := command.Wait(); err != nil {
+		t.Fatalf("helper process failed: %v\n%s", err, output.String())
+	}
+
+	select {
+	case message := <-received:
+		if len(message.Args) != 1 || message.Args[0] != "child.sql" {
+			t.Fatalf("unexpected helper activation message: %#v", message)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("primary did not receive the helper activation message")
+	}
+}

--- a/internal/singleinstance/singleinstance.go
+++ b/internal/singleinstance/singleinstance.go
@@ -1,0 +1,482 @@
+// Package singleinstance 提供跨平台主进程单实例约束与次实例激活转发。
+//
+// 设计目标：
+//  1. 同一用户会话中只允许一个 GoNavi 主 GUI 进程
+//  2. 第二个主进程启动时，把启动参数转发给已运行主实例后退出
+//  3. detached-window / mcp-server 等特殊模式不使用本包
+//
+// 平台实现：
+//   - Windows: 命名互斥体
+//   - macOS/Linux: flock 锁文件（路径固定，不依赖 XDG_RUNTIME_DIR/TMPDIR）
+//
+// IPC 统一使用 TCP 回环 + endpoint 文件，避免命名管道/Unix Socket 差异。
+package singleinstance
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultName           = "gonavi"
+	notifyRetryWindow     = 3 * time.Second
+	notifyAttemptTimeout  = 250 * time.Millisecond
+	notifyRetryInterval   = 50 * time.Millisecond
+	activationReadTimeout = 3 * time.Second
+)
+
+// ActivationMessage 是次实例发给主实例的激活载荷。
+type ActivationMessage struct {
+	Args []string `json:"args"`
+}
+
+// AcquireResult 描述单实例获取结果。
+type AcquireResult struct {
+	// Acquired 为 true 表示当前进程成为主实例。
+	Acquired bool
+	// Handle 仅在 Acquired=true 时有效。
+	Handle *Handle
+	// AcquireErr 表示锁本身获取失败（非“已被占用”）。
+	AcquireErr error
+	// NotifyErr 表示次实例通知主实例失败。
+	NotifyErr error
+}
+
+// Handle 表示主实例持有的锁与 IPC 服务端。
+type Handle struct {
+	lock     platformLock
+	listener net.Listener
+	mu       sync.Mutex
+	closed   bool
+	wg       sync.WaitGroup
+}
+
+// ActivationHandler 处理次实例激活请求。
+type ActivationHandler func(message ActivationMessage) error
+
+// Logger 由宿主注入，避免循环依赖。
+type Logger interface {
+	Infof(format string, args ...any)
+	Warnf(format string, args ...any)
+}
+
+type stderrLogger struct{}
+
+func (stderrLogger) Infof(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "[singleinstance] "+format+"\n", args...)
+}
+
+func (stderrLogger) Warnf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "[singleinstance] WARN "+format+"\n", args...)
+}
+
+var (
+	packageLogger Logger = stderrLogger{}
+	// platformAcquireLock 可在测试中替换。
+	platformAcquireLock = acquireLock
+)
+
+// SetLogger 注入宿主日志实现。
+func SetLogger(logger Logger) {
+	if logger == nil {
+		packageLogger = stderrLogger{}
+		return
+	}
+	packageLogger = logger
+}
+
+// Acquire 尝试成为主实例。
+//
+//   - 成功：Acquired=true，调用方应 Listen 并在退出时 Close
+//   - 锁已被占用：尝试通知主实例后 Acquired=false
+//   - 锁初始化失败：Acquired=false 且 AcquireErr 非空（调用方应终止 GUI 启动）
+func Acquire(name string, args []string) AcquireResult {
+	name = normalizeName(name)
+	lock, err := platformAcquireLock(name)
+	if err != nil {
+		if isLockHeldError(err) {
+			notifyErr := notifyPrimaryWithRetry(name, ActivationMessage{Args: append([]string(nil), args...)})
+			return AcquireResult{Acquired: false, NotifyErr: notifyErr}
+		}
+		return AcquireResult{
+			Acquired:   false,
+			AcquireErr: fmt.Errorf("acquire single-instance lock %q: %w", name, err),
+		}
+	}
+	return AcquireResult{
+		Acquired: true,
+		Handle:   &Handle{lock: lock},
+	}
+}
+
+// Listen 启动主实例 IPC 服务端。应在拿到主实例锁后尽快调用。
+func (h *Handle) Listen(name string, handler ActivationHandler) error {
+	if h == nil {
+		return errors.New("nil single-instance handle")
+	}
+	if handler == nil {
+		return errors.New("nil activation handler")
+	}
+	name = normalizeName(name)
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return errors.New("single-instance handle already closed")
+	}
+	if h.listener != nil {
+		return nil
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("listen single-instance ipc: %w", err)
+	}
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		_ = listener.Close()
+		return fmt.Errorf("unexpected single-instance listener address type %T", listener.Addr())
+	}
+	if err := writeEndpoint(name, addr.Port); err != nil {
+		_ = listener.Close()
+		return err
+	}
+	h.listener = listener
+	h.wg.Add(1)
+	go h.serve(handler)
+	return nil
+}
+
+// Close 释放锁并关闭 IPC。
+func (h *Handle) Close() error {
+	if h == nil {
+		return nil
+	}
+	h.mu.Lock()
+	if h.closed {
+		h.mu.Unlock()
+		return nil
+	}
+	h.closed = true
+	listener := h.listener
+	h.listener = nil
+	lock := h.lock
+	h.lock = nil
+	h.mu.Unlock()
+
+	if listener != nil {
+		_ = listener.Close()
+	}
+	h.wg.Wait()
+
+	var firstErr error
+	if lock != nil {
+		if err := lock.Release(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (h *Handle) serve(handler ActivationHandler) {
+	defer h.wg.Done()
+	for {
+		h.mu.Lock()
+		listener := h.listener
+		closed := h.closed
+		h.mu.Unlock()
+		if closed || listener == nil {
+			return
+		}
+		conn, err := listener.Accept()
+		if err != nil {
+			if closed || errors.Is(err, net.ErrClosed) {
+				return
+			}
+			packageLogger.Warnf("single-instance accept failed: %v", err)
+			continue
+		}
+		h.wg.Add(1)
+		go func(c net.Conn) {
+			defer h.wg.Done()
+			h.handleConn(c, handler)
+		}(conn)
+	}
+}
+
+func (h *Handle) handleConn(conn net.Conn, handler ActivationHandler) {
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(activationReadTimeout))
+	reader := bufio.NewReader(conn)
+	line, err := reader.ReadBytes('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		packageLogger.Warnf("single-instance read failed: %v", err)
+		return
+	}
+	line = bytesTrimSpace(line)
+	if len(line) == 0 {
+		return
+	}
+	var message ActivationMessage
+	if err := json.Unmarshal(line, &message); err != nil {
+		packageLogger.Warnf("single-instance decode failed: %v", err)
+		return
+	}
+	if err := handler(message); err != nil {
+		packageLogger.Warnf("single-instance handler failed: %v", err)
+	}
+}
+
+func notifyPrimaryWithRetry(name string, message ActivationMessage) error {
+	deadline := time.Now().Add(notifyRetryWindow)
+	var lastErr error
+	for {
+		lastErr = notifyPrimary(name, message)
+		if lastErr == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return lastErr
+		}
+		time.Sleep(notifyRetryInterval)
+	}
+}
+
+func notifyPrimary(name string, message ActivationMessage) error {
+	port, err := readEndpoint(name)
+	if err != nil {
+		return err
+	}
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)), notifyAttemptTimeout)
+	if err != nil {
+		return fmt.Errorf("dial primary instance: %w", err)
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(notifyAttemptTimeout))
+	payload, err := json.Marshal(message)
+	if err != nil {
+		return err
+	}
+	if _, err := conn.Write(append(payload, '\n')); err != nil {
+		return fmt.Errorf("write activation message: %w", err)
+	}
+	return nil
+}
+
+func normalizeName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return defaultName
+	}
+	// 仅保留文件名安全字符，避免路径穿越。
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	if b.Len() == 0 {
+		return defaultName
+	}
+	return b.String()
+}
+
+func endpointFileName(name string) string {
+	return normalizeName(name) + ".endpoint"
+}
+
+func endpointFilePath(name string) string {
+	return filepath.Join(runtimeDir(), endpointFileName(name))
+}
+
+func endpointCandidatePaths(name string) []string {
+	fileName := endpointFileName(name)
+	seen := make(map[string]struct{})
+	var paths []string
+	add := func(dir string) {
+		if dir == "" {
+			return
+		}
+		path := filepath.Join(dir, fileName)
+		if _, ok := seen[path]; ok {
+			return
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+	// 当前进程选中的可写目录优先。
+	add(runtimeDir())
+	if override := strings.TrimSpace(os.Getenv("GONAVI_RUNTIME_DIR")); override != "" {
+		add(override)
+	}
+	for _, dir := range candidateRuntimeDirs() {
+		add(dir)
+	}
+	return paths
+}
+
+func writeEndpoint(name string, port int) error {
+	path := endpointFilePath(name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create single-instance runtime dir: %w", err)
+	}
+	content := []byte(strconv.Itoa(port) + "\n")
+	if err := writeFileAtomic(path, content, 0o600); err != nil {
+		return fmt.Errorf("write single-instance endpoint: %w", err)
+	}
+	return nil
+}
+
+func writeFileAtomic(path string, content []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".endpoint-*.tmp")
+	if err != nil {
+		// CreateTemp 失败时退回直接写入（例如目录权限异常时给出原始错误）。
+		return os.WriteFile(path, content, perm)
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		// Windows 上 Chmod 可能无效，忽略。
+		_ = err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		// Windows 上目标已存在时 rename 可能失败，尝试覆盖。
+		_ = os.Remove(path)
+		if err2 := os.Rename(tmpName, path); err2 != nil {
+			return err2
+		}
+	}
+	cleanup = false
+	return nil
+}
+
+func readEndpoint(name string) (int, error) {
+	var lastErr error
+	for _, path := range endpointCandidatePaths(name) {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		port, err := strconv.Atoi(strings.TrimSpace(string(data)))
+		if err != nil || port <= 0 || port > 65535 {
+			lastErr = fmt.Errorf("invalid single-instance endpoint content %q", strings.TrimSpace(string(data)))
+			continue
+		}
+		return port, nil
+	}
+	if lastErr == nil {
+		lastErr = os.ErrNotExist
+	}
+	return 0, fmt.Errorf("read single-instance endpoint: %w", lastErr)
+}
+
+func removeEndpoint(name string) {
+	for _, path := range endpointCandidatePaths(name) {
+		_ = os.Remove(path)
+	}
+}
+
+func bytesTrimSpace(b []byte) []byte {
+	return []byte(strings.TrimSpace(string(b)))
+}
+
+// platformLock 是各平台锁抽象。
+type platformLock interface {
+	Release() error
+}
+
+// lockHeldError 表示锁已被其他进程持有。
+type lockHeldError struct {
+	name string
+}
+
+func (e *lockHeldError) Error() string {
+	return fmt.Sprintf("single-instance lock already held: %s", e.name)
+}
+
+func isLockHeldError(err error) bool {
+	var held *lockHeldError
+	return errors.As(err, &held)
+}
+
+var (
+	runtimeDirOnce   sync.Once
+	runtimeDirCached string
+)
+
+// runtimeDir 返回跨启动器稳定的运行时目录。
+// 优先固定用户目录，避免 macOS Finder 与终端因 TMPDIR 不同而分裂；
+// 若当前环境不可写（沙箱/权限），自动回退到可写位置。
+// 进程内缓存，保证 Listen/notify/Close 使用同一目录。
+func runtimeDir() string {
+	runtimeDirOnce.Do(func() {
+		if override := strings.TrimSpace(os.Getenv("GONAVI_RUNTIME_DIR")); override != "" {
+			_ = os.MkdirAll(override, 0o700)
+			runtimeDirCached = override
+			return
+		}
+		runtimeDirCached = ensureWritableRuntimeDir()
+	})
+	return runtimeDirCached
+}
+
+func candidateRuntimeDirs() []string {
+	var dirs []string
+	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		dirs = append(dirs, filepath.Join(home, ".gonavi", "runtime"))
+	}
+	if local := strings.TrimSpace(os.Getenv("LOCALAPPDATA")); local != "" {
+		dirs = append(dirs, filepath.Join(local, "GoNavi", "runtime"))
+	}
+	if xdg := strings.TrimSpace(os.Getenv("XDG_CACHE_HOME")); xdg != "" {
+		dirs = append(dirs, filepath.Join(xdg, "gonavi", "runtime"))
+	}
+	dirs = append(dirs, filepath.Join(os.TempDir(), "gonavi-runtime"))
+	return dirs
+}
+
+func ensureWritableRuntimeDir() string {
+	for _, dir := range candidateRuntimeDirs() {
+		if dir == "" {
+			continue
+		}
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			continue
+		}
+		probe := filepath.Join(dir, ".write-probe-"+strconv.FormatInt(time.Now().UnixNano(), 36))
+		if err := os.WriteFile(probe, []byte("1"), 0o600); err != nil {
+			continue
+		}
+		_ = os.Remove(probe)
+		return dir
+	}
+	// 最后兜底：即使探测失败也返回 TempDir 路径，让调用方拿到明确错误。
+	return filepath.Join(os.TempDir(), "gonavi-runtime")
+}

--- a/internal/singleinstance/singleinstance_test.go
+++ b/internal/singleinstance/singleinstance_test.go
@@ -1,0 +1,170 @@
+package singleinstance
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func uniqueName(t *testing.T) string {
+	t.Helper()
+	return "test-" + filepath.Base(t.Name()) + "-" + time.Now().Format("150405.000")
+}
+
+func TestAcquireReleaseAndSecondInstance(t *testing.T) {
+	name := uniqueName(t)
+	_ = os.Remove(endpointFilePath(name))
+
+	first := Acquire(name, nil)
+	if !first.Acquired {
+		t.Fatalf("first acquire failed: %v", first.AcquireErr)
+	}
+	defer first.Handle.Close()
+
+	received := make(chan ActivationMessage, 1)
+	if err := first.Handle.Listen(name, func(message ActivationMessage) error {
+		received <- message
+		return nil
+	}); err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	second := Acquire(name, []string{"demo.sql"})
+	if second.Acquired {
+		t.Fatal("second instance should not acquire lock")
+	}
+	if second.AcquireErr != nil {
+		t.Fatalf("second acquire unexpected error: %v", second.AcquireErr)
+	}
+	if second.NotifyErr != nil {
+		t.Fatalf("notify failed: %v", second.NotifyErr)
+	}
+
+	select {
+	case msg := <-received:
+		if len(msg.Args) != 1 || msg.Args[0] != "demo.sql" {
+			t.Fatalf("unexpected message: %#v", msg)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not receive activation")
+	}
+}
+
+func TestSecondInstanceWaitsForDelayedListener(t *testing.T) {
+	name := uniqueName(t)
+	_ = os.Remove(endpointFilePath(name))
+
+	primary := Acquire(name, nil)
+	if !primary.Acquired {
+		t.Fatalf("primary acquire failed: %v", primary.AcquireErr)
+	}
+	defer primary.Handle.Close()
+
+	received := make(chan ActivationMessage, 1)
+	done := make(chan error, 1)
+	go func() {
+		// 模拟冷启动：先拿到锁，稍后再 Listen。
+		time.Sleep(150 * time.Millisecond)
+		done <- primary.Handle.Listen(name, func(message ActivationMessage) error {
+			received <- message
+			return nil
+		})
+	}()
+
+	second := Acquire(name, []string{"cold.sql"})
+	if second.Acquired {
+		t.Fatal("second should not acquire")
+	}
+	if second.NotifyErr != nil {
+		t.Fatalf("notify should succeed after retry: %v", second.NotifyErr)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+	select {
+	case msg := <-received:
+		if len(msg.Args) != 1 || msg.Args[0] != "cold.sql" {
+			t.Fatalf("unexpected message: %#v", msg)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("activation not received")
+	}
+}
+
+func TestEndpointLifecycle(t *testing.T) {
+	name := uniqueName(t)
+	path := endpointFilePath(name)
+	_ = os.Remove(path)
+
+	h := Acquire(name, nil)
+	if !h.Acquired {
+		t.Fatalf("acquire failed: %v", h.AcquireErr)
+	}
+	if err := h.Handle.Listen(name, func(ActivationMessage) error { return nil }); err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("endpoint missing: %v", err)
+	}
+	if err := h.Handle.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	// Close 后 endpoint 应被清理（Windows/Unix Release 都会 removeEndpoint）。
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("endpoint still exists after close: %v", err)
+	}
+}
+
+func TestAcquireLockFailureDoesNotFailOpen(t *testing.T) {
+	originalAcquireLock := platformAcquireLock
+	t.Cleanup(func() { platformAcquireLock = originalAcquireLock })
+	wantErr := errors.New("lock infrastructure unavailable")
+	platformAcquireLock = func(string) (platformLock, error) {
+		return nil, wantErr
+	}
+
+	result := Acquire(uniqueName(t), nil)
+	if result.Acquired || result.Handle != nil {
+		t.Fatalf("lock failure unexpectedly allowed GUI startup: %#v", result)
+	}
+	if !errors.Is(result.AcquireErr, wantErr) {
+		t.Fatalf("AcquireErr = %v, want %v", result.AcquireErr, wantErr)
+	}
+}
+
+func TestCloseIsIdempotent(t *testing.T) {
+	name := uniqueName(t)
+	h := Acquire(name, nil)
+	if !h.Acquired {
+		t.Fatalf("acquire failed: %v", h.AcquireErr)
+	}
+	if err := h.Handle.Close(); err != nil {
+		t.Fatalf("first close: %v", err)
+	}
+	if err := h.Handle.Close(); err != nil {
+		t.Fatalf("second close: %v", err)
+	}
+}
+
+func TestEmptyNameFallsBack(t *testing.T) {
+	if got := normalizeName(""); got != defaultName {
+		t.Fatalf("normalize empty = %q", got)
+	}
+	if got := normalizeName("  "); got != defaultName {
+		t.Fatalf("normalize spaces = %q", got)
+	}
+}
+
+func TestRuntimeDirWritable(t *testing.T) {
+	dir := runtimeDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir runtime dir: %v", err)
+	}
+	path := filepath.Join(dir, "probe-"+uniqueName(t))
+	if err := os.WriteFile(path, []byte("ok"), 0o600); err != nil {
+		t.Fatalf("write runtime dir: %v", err)
+	}
+	_ = os.Remove(path)
+}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"GoNavi-Wails/internal/logger"
 	"GoNavi-Wails/internal/mcpserver"
 	"GoNavi-Wails/internal/nativewindow"
+	"GoNavi-Wails/internal/singleinstance"
 	"GoNavi-Wails/internal/webserver"
 
 	"github.com/wailsapp/wails/v2"
@@ -27,6 +28,16 @@ import (
 
 const nativeSelectCurrentLineEvent = "gonavi:native-select-current-line"
 
+// singleInstanceName 是 GoNavi 单实例锁的稳定标识符。便携版和安装版共用
+// 同一名称，确保同一用户会话中同时只能有一个主 GoNavi 进程。
+const singleInstanceName = "gonavi"
+
+// loggerLogger 把 internal/logger 接到 singleinstance 包。
+type loggerLogger struct{}
+
+func (loggerLogger) Infof(format string, args ...any) { logger.Infof(format, args...) }
+func (loggerLogger) Warnf(format string, args ...any) { logger.Warnf(format, args...) }
+
 func main() {
 	// 大结果集导出（88W+ 行）时，JSON 编解码会产生 5-8 倍内存副本，
 	// Go 默认 GOGC=100 下堆翻倍才触发 GC，叠加 Windows MADV_FREE 不归还 RSS，
@@ -34,8 +45,52 @@ func main() {
 	// 代价是 CPU 开销略增，但导出/导入场景属 I/O 密集型，GC 开销可忽略。
 	debug.SetGCPercent(50)
 
+	// detached-window / mcp-server / web-server 等特殊模式不参与单实例判断。
 	if runSpecialMode(os.Args[1:]) {
 		return
+	}
+
+	// 单实例约束：第二个主实例启动时，转发启动参数给已运行的主实例后退出。
+	singleinstance.SetLogger(loggerLogger{})
+	singleInstanceResult := singleinstance.Acquire(singleInstanceName, os.Args[1:])
+	if !singleInstanceResult.Acquired {
+		if singleInstanceResult.AcquireErr != nil {
+			logger.Errorf("GoNavi 单实例初始化失败，终止当前 GUI 启动：%v", singleInstanceResult.AcquireErr)
+		} else if singleInstanceResult.NotifyErr != nil {
+			logger.Warnf("GoNavi 单实例：通知主实例失败：%v", singleInstanceResult.NotifyErr)
+		} else {
+			logger.Infof("GoNavi 单实例：已通知运行中的主实例，当前进程退出")
+		}
+		return
+	}
+	singleInstanceHandle := singleInstanceResult.Handle
+	defer func() {
+		if singleInstanceHandle != nil {
+			_ = singleInstanceHandle.Close()
+		}
+	}()
+
+	activationState := &singleInstanceActivationState{}
+	// 主实例被再次拉起时，把窗口调到前台并取消最小化。激活是纯信号，
+	// 不携带任何参数——仅用于"第二次点击图标/命令时唤起已有窗口"。
+	activatePrimaryWindow := func(ctx context.Context) {
+		if ctx == nil {
+			return
+		}
+		wailsRuntime.WindowShow(ctx)
+		wailsRuntime.WindowUnminimise(ctx)
+	}
+	// 拿到主实例锁后立即建立 IPC，避免首窗口冷启动期间第二实例找不到 endpoint。
+	if singleInstanceHandle != nil {
+		if err := singleInstanceHandle.Listen(singleInstanceName, func(message singleinstance.ActivationMessage) error {
+			logger.Infof("GoNavi 单实例：收到次实例激活信号")
+			if ctx := activationState.request(); ctx != nil {
+				activatePrimaryWindow(ctx)
+			}
+			return nil
+		}); err != nil {
+			logger.Warnf("启动单实例 IPC 服务失败：%v", err)
+		}
 	}
 
 	// Create an instance of the app structure
@@ -87,6 +142,10 @@ func main() {
 		Menu:             appMenu,
 		OnStartup: func(ctx context.Context) {
 			runtimeCtx = ctx
+			// 绑定 runtime context，供次实例激活时唤起前台使用。
+			if pending := activationState.start(ctx); pending {
+				activatePrimaryWindow(ctx)
+			}
 			lifecycleCtx := ctx
 			if nativeWindowManager != nil {
 				if err := nativewindow.InitializeLifecycle(nativeWindowManager, ctx); err != nil {
@@ -102,6 +161,7 @@ func main() {
 			}
 		},
 		OnShutdown: func(ctx context.Context) {
+			activationState.stop()
 			nativewindow.ShutdownLifecycle(nativeWindowManager)
 			aiService.Shutdown()
 			application.Shutdown()

--- a/main_single_instance.go
+++ b/main_single_instance.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"sync"
+)
+
+// singleInstanceActivationState 持有 Wails runtime context，供次实例激活时
+// 将主窗口唤起到前台。仅需在 OnStartup 后可用，OnShutdown 后失效。
+type singleInstanceActivationState struct {
+	mu      sync.Mutex
+	ctx     context.Context
+	pending bool
+	stopped bool
+}
+
+// start 绑定 Wails runtime context，并返回冷启动期间是否收到过激活请求。
+func (s *singleInstanceActivationState) start(ctx context.Context) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stopped {
+		return false
+	}
+	s.ctx = ctx
+	pending := s.pending
+	s.pending = false
+	return pending
+}
+
+// request 请求激活主窗口。Wails context 尚未就绪时记录 pending，由
+// OnStartup 补执行；已停止时忽略。
+func (s *singleInstanceActivationState) request() context.Context {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stopped {
+		return nil
+	}
+	if s.ctx == nil {
+		s.pending = true
+		return nil
+	}
+	return s.ctx
+}
+
+func (s *singleInstanceActivationState) stop() {
+	s.mu.Lock()
+	s.ctx = nil
+	s.pending = false
+	s.stopped = true
+	s.mu.Unlock()
+}

--- a/main_single_instance_test.go
+++ b/main_single_instance_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSingleInstanceActivationStateContextLifecycle(t *testing.T) {
+	state := &singleInstanceActivationState{}
+	// 未 start 前先记录一次冷启动激活。
+	if ctx := state.request(); ctx != nil {
+		t.Fatalf("request before startup should return nil, got %#v", ctx)
+	}
+
+	ctx := context.Background()
+	if pending := state.start(ctx); !pending {
+		t.Fatal("startup did not consume pending activation")
+	}
+	if got := state.request(); got != ctx {
+		t.Fatalf("request after start = %#v, want %#v", got, ctx)
+	}
+
+	// stop 后 context 失效，且 start 不再生效。
+	state.stop()
+	if got := state.request(); got != nil {
+		t.Fatalf("request after shutdown should return nil, got %#v", got)
+	}
+	if pending := state.start(ctx); pending {
+		t.Fatal("stopped state accepted startup context")
+	}
+}


### PR DESCRIPTION
## 背景

GoNavi 主 GUI 被重复启动时会创建多个窗口。安装版、便携版以及 macOS 应用缺少统一的单实例约束，冷启动阶段也可能因 IPC 尚未就绪而丢失唤醒请求。

## 变更点

- 在特殊模式判断后尽早获取应用级单实例锁，`mcp-server`、`web-server` 与 `detached-window` 不受影响
- Windows 使用用户 Session 级命名互斥体，macOS/Linux 使用稳定的 `flock` 锁文件
- 安装版与便携版共用同一实例标识，重复启动只通知已有主实例
- 使用 TCP 回环 IPC 与 endpoint 文件传递激活信号，并通过重试覆盖冷启动监听竞态
- Wails context 尚未就绪时记录 pending 激活，`OnStartup` 后补执行窗口唤醒
- 重复启动仅显示并取消最小化，不改变用户原有窗口大小
- 锁初始化异常时 fail-closed，避免错误放行第二个 GUI

## 影响范围

- 同一用户会话中只允许一个 GoNavi 主 GUI 实例
- Windows 安装版与便携版互斥；macOS/Linux 同一用户下同样生效
- 不影响服务模式、原生独立窗口、数据库连接及数据功能
- 无配置、依赖和数据结构变更

## 验证

- `go test -race . ./internal/singleinstance -count=1 -timeout=3m`
- `go vet . ./internal/singleinstance`
- Windows 真实子进程冷启动/延迟监听回归测试
- macOS amd64 与 Linux amd64 目标交叉编译
- `git diff --check`

## 说明

当前已在 Windows 环境完成运行测试；macOS 逻辑已完成并通过包级交叉编译，仍建议维护者在真实 `.app` 包上补充重复启动验收。