### PR TITLE
🐛 fix(about): 移除关于页非必要滚动条

### DIFF
--- a/frontend/src/App.settings-center.test.ts
+++ b/frontend/src/App.settings-center.test.ts
@@ -343,6 +343,8 @@ describe('settings center layout', () => {
     expect(appSource).toContain("border: 'none'");
     expect(appSource).toContain("background: 'transparent'");
     expect(aboutPaneSource).toContain('className="gonavi-about-pane"');
+    expect(aboutPaneSource).toContain("style={{ display: 'flex', flexDirection: 'column' }}");
+    expect(aboutPaneSource).not.toContain("padding: '0 0 18px'");
     expect(aboutPaneSource).toContain('aria-labelledby="gonavi-about-version-heading"');
     expect(aboutPaneSource).toContain('aria-labelledby="gonavi-about-project-heading"');
     expect(aboutPaneSource).toContain("gridTemplateColumns: 'minmax(0, 1.15fr) minmax(260px, 0.85fr)'");

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5333,7 +5333,7 @@ function App() {
       ];
 
       return (
-          <div className="gonavi-about-pane" style={{ display: 'flex', flexDirection: 'column', padding: '0 0 18px' }}>
+          <div className="gonavi-about-pane" style={{ display: 'flex', flexDirection: 'column' }}>
               <section
                 aria-label="GoNavi"
                 style={{


### PR DESCRIPTION
## 背景

Issue #702 中，安装版在“已是最新版本”且页面内容可以完整展示时，关于页右侧仍会出现滚动条。原因是内容根节点额外的 18px 底部留白造成了临界溢出。

## 变更点

- 移除关于页内容根节点冗余的底部留白
- 保留详情容器原有的 `overflowY: auto`，仅在内容真实溢出时显示滚动条
- 补充设置中心布局回归断言，防止非必要底部留白再次引入

## 影响范围

- 仅影响设置中心“关于 GoNavi”页面的垂直布局
- 已是最新版本且内容可完整展示时不再出现滚动条
- 有可用更新并显示“本次更新包”等额外信息时，内容溢出仍可正常滚动
- 不修改更新检查、下载、安装或自动检查间隔逻辑
- 无后端、数据库、依赖或配置变更

## 验证

- `npm test -- --run App.settings-center.test.ts`：22/22 通过
- `npx tsc --noEmit --pretty false`：通过
- Playwright 运行时验证：最新安装版内容 591px / 容器 599px，无溢出；有更新时内容 624px / 容器 599px，保留 25px 可滚动区域
- `git diff --check origin/dev...HEAD`：通过

Closes #702