### PR TITLE
✨ feat(query-editor): 美化 SQL 支持仅格式化选中内容

### DIFF
--- a/frontend/src/components/QueryEditor.external-sql-save.test.tsx
+++ b/frontend/src/components/QueryEditor.external-sql-save.test.tsx
@@ -4408,6 +4408,51 @@ describe('QueryEditor external SQL save', () => {
     });
   });
 
+  it('formats only the selected SQL when a non-empty selection exists', async () => {
+    let renderer!: ReactTestRenderer;
+    const originalSql = 'select 1; select * from users where id=1';
+
+    await act(async () => {
+      renderer = create(<QueryEditor tab={createTab({ query: originalSql })} />);
+    });
+
+    editorState.selection = {
+      startLineNumber: 1,
+      startColumn: 11,
+      endLineNumber: 1,
+      endColumn: originalSql.length + 1,
+    };
+
+    const formatButton = findButton(renderer, '美化');
+    await act(async () => {
+      await formatButton.props.onClick();
+    });
+
+    expect(editorState.editor.executeEdits).toHaveBeenCalledWith(
+      'gonavi-format-sql',
+      expect.arrayContaining([
+        expect.objectContaining({
+          range: expect.objectContaining({
+            startLineNumber: 1,
+            startColumn: 11,
+            endLineNumber: 1,
+            endColumn: originalSql.length + 1,
+          }),
+          text: expect.stringContaining('SELECT'),
+        }),
+      ]),
+    );
+    expect(editorState.value.startsWith('select 1;')).toBe(true);
+    expect(editorState.value).toContain('SELECT');
+    expect(editorState.value).not.toBe(originalSql);
+    expect(storeState.updateQueryTabDraft).toHaveBeenCalledWith('tab-1', {
+      formatRestoreSnapshot: {
+        query: originalSql,
+        createdAt: expect.any(Number),
+      },
+    });
+  });
+
   it('registers a configurable Monaco shortcut action for SQL formatting', async () => {
     await act(async () => {
       create(<QueryEditor tab={createTab({ query: 'select * from users where id=1' })} />);

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -6116,38 +6116,49 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                   ? connectionsRef.current.find(c => c.id === tabConnectionId)
                   : undefined);
           const formatterLanguage = resolveQueryEditorFormatterLanguage(conn);
-          const sourceSql = getCurrentQuery();
+          const editor = editorRef.current;
+          const monaco = monacoRef.current;
+          const model = editor?.getModel?.();
+          const selection = editor?.getSelection?.();
+          const selectedRaw = model && selection
+              ? String(model.getValueInRange?.(selection) || '')
+              : '';
+          const formatSelection = !!selection && !!selectedRaw.trim();
+          const fullQuery = getCurrentQuery();
+          const sourceSql = formatSelection ? selectedRaw : fullQuery;
           const formatted = format(sourceSql, { language: formatterLanguage, keywordCase: sqlFormatOptions.keywordCase });
           if (sourceSql === formatted) {
               return;
           }
           updateQueryTabDraft(tab.id, {
               formatRestoreSnapshot: {
-                  query: sourceSql,
+                  query: fullQuery,
                   createdAt: Date.now(),
               },
           });
-          const editor = editorRef.current;
-          const monaco = monacoRef.current;
-          const model = editor?.getModel?.();
           if (editor && monaco && model) {
-              const currentValue = String(model.getValue?.() || sourceSql);
-              if (currentValue === formatted) {
+              const editRange = formatSelection
+                  ? selection
+                  : (model.getFullModelRange?.()
+                      || new monaco.Range(1, 1, model.getLineCount?.() || 1, model.getLineMaxColumn?.(model.getLineCount?.() || 1) || 1));
+              const currentValue = String(model.getValue?.() || fullQuery);
+              if (!formatSelection && currentValue === formatted) {
                   return;
               }
-              const fullRange = model.getFullModelRange?.()
-                  || new monaco.Range(1, 1, model.getLineCount?.() || 1, model.getLineMaxColumn?.(model.getLineCount?.() || 1) || 1);
               editor.pushUndoStop?.();
               editor.executeEdits?.('gonavi-format-sql', [{
-                  range: fullRange,
+                  range: editRange,
                   text: formatted,
                   forceMoveMarkers: true,
               }]);
               editor.pushUndoStop?.();
               const nextValue = editor.getValue?.();
-              applyQueryState(typeof nextValue === 'string' ? nextValue : formatted);
+              applyQueryState(typeof nextValue === 'string' ? nextValue : (formatSelection ? currentValue : formatted));
               refreshObjectDecorations();
               return;
+      }
+      if (formatSelection) {
+          return;
       }
       syncQueryToEditor(formatted);
   } catch (e) {


### PR DESCRIPTION
有非空选区时只美化选中 SQL，无选区时仍美化全文。