### PR TITLE
🐛 fix(data-viewer): 刷新表数据时重新统计总数

### DIFF
--- a/frontend/src/components/DataViewer.primary-key.test.tsx
+++ b/frontend/src/components/DataViewer.primary-key.test.tsx
@@ -606,6 +606,58 @@ describe('DataViewer safe editing locator', () => {
     renderer!.unmount();
   });
 
+  it('recounts the known total when table data shrinks after a manual refresh', async () => {
+    storeState.connections[0].config.type = 'mysql';
+    storeState.connections[0].config.database = 'main';
+    backendApp.DBGetColumns.mockResolvedValue({
+      success: true,
+      data: [{ name: 'ID', key: 'PRI' }, { name: 'NAME', key: '' }],
+    });
+
+    let countQueryCount = 0;
+    backendApp.DBQuery.mockImplementation(async (_config: any, _dbName: string, sql: string) => {
+      if (/count\s*\(/i.test(String(sql))) {
+        countQueryCount += 1;
+        return {
+          success: true,
+          fields: ['total'],
+          data: [{ total: countQueryCount === 1 ? 500 : 430 }],
+        };
+      }
+      return {
+        success: true,
+        fields: ['ID', 'NAME'],
+        data: createRows(101),
+      };
+    });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<DataViewer tab={createTab({ dbName: 'main', tableName: 'users', title: 'users' })} />);
+    });
+    await flushPromises();
+
+    expect(dataGridState.latestProps?.pagination).toMatchObject({
+      total: 500,
+      totalKnown: true,
+    });
+
+    await act(async () => {
+      dataGridState.latestProps?.onReload();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await flushPromises();
+
+    expect(countQueryCount).toBe(2);
+    expect(dataGridState.latestProps?.pagination).toMatchObject({
+      total: 430,
+      totalKnown: true,
+    });
+    expect(dataGridState.latestProps?.data).toHaveLength(100);
+    renderer!.unmount();
+  });
+
   it('shows an actionable message for DuckDB timeout interruption errors', async () => {
     storeState.languagePreference = 'en-US';
     storeState.connections[0].config.type = 'duckdb';

--- a/frontend/src/components/DataViewer.tsx
+++ b/frontend/src/components/DataViewer.tsx
@@ -583,7 +583,8 @@ const DataViewer: React.FC<{ tab: TabData; isActive?: boolean }> = React.memo(({
     setPagination(prev => ({ ...prev, totalCountLoading: false, totalCountCancelled: true }));
   }, []);
 
-  const fetchData = useCallback(async (page = pagination.current, size = pagination.pageSize) => {
+  const fetchData = useCallback(async (page = pagination.current, size = pagination.pageSize, options?: { refreshTotal?: boolean }) => {
+    const refreshTotal = options?.refreshTotal === true;
     const seq = ++fetchSeqRef.current;
     setLoading(true);
     const conn = connections.find(c => c.id === tab.connectionId);
@@ -717,15 +718,16 @@ const DataViewer: React.FC<{ tab: TabData; isActive?: boolean }> = React.memo(({
       : buildOrderBySQL(dbType, sortInfo, resolveDataViewerOrderFallbackColumns(editLocatorForQuery, pkColumnsForQuery));
     const totalRows = Number(pagination.total);
     const hasFiniteTotal = Number.isFinite(totalRows) && totalRows >= 0;
-    const totalKnown = pagination.totalKnown && hasFiniteTotal;
+    const totalKnown = !refreshTotal && pagination.totalKnown && hasFiniteTotal;
     const approximateTotalRows = Number(pagination.approximateTotal);
     const hasApproximateTotalPages =
+      !refreshTotal &&
       !totalKnown &&
       supportsApproximateTotalPages &&
       pagination.totalApprox &&
       Number.isFinite(approximateTotalRows) &&
       approximateTotalRows > 0;
-    const effectiveTotalRows = hasApproximateTotalPages ? approximateTotalRows : totalRows;
+    const effectiveTotalRows = hasApproximateTotalPages ? approximateTotalRows : (refreshTotal ? 0 : totalRows);
     const totalPages = Number.isFinite(effectiveTotalRows) && effectiveTotalRows > 0 ? Math.max(1, Math.ceil(effectiveTotalRows / size)) : 0;
     const currentPage = totalPages > 0 ? Math.min(Math.max(1, page), totalPages) : Math.max(1, page);
     const offset = (currentPage - 1) * size;
@@ -1141,7 +1143,24 @@ const DataViewer: React.FC<{ tab: TabData; isActive?: boolean }> = React.memo(({
     void fetchData(pagination.current, pagination.pageSize);
   }, [fetchData, pagination.current, pagination.pageSize]);
   const handleReload = useCallback(() => {
-    fetchData(pagination.current, pagination.pageSize);
+    countSeqRef.current++;
+    manualCountSeqRef.current++;
+    duckdbApproxSeqRef.current++;
+    oracleApproxSeqRef.current++;
+    countKeyRef.current = '';
+    autoCountKeyRef.current = '';
+    manualCountKeyRef.current = '';
+    duckdbApproxKeyRef.current = '';
+    oracleApproxKeyRef.current = '';
+    setPagination(prev => ({
+      ...prev,
+      totalKnown: false,
+      totalApprox: false,
+      approximateTotal: undefined,
+      totalCountLoading: false,
+      totalCountCancelled: false,
+    }));
+    fetchData(pagination.current, pagination.pageSize, { refreshTotal: true });
   }, [fetchData, pagination.current, pagination.pageSize]);
   const handleSort = useCallback((field: string, order: string) => {
     // 支持多字段排序：field 为 JSON 数组字符串时解析为多字段

--- a/frontend/src/components/QueryEditor.external-sql-save.test.tsx
+++ b/frontend/src/components/QueryEditor.external-sql-save.test.tsx
@@ -4408,6 +4408,51 @@ describe('QueryEditor external SQL save', () => {
     });
   });
 
+  it('formats only the selected SQL when a non-empty selection exists', async () => {
+    let renderer!: ReactTestRenderer;
+    const originalSql = 'select 1; select * from users where id=1';
+
+    await act(async () => {
+      renderer = create(<QueryEditor tab={createTab({ query: originalSql })} />);
+    });
+
+    editorState.selection = {
+      startLineNumber: 1,
+      startColumn: 11,
+      endLineNumber: 1,
+      endColumn: originalSql.length + 1,
+    };
+
+    const formatButton = findButton(renderer, '美化');
+    await act(async () => {
+      await formatButton.props.onClick();
+    });
+
+    expect(editorState.editor.executeEdits).toHaveBeenCalledWith(
+      'gonavi-format-sql',
+      expect.arrayContaining([
+        expect.objectContaining({
+          range: expect.objectContaining({
+            startLineNumber: 1,
+            startColumn: 11,
+            endLineNumber: 1,
+            endColumn: originalSql.length + 1,
+          }),
+          text: expect.stringContaining('SELECT'),
+        }),
+      ]),
+    );
+    expect(editorState.value.startsWith('select 1;')).toBe(true);
+    expect(editorState.value).toContain('SELECT');
+    expect(editorState.value).not.toBe(originalSql);
+    expect(storeState.updateQueryTabDraft).toHaveBeenCalledWith('tab-1', {
+      formatRestoreSnapshot: {
+        query: originalSql,
+        createdAt: expect.any(Number),
+      },
+    });
+  });
+
   it('registers a configurable Monaco shortcut action for SQL formatting', async () => {
     await act(async () => {
       create(<QueryEditor tab={createTab({ query: 'select * from users where id=1' })} />);

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -6116,38 +6116,49 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                   ? connectionsRef.current.find(c => c.id === tabConnectionId)
                   : undefined);
           const formatterLanguage = resolveQueryEditorFormatterLanguage(conn);
-          const sourceSql = getCurrentQuery();
+          const editor = editorRef.current;
+          const monaco = monacoRef.current;
+          const model = editor?.getModel?.();
+          const selection = editor?.getSelection?.();
+          const selectedRaw = model && selection
+              ? String(model.getValueInRange?.(selection) || '')
+              : '';
+          const formatSelection = !!selection && !!selectedRaw.trim();
+          const fullQuery = getCurrentQuery();
+          const sourceSql = formatSelection ? selectedRaw : fullQuery;
           const formatted = format(sourceSql, { language: formatterLanguage, keywordCase: sqlFormatOptions.keywordCase });
           if (sourceSql === formatted) {
               return;
           }
           updateQueryTabDraft(tab.id, {
               formatRestoreSnapshot: {
-                  query: sourceSql,
+                  query: fullQuery,
                   createdAt: Date.now(),
               },
           });
-          const editor = editorRef.current;
-          const monaco = monacoRef.current;
-          const model = editor?.getModel?.();
           if (editor && monaco && model) {
-              const currentValue = String(model.getValue?.() || sourceSql);
-              if (currentValue === formatted) {
+              const editRange = formatSelection
+                  ? selection
+                  : (model.getFullModelRange?.()
+                      || new monaco.Range(1, 1, model.getLineCount?.() || 1, model.getLineMaxColumn?.(model.getLineCount?.() || 1) || 1));
+              const currentValue = String(model.getValue?.() || fullQuery);
+              if (!formatSelection && currentValue === formatted) {
                   return;
               }
-              const fullRange = model.getFullModelRange?.()
-                  || new monaco.Range(1, 1, model.getLineCount?.() || 1, model.getLineMaxColumn?.(model.getLineCount?.() || 1) || 1);
               editor.pushUndoStop?.();
               editor.executeEdits?.('gonavi-format-sql', [{
-                  range: fullRange,
+                  range: editRange,
                   text: formatted,
                   forceMoveMarkers: true,
               }]);
               editor.pushUndoStop?.();
               const nextValue = editor.getValue?.();
-              applyQueryState(typeof nextValue === 'string' ? nextValue : formatted);
+              applyQueryState(typeof nextValue === 'string' ? nextValue : (formatSelection ? currentValue : formatted));
               refreshObjectDecorations();
               return;
+      }
+      if (formatSelection) {
+          return;
       }
       syncQueryToEditor(formatted);
   } catch (e) {


### PR DESCRIPTION
## Summary
- Invalidate cached table total count when refreshing DataViewer data
- Re-run total count after refresh so footer count reflects external table changes
- Add regression coverage for table data shrinking after refresh

Fixes Syngnat/GoNavi#707

## Verification
- `npm --prefix frontend run test -- DataViewer.primary-key.test.tsx`
- `npm --prefix frontend run build`