### PR TITLE
🐛 fix(query-editor): 移除搜索框顶部空白区域

### DIFF
--- a/frontend/src/components/QueryEditor.external-sql-save.test.tsx
+++ b/frontend/src/components/QueryEditor.external-sql-save.test.tsx
@@ -4526,7 +4526,7 @@ describe('QueryEditor external SQL save', () => {
     expect(initialOptions).toMatchObject({
       fixedOverflowWidgets: true,
       find: {
-        addExtraSpaceOnTop: true,
+        addExtraSpaceOnTop: false,
       },
       hover: {
         enabled: true,
@@ -11164,14 +11164,13 @@ describe('QueryEditor external SQL save', () => {
     expect(css).toContain('body[data-ui-version="v2"] .gn-v2-query-results .query-result-tab-text {');
   });
 
-  it('keeps Monaco find widget spacing scoped to the v2 query editor shell', () => {
+  it('does not reserve vertical space for the Monaco find widget in the v2 query editor', () => {
     const source = readFileSync(new URL('./QueryEditor.tsx', import.meta.url), 'utf8');
     const css = readV2ThemeCss();
 
-    expect(source).toContain('addExtraSpaceOnTop: true');
-    expect(css).toContain('body[data-ui-version="v2"] .gn-v2-query-monaco-stage:has(.monaco-editor .find-widget.visible:not(.hiddenEditor)) {');
-    expect(css).toContain('padding-top: 24px;');
-    expect(css).toContain('overflow: visible;');
+    expect(source).not.toContain('addExtraSpaceOnTop: true');
+    expect(css).not.toContain('body[data-ui-version="v2"] .gn-v2-query-monaco-stage:has(.monaco-editor .find-widget.visible:not(.hiddenEditor)) {');
+    expect(css).not.toContain('padding-top: 24px;');
     expect(css).not.toContain('body[data-ui-version="v2"] .gn-v2-query-monaco-stage .monaco-editor .find-widget {');
   });
 

--- a/frontend/src/components/QueryEditor.i18n.test.ts
+++ b/frontend/src/components/QueryEditor.i18n.test.ts
@@ -39,7 +39,7 @@ describe('QueryEditor i18n source guards', () => {
     expect(queryEditorSource).toContain('query_editor.action.find_in_editor');
     expect(queryEditorSource).toContain('gonavi:find-active-query');
     expect(queryEditorSource).toContain("editor.getAction?.('actions.find')");
-    expect(queryEditorSource).toContain('addExtraSpaceOnTop: true');
+    expect(queryEditorSource).toContain('addExtraSpaceOnTop: false');
   });
 
   it('uses a localized wrapper for save query failures', () => {

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -210,9 +210,6 @@ export {
 const buildQueryEditorMonacoActionLabel = (key: string): string =>
     `GoNavi: ${translate(key)}`;
 
-const QUERY_EDITOR_MONACO_FIND_OPTIONS = {
-    addExtraSpaceOnTop: true,
-} as const;
 const QUERY_EDITOR_NATIVE_SELECT_CURRENT_LINE_EVENT = 'gonavi:native-select-current-line';
 const QUERY_EDITOR_MAC_FIND_WITH_SELECTION_COMBO = 'Meta+E';
 const QUERY_EDITOR_MAC_FIND_WITH_SELECTION_GUARD_ACTION_ID = 'gonavi.suppressMacFindWithSelection';
@@ -316,7 +313,10 @@ const buildQueryEditorMonacoOptions = (isObjectEditQueryTab: boolean) => ({
     minimap: { enabled: false },
     automaticLayout: true,
     fixedOverflowWidgets: true,
-    find: QUERY_EDITOR_MONACO_FIND_OPTIONS,
+    // Keep the find widget as an overlay; Monaco's default top spacer creates a blank band.
+    find: {
+        addExtraSpaceOnTop: false,
+    },
     hover: {
         enabled: true,
         delay: QUERY_EDITOR_HOVER_DELAY_MS,

--- a/frontend/src/styles/v2-theme-workbench.css
+++ b/frontend/src/styles/v2-theme-workbench.css
@@ -296,11 +296,6 @@ body[data-ui-version="v2"] .gn-v2-query-monaco-stage {
   background: var(--gn-bg-panel);
 }
 
-body[data-ui-version="v2"] .gn-v2-query-monaco-stage:has(.monaco-editor .find-widget.visible:not(.hiddenEditor)) {
-  padding-top: 24px;
-  overflow: visible;
-}
-
 body[data-ui-version="v2"] .gn-v2-query-monaco-shell {
   min-height: 0;
   overflow: visible;


### PR DESCRIPTION
## 背景

V2 SQL 查询编辑器打开 Monaco 查找组件时，同时启用了 Monaco 顶部预留空间和额外的 24px CSS 补偿，导致编辑区顶部出现明显空白区域。

## 变更点

- 关闭 Monaco 查找组件的 `addExtraSpaceOnTop`，保留原生浮层行为
- 删除 V2 查询编辑器针对可见查找组件添加的顶部 padding
- 更新 Monaco 配置和样式范围回归测试

## 影响范围

- 仅影响 V2 SQL 查询编辑器中查找组件的布局
- Windows、macOS 和 Linux 共用同一套 Monaco/WebView 前端配置
- 不涉及后端、数据库结构、依赖或配置变更

## 验证

- `npm run test -- src/components/QueryEditor.external-sql-save.test.tsx -t "renders SQL metadata hover as a fixed overflow widget below first-line tokens|does not reserve vertical space for the Monaco find widget in the v2 query editor"`（2 passed）
- `npm run test -- src/components/QueryEditor.i18n.test.ts`（9 passed）
- `npx tsc --noEmit`
- `npm run build`（8690 modules transformed）

备注：在当前本地共享依赖环境全量执行 `QueryEditor.external-sql-save.test.tsx` 时，另有 15 条结果面板、Oracle 表名等非本次行为路径断言失败；本次相关的 2 条定向用例均通过，未修改这些无关断言。