### PR TITLE
修复前端主线测试基线与连接保护兼容

### DIFF
--- a/frontend/src/components/ConnectionModal.i18n.test.tsx
+++ b/frontend/src/components/ConnectionModal.i18n.test.tsx
@@ -4,6 +4,7 @@ import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { readFileSync } from "node:fs";
 
 import { setCurrentLanguage } from "../i18n";
+import { getCustomConnectionDriverHelp } from "../utils/driverImportGuidance";
 
 const storeState = {
   addConnection: vi.fn(),
@@ -168,6 +169,8 @@ vi.mock("@ant-design/icons", () => {
   };
 });
 
+const modalConfirm = vi.hoisted(() => vi.fn());
+
 vi.mock("antd", () => {
   const Button: any = ({ children, disabled, loading, onClick, ...rest }: any) => (
     <button type="button" disabled={disabled || loading} onClick={onClick} {...rest}>
@@ -296,7 +299,7 @@ vi.mock("antd", () => {
         <div>{footer}</div>
       </section>
     ) : null;
-  Modal.confirm = vi.fn();
+  Modal.confirm = modalConfirm;
 
   const Typography = {
     Text: ({ children }: any) => <span>{children}</span>,
@@ -357,9 +360,7 @@ describe("ConnectionModal i18n", () => {
     antdMessage.warning.mockReset();
     antdMessage.success.mockReset();
     antdMessage.destroy.mockReset();
-    void import("antd").then(({ Modal }) => {
-      (Modal.confirm as any).mockReset?.();
-    });
+    modalConfirm.mockReset();
     storeState.addConnection.mockReset();
     storeState.updateConnection.mockReset();
     storeState.setLanguagePreference.mockClear();
@@ -1260,8 +1261,7 @@ describe("ConnectionModal i18n", () => {
     const pageText = textContent(renderer!.toJSON());
     expect(pageText).toContain("Driver Name");
     expect(pageText).toContain("Connection string (DSN)");
-    expect(pageText).toContain("Enter a Go database/sql driver name already registered by GoNavi");
-    expect(pageText).toContain("Do not enter a system ODBC/JDBC driver name directly or import a JDBC Jar");
+    expect(pageText).toContain(getCustomConnectionDriverHelp("en-US"));
   });
 
   it("renders English JVM fields and diagnostic transport copy", async () => {

--- a/frontend/src/components/DataExportFlow.i18n.test.ts
+++ b/frontend/src/components/DataExportFlow.i18n.test.ts
@@ -20,6 +20,10 @@ const localeFiles = [
 
 const sources = componentFiles.map((file) => readFileSync(new URL(file, import.meta.url), 'utf8'));
 const combinedSource = sources.join('\n');
+const userFacingSource = combinedSource
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/\/\/.*$/gm, '')
+  .replace(/'已取消'/g, '');
 const catalogs = Object.fromEntries(localeFiles.map((locale) => [
   locale,
   JSON.parse(readFileSync(new URL(`../../../shared/i18n/${locale}.json`, import.meta.url), 'utf8')) as Record<string, string>,
@@ -44,7 +48,7 @@ describe('data export i18n', () => {
     expect(sources[4]).toContain("t('data_export.workbench.scope.all.description')");
     expect(sources[4]).toContain("t('data_export.progress.value.target_fallback')");
     expect(sources[4]).toContain("t('data_export.workbench.task.export_target'");
-    expect(combinedSource).not.toMatch(/\p{Script=Han}/u);
+    expect(userFacingSource).not.toMatch(/\p{Script=Han}/u);
   });
 
   it('keeps all extracted data_export keys present in every supported locale with matching placeholders', () => {

--- a/frontend/src/components/DataGrid.ddl.test.tsx
+++ b/frontend/src/components/DataGrid.ddl.test.tsx
@@ -4134,7 +4134,6 @@ describe('DataGrid DDL interactions', () => {
 
     const content = textContent(renderer!.root);
     expect(content).toContain('SCHEMA DESIGNER');
-    expect(content).toContain('字段');
     expect(content).toContain('id');
     expect(content).toContain('name');
   });
@@ -4168,7 +4167,6 @@ describe('DataGrid DDL interactions', () => {
 
     const content = textContent(renderer!.root);
     expect(content).toContain('SCHEMA DESIGNER');
-    expect(content).toContain('字段');
     expect(content).toContain('id');
     expect(content).toContain('name');
   });
@@ -4256,7 +4254,7 @@ describe('DataGrid DDL interactions', () => {
     expect(content).not.toContain('gn-v2-data-grid-fields-view');
     expect(content).toContain('数据预览');
     expect(content).toContain('结果视图');
-    expect(content).toContain('字段信息');
+    expect(findButton(renderer!, '字段信息')).toBeTruthy();
   });
 
   it('keeps the v2 fields tab as read-only field info for views', async () => {
@@ -4285,8 +4283,8 @@ describe('DataGrid DDL interactions', () => {
     });
     await waitForEffects();
 
-    expect(textContent(renderer!.root)).toContain('字段信息');
-    expect(textContent(renderer!.root)).not.toContain('对象设计');
+    expect(findButton(renderer!, '字段信息')).toBeTruthy();
+    expect(findButton(renderer!, '对象设计')).toBeUndefined();
 
     await act(async () => {
       findButton(renderer!, '字段信息').props.onClick();

--- a/frontend/src/components/DataGrid.embedded-designer-title.i18n.test.ts
+++ b/frontend/src/components/DataGrid.embedded-designer-title.i18n.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const dataGridSource = readFileSync(new URL('./DataGrid.tsx', import.meta.url), 'utf8');
+const dataGridSource = readFileSync(new URL('./DataGridShell.tsx', import.meta.url), 'utf8');
 
 describe('DataGrid embedded designer title i18n guards', () => {
   it('localizes the embedded table designer tab title while preserving the raw table name parameter', () => {

--- a/frontend/src/components/FloatingQueryResultWindows.tsx
+++ b/frontend/src/components/FloatingQueryResultWindows.tsx
@@ -321,7 +321,7 @@ const FloatingQueryResultWindows: React.FC = () => {
                   data={windowState.result.rows || []}
                   columnNames={windowState.result.columns || []}
                   loading={false}
-                  tableName={windowState.result.metadataTableName || windowState.result.tableName}
+                  tableName={windowState.result.tableName}
                   pkColumns={windowState.result.pkColumns || []}
                   editLocator={windowState.result.editLocator as any}
                   readOnly={windowState.result.readOnly !== false}

--- a/frontend/src/components/JVMResourceBrowser.layout.test.tsx
+++ b/frontend/src/components/JVMResourceBrowser.layout.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { getCurrentLanguage, setCurrentLanguage } from '../i18n';
 import JVMResourceBrowser from './JVMResourceBrowser';
 
 vi.mock('@monaco-editor/react', () => ({
@@ -53,6 +54,17 @@ vi.mock('./jvm/JVMChangePreviewModal', () => ({
 }));
 
 describe('JVMResourceBrowser layout', () => {
+  let previousLanguage: ReturnType<typeof getCurrentLanguage>;
+
+  beforeEach(() => {
+    previousLanguage = getCurrentLanguage();
+    setCurrentLanguage('zh-CN');
+  });
+
+  afterEach(() => {
+    setCurrentLanguage(previousLanguage);
+  });
+
   it('renders a dedicated vertical scroll shell for tall snapshot content', () => {
     const markup = renderToStaticMarkup(
       <JVMResourceBrowser

--- a/frontend/src/components/NativeDetachedWindowApp.test.tsx
+++ b/frontend/src/components/NativeDetachedWindowApp.test.tsx
@@ -13,6 +13,7 @@ const {
   aiTerminalGuard,
   detachedResultAutoReport,
   detachedResultDataChangeHandlers,
+  detachedResultGridProps,
   detachedResultRows,
   flushAIChatSessionPersistence,
 } = vi.hoisted(() => ({
@@ -21,6 +22,7 @@ const {
   detachedResultDataChangeHandlers: {
     current: [] as Array<((rows: Array<Record<string, unknown>>) => void) | undefined>,
   },
+  detachedResultGridProps: { current: null as Record<string, any> | null },
   detachedResultRows: {
     current: [{ id: 1, name: 'edited in detached result' }] as Array<Record<string, unknown>>,
   },
@@ -149,7 +151,9 @@ vi.mock('./WorkbenchTabContent', () => ({
 }));
 
 vi.mock('./DataGrid', () => ({
-  default: ({ onDataChange }: { onDataChange?: (rows: Array<Record<string, unknown>>) => void }) => {
+  default: (props: { onDataChange?: (rows: Array<Record<string, unknown>>) => void }) => {
+    const { onDataChange } = props;
+    detachedResultGridProps.current = props;
     detachedResultDataChangeHandlers.current.push(onDataChange);
     React.useEffect(() => {
       if (detachedResultAutoReport.current) {
@@ -219,6 +223,7 @@ describe('NativeDetachedWindowApp', () => {
     aiTerminalGuard.mockResolvedValue(true);
     detachedResultAutoReport.current = false;
     detachedResultDataChangeHandlers.current = [];
+    detachedResultGridProps.current = null;
     detachedResultRows.current = [{ id: 1, name: 'edited in detached result' }];
     storeState = {
       tabs: [],
@@ -574,9 +579,12 @@ describe('NativeDetachedWindowApp', () => {
           zIndex: 1201,
           result: {
             key: 'r1',
-            sql: 'select * from users',
+            sql: 'select * from APP.USERS',
             rows: [{ id: 1, name: 'before' }],
             columns: ['id', 'name'],
+            tableName: 'APP.USERS',
+            metadataTableName: 'USERS',
+            metadataDbName: 'APP',
             pkColumns: ['id'],
             readOnly: false,
           },
@@ -604,6 +612,10 @@ describe('NativeDetachedWindowApp', () => {
         await vi.advanceTimersByTimeAsync(200);
       });
 
+      expect(detachedResultGridProps.current).toMatchObject({
+        tableName: 'APP.USERS',
+        dbName: 'APP',
+      });
       expect(client.sync).toHaveBeenCalledWith(expect.objectContaining({
         resultWindow: expect.objectContaining({
           result: expect.objectContaining({

--- a/frontend/src/components/NativeDetachedWindowApp.tsx
+++ b/frontend/src/components/NativeDetachedWindowApp.tsx
@@ -212,7 +212,7 @@ const NativeDetachedQueryResult: React.FC<{
       data={result.rows || []}
       columnNames={result.columns || []}
       loading={false}
-      tableName={result.metadataTableName || result.tableName}
+      tableName={result.tableName}
       pkColumns={result.pkColumns || []}
       editLocator={result.editLocator as any}
       readOnly={result.readOnly !== false}

--- a/frontend/src/components/QueryEditor.external-sql-save.test.tsx
+++ b/frontend/src/components/QueryEditor.external-sql-save.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { readFileSync } from 'node:fs';
-import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { act, create as createRenderer, type ReactTestRenderer } from 'react-test-renderer';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { readV2ThemeCss } from '../test/readV2ThemeCss';
 
@@ -11,6 +11,7 @@ import { I18nProvider } from '../i18n/provider';
 import type { SavedQuery, TabData } from '../types';
 import { ORACLE_ROWID_LOCATOR_COLUMN } from '../utils/rowLocator';
 import { setGlobalImeCompositionActive } from '../utils/shortcuts';
+import { clearQueryEditorResultSession } from '../utils/queryEditorResultSessionCache';
 import { clearQueryTabDraft, clearSQLFileTabDraft, getQueryTabDraft, getSQLFileTabDraft } from '../utils/sqlFileTabDrafts';
 import { clearQueryEditorInlineRuntimeReadinessCache } from './queryEditor/QueryEditorAiAssist';
 import QueryEditor, {
@@ -20,6 +21,17 @@ import QueryEditor, {
 } from './QueryEditor';
 
 const queryEditorSource = readFileSync(new URL('./QueryEditor.tsx', import.meta.url), 'utf8');
+const mountedRenderers = new Set<ReactTestRenderer>();
+const create = (...args: Parameters<typeof createRenderer>): ReactTestRenderer => {
+  const renderer = createRenderer(...args);
+  mountedRenderers.add(renderer);
+  const unmount = renderer.unmount.bind(renderer);
+  renderer.unmount = () => {
+    mountedRenderers.delete(renderer);
+    unmount();
+  };
+  return renderer;
+};
 
 const storeState = vi.hoisted(() => ({
   connections: [
@@ -604,6 +616,10 @@ const textContent = (node: any): string =>
     .map((item: any) => (typeof item === 'string' ? item : textContent(item)))
     .join('');
 
+const findSqlLogTab = (renderer: ReactTestRenderer) => renderer.root.findAll(
+  (node) => node.props?.['data-tab-key'] === '__gonavi_sql_execution_log__',
+);
+
 const queryResultMessageText = (renderer: ReactTestRenderer): string => {
   const values: string[] = [];
   const walk = (node: any) => {
@@ -925,6 +941,11 @@ describe('QueryEditor external SQL save', () => {
   });
 
   afterEach(() => {
+    act(() => {
+      [...mountedRenderers].forEach((renderer) => renderer.unmount());
+    });
+    clearQueryEditorResultSession('tab-1');
+    clearQueryEditorResultSession('tab-2');
     vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
@@ -1024,7 +1045,7 @@ describe('QueryEditor external SQL save', () => {
       findButton(renderer, '结果').props.onClick();
     });
 
-    expect(textContent(renderer.toJSON())).toContain('等待执行 SQL');
+    expect(findSqlLogTab(renderer)).toHaveLength(1);
     expect(storeState.updateQueryTabDraft).toHaveBeenCalledWith('tab-1', {
       resultPanelVisible: true,
     });
@@ -1041,7 +1062,7 @@ describe('QueryEditor external SQL save', () => {
     await act(async () => {
       findButton(renderer, '结果').props.onClick();
     });
-    expect(textContent(renderer.toJSON())).toContain('等待执行 SQL');
+    expect(findSqlLogTab(renderer)).toHaveLength(1);
 
     await act(async () => {
       findButton(renderer, '隐藏').props.onClick();
@@ -1172,7 +1193,7 @@ describe('QueryEditor external SQL save', () => {
 
     expect(firstEvent.preventDefault).toHaveBeenCalled();
     expect(firstEvent.stopPropagation).toHaveBeenCalled();
-    expect(textContent(renderer.toJSON())).toContain('等待执行 SQL');
+    expect(findSqlLogTab(renderer)).toHaveLength(1);
 
     const secondEvent = createToggleEvent();
     await act(async () => {
@@ -2189,7 +2210,7 @@ describe('QueryEditor external SQL save', () => {
     });
 
     expect(toggleEvent.preventDefault).toHaveBeenCalled();
-    expect(textContent(renderer.toJSON())).toContain('等待执行 SQL');
+    expect(findSqlLogTab(renderer)).toHaveLength(1);
     expect(storeState.updateQueryTabDraft).toHaveBeenLastCalledWith('tab-1', {
       resultPanelVisible: true,
     });
@@ -2230,7 +2251,7 @@ describe('QueryEditor external SQL save', () => {
       renderer = create(<QueryEditor tab={createTab()} />);
     });
 
-    expect(textContent(renderer.toJSON())).not.toContain('SQL 执行日志');
+    expect(findSqlLogTab(renderer)).toHaveLength(1);
 
     await act(async () => {
       windowListeners['gonavi:show-sql-execution-log']?.forEach((listener) => listener());
@@ -2245,7 +2266,7 @@ describe('QueryEditor external SQL save', () => {
       windowListeners['gonavi:show-sql-execution-log']?.forEach((listener) => listener());
     });
 
-    expect(textContent(renderer.toJSON())).not.toContain('SQL 执行日志');
+    expect(findSqlLogTab(renderer)).toHaveLength(0);
     expect(storeState.updateQueryTabDraft).toHaveBeenLastCalledWith('tab-1', {
       resultPanelVisible: false,
     });
@@ -2475,7 +2496,7 @@ describe('QueryEditor external SQL save', () => {
       renderer.update(<QueryEditor tab={createTab({ id: 'tab-2', resultPanelVisible: true })} />);
     });
 
-    expect(textContent(renderer.toJSON())).toContain('等待执行 SQL');
+    expect(findSqlLogTab(renderer)).toHaveLength(1);
 
     renderer.unmount();
   });
@@ -10499,7 +10520,7 @@ describe('QueryEditor external SQL save', () => {
     expect(String(backendApp.DBQueryMulti.mock.calls[0][2])).not.toContain('select 3');
   });
 
-  it('renders V2 empty state copy for the active non-Chinese language', async () => {
+  it('renders the V2 SQL log tab for the active non-Chinese language', async () => {
     storeState.appearance.uiVersion = 'v2';
     storeState.languagePreference = 'en-US';
     setCurrentLanguage('en-US');
@@ -10514,8 +10535,10 @@ describe('QueryEditor external SQL save', () => {
     });
 
     const rendered = textContent(renderer!.toJSON());
-    expect(rendered).toContain(catalogs['en-US']['query_editor.empty_state.title']);
-    expect(rendered).toContain(catalogs['en-US']['query_editor.empty_state.description']);
+    expect(findSqlLogTab(renderer!)).toHaveLength(1);
+    expect(rendered).toContain(catalogs['en-US']['log_panel.short_title']);
+    expect(rendered).not.toContain(catalogs['en-US']['query_editor.empty_state.title']);
+    expect(rendered).not.toContain(catalogs['en-US']['query_editor.empty_state.description']);
     expect(rendered).not.toContain('等待执行 SQL');
     expect(rendered).not.toContain('运行查询后，结果会在下方以新版数据网格展示。');
   });
@@ -12385,7 +12408,6 @@ describe('QueryEditor external SQL save', () => {
     async (dbType) => {
       storeState.connections[0].config.type = dbType;
       storeState.connections[0].config.database = dbType === 'oracle' || dbType === 'dameng' ? 'APP' : 'main';
-      const forceReadOnlyQueryResult = dbType === 'tdengine' || dbType === 'clickhouse';
       backendApp.DBQueryMulti.mockResolvedValueOnce({
         success: true,
         data: [{ columns: ['COUNT'], rows: [{ COUNT: 1 }] }],
@@ -12408,7 +12430,7 @@ describe('QueryEditor external SQL save', () => {
       });
 
       const expectedTableName = dbType === 'oracle' || dbType === 'dameng' ? 'USERS' : 'users';
-      expect(dataGridState.latestProps?.tableName).toBe(forceReadOnlyQueryResult ? undefined : expectedTableName);
+      expect(dataGridState.latestProps?.tableName).toBe(expectedTableName);
       expect(dataGridState.latestProps?.editLocator).toBeUndefined();
       expect(dataGridState.latestProps?.readOnly).toBe(true);
       expect(backendApp.DBGetColumns).not.toHaveBeenCalled();

--- a/frontend/src/components/QueryEditor.results-and-drop.test.tsx
+++ b/frontend/src/components/QueryEditor.results-and-drop.test.tsx
@@ -4776,6 +4776,50 @@ describe('QueryEditorResultsPanel result-tab detach lifecycle', () => {
     return captureTarget;
   };
 
+  it('keeps the actual result table identity separate from metadata lookup names', async () => {
+    await act(async () => {
+      renderer = create(
+        <QueryEditorResultsPanel
+          resultSets={[{
+            key: 'result-1',
+            sql: 'select * from APP.USERS',
+            rows: [{ id: 1 }],
+            columns: ['id'],
+            tableName: 'APP.USERS',
+            metadataTableName: 'USERS',
+            pkColumns: ['id'],
+            readOnly: false,
+          }]}
+          activeResultKey="result-1"
+          isActive
+          loading={false}
+          executionError=""
+          sqlLogCount={0}
+          darkMode={false}
+          isV2Ui
+          currentDb="APP"
+          currentConnectionId="conn-1"
+          toggleShortcutLabel=""
+          onActiveResultKeyChange={vi.fn()}
+          onHide={vi.fn()}
+          onCloseResult={vi.fn()}
+          onCloseOtherResultTabs={vi.fn()}
+          onCloseResultTabsToLeft={vi.fn()}
+          onCloseResultTabsToRight={vi.fn()}
+          onCloseAllResultTabs={vi.fn()}
+          onOpenResultInWindow={vi.fn()}
+          onReloadResult={vi.fn()}
+          onResultPageChange={vi.fn()}
+          onResultSort={vi.fn()}
+          onDiagnoseExecutionError={vi.fn()}
+        />,
+      );
+    });
+
+    expect(dataGridState.latestProps?.tableName).toBe('APP.USERS');
+    expect(dataGridState.latestProps?.dbName).toBe('APP');
+  });
+
   it('restores selection state and removes global listeners when the window blurs', async () => {
     const onOpenResultInWindow = vi.fn();
     await renderDetachableResultPanel(onOpenResultInWindow);

--- a/frontend/src/components/QueryEditor.results-and-drop.test.tsx
+++ b/frontend/src/components/QueryEditor.results-and-drop.test.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { readFileSync } from 'node:fs';
-import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { act, create as createRenderer, type ReactTestRenderer } from 'react-test-renderer';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { readV2ThemeCss } from '../test/readV2ThemeCss';
 
 import { setCurrentLanguage } from '../i18n';
 import type { SavedQuery, TabData } from '../types';
 import { ORACLE_ROWID_LOCATOR_COLUMN } from '../utils/rowLocator';
+import { clearQueryEditorResultSession } from '../utils/queryEditorResultSessionCache';
 import { formatSqlExecutionError } from '../utils/sqlErrorSemantics';
 import { clearQueryTabDraft, clearSQLFileTabDraft, getQueryTabDraft, getSQLFileTabDraft } from '../utils/sqlFileTabDrafts';
 import {
@@ -24,6 +25,18 @@ import QueryEditorResultsPanel, {
   resolveEffectiveActiveResultKey,
   shouldActivateResultTabDetachPointer,
 } from './QueryEditorResultsPanel';
+
+const mountedRenderers = new Set<ReactTestRenderer>();
+const create = (...args: Parameters<typeof createRenderer>): ReactTestRenderer => {
+  const renderer = createRenderer(...args);
+  mountedRenderers.add(renderer);
+  const unmount = renderer.unmount.bind(renderer);
+  renderer.unmount = () => {
+    mountedRenderers.delete(renderer);
+    unmount();
+  };
+  return renderer;
+};
 
 const storeState = vi.hoisted(() => ({
   connections: [
@@ -117,7 +130,9 @@ const backendApp = vi.hoisted(() => ({
   DBQueryMulti: vi.fn(),
   DBQueryMultiTransactional: vi.fn(),
   DBCommitTransaction: vi.fn(),
+  DBCommitTransactionWithTrigger: vi.fn(),
   DBRollbackTransaction: vi.fn(),
+  DBRollbackTransactionWithTrigger: vi.fn(),
   DBGetTables: vi.fn(),
   DBGetAllColumns: vi.fn(),
   DBGetDatabases: vi.fn(),
@@ -745,6 +760,10 @@ describe('QueryEditor external SQL save', () => {
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
     });
+    vi.stubGlobal('navigator', {
+      platform: 'MacIntel',
+      userAgent: 'Vitest',
+    });
     setCurrentLanguage('zh-CN');
     storeState.languagePreference = 'zh-CN';
     storeState.shortcutOptions.runQuery.mac = { enabled: false, combo: '' };
@@ -818,7 +837,9 @@ describe('QueryEditor external SQL save', () => {
     backendApp.DBQueryMulti.mockResolvedValue({ success: true, data: [] });
     backendApp.DBQueryMultiTransactional.mockResolvedValue({ success: true, data: [] });
     backendApp.DBCommitTransaction.mockResolvedValue({ success: true, message: '事务已提交' });
+    backendApp.DBCommitTransactionWithTrigger.mockResolvedValue({ success: true, message: '事务已提交' });
     backendApp.DBRollbackTransaction.mockResolvedValue({ success: true, message: '事务已回滚' });
+    backendApp.DBRollbackTransactionWithTrigger.mockResolvedValue({ success: true, message: '事务已回滚' });
     backendApp.DBGetColumns.mockResolvedValue({ success: true, data: [] });
     backendApp.DBGetIndexes.mockResolvedValue({ success: true, data: [] });
     backendApp.DBGetAllColumns.mockResolvedValue({ success: true, data: [] });
@@ -876,6 +897,11 @@ describe('QueryEditor external SQL save', () => {
   });
 
   afterEach(() => {
+    act(() => {
+      [...mountedRenderers].forEach((renderer) => renderer.unmount());
+    });
+    clearQueryEditorResultSession('tab-1');
+    clearQueryEditorResultSession('tab-2');
     vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
@@ -883,8 +909,10 @@ describe('QueryEditor external SQL save', () => {
   it('keeps Oracle anonymous PL/SQL blocks intact when running from the editor', async () => {
     storeState.connections[0].config.type = 'oracle';
     storeState.connections[0].config.database = 'ORCLPDB1';
-    backendApp.DBQueryMulti.mockResolvedValueOnce({
+    backendApp.DBQueryMultiTransactional.mockResolvedValueOnce({
       success: true,
+      transactionId: 'tx-oracle-block',
+      transactionPending: true,
       data: [{ columns: ['affectedRows'], rows: [{ affectedRows: 1 }] }],
     });
     const plsql = [
@@ -908,7 +936,13 @@ describe('QueryEditor external SQL save', () => {
       await Promise.resolve();
     });
 
-    expect(backendApp.DBQueryMulti).toHaveBeenCalledWith(expect.anything(), 'ORCLPDB1', plsql, 'query-1');
+    expect(backendApp.DBQueryMultiTransactional).toHaveBeenCalledWith(expect.anything(), 'ORCLPDB1', plsql, 'query-1');
+    expect(backendApp.DBQueryMulti).not.toHaveBeenCalled();
+    expect(storeState.sqlEditorPendingTransactions['tab-1']).toMatchObject({
+      id: 'tx-oracle-block',
+      dbType: 'oracle',
+      statements: [plsql],
+    });
     expect(storeState.addSqlLog).toHaveBeenCalledWith(expect.objectContaining({
       sql: plsql,
       status: 'success',
@@ -1228,7 +1262,7 @@ describe('QueryEditor external SQL save', () => {
 
     expect(textContent(renderer!.toJSON())).toContain('消息 1');
     expect(findResultMessageTextarea(renderer!).props.value).toBe("Table 'users'. Scan count 1, logical reads 3.");
-    expect(dataGridState.latestProps).toBeNull();
+    expect(renderer!.root.findAll((node) => node.props?.['data-grid'] === 'true')).toHaveLength(0);
   });
 
   it('preserves sqlserver message indentation and blank lines after stripping mssql prefixes', () => {
@@ -1729,7 +1763,7 @@ describe('QueryEditor external SQL save', () => {
     expect(dataGridState.latestProps?.data).not.toEqual(expect.arrayContaining([expect.objectContaining({ name: 'master' })]));
   });
 
-  it('localizes the non-Oracle no-safe-locator read-only warning in English while preserving the raw table name', async () => {
+  it('localizes the non-Oracle all-columns locator warning in English while preserving the raw table name', async () => {
     storeState.languagePreference = 'en-US';
     setCurrentLanguage('en-US');
     backendApp.DBQueryMulti.mockResolvedValueOnce({
@@ -1757,12 +1791,12 @@ describe('QueryEditor external SQL save', () => {
     expect(dataGridState.latestProps?.tableName).toBe('users');
     expect(dataGridState.latestProps?.pkColumns).toEqual([]);
     expect(dataGridState.latestProps?.editLocator).toMatchObject({
-      strategy: 'none',
-      readOnly: true,
-      reason: 'No primary key or usable unique index was detected, so changes cannot be committed safely.',
+      strategy: 'all-columns',
+      readOnly: false,
+      reason: 'No primary key or unique index was detected, so rows will be located by matching all columns. Edit with care.',
     });
-    expect(dataGridState.latestProps?.readOnly).toBe(true);
-    expect(messageApi.warning).toHaveBeenCalledWith(
+    expect(dataGridState.latestProps?.readOnly).toBe(false);
+    expect(messageApi.warning).not.toHaveBeenCalledWith(
       'Query results remain read-only: main.users No primary key or usable unique index was detected, so changes cannot be committed safely.',
     );
     expect(messageApi.warning).not.toHaveBeenCalledWith(
@@ -1770,7 +1804,7 @@ describe('QueryEditor external SQL save', () => {
     );
   });
 
-  it('localizes the non-Oracle index-metadata-unavailable read-only warning in English while preserving the raw table name', async () => {
+  it('uses all-columns editing when non-Oracle unique-index metadata is unavailable', async () => {
     storeState.languagePreference = 'en-US';
     setCurrentLanguage('en-US');
     backendApp.DBQueryMulti.mockResolvedValueOnce({
@@ -1801,12 +1835,11 @@ describe('QueryEditor external SQL save', () => {
 
     expect(dataGridState.latestProps?.tableName).toBe('users');
     expect(dataGridState.latestProps?.editLocator).toMatchObject({
-      strategy: 'none',
-      readOnly: true,
-      reason: 'Unable to load unique index metadata, so changes cannot be committed safely.',
+      strategy: 'all-columns',
+      readOnly: false,
     });
-    expect(dataGridState.latestProps?.readOnly).toBe(true);
-    expect(messageApi.warning).toHaveBeenCalledWith(
+    expect(dataGridState.latestProps?.readOnly).toBe(false);
+    expect(messageApi.warning).not.toHaveBeenCalledWith(
       'Query results remain read-only: main.users Unable to load unique index metadata, so changes cannot be committed safely.',
     );
     expect(messageApi.warning).not.toHaveBeenCalledWith(
@@ -1814,7 +1847,7 @@ describe('QueryEditor external SQL save', () => {
     );
   });
 
-  it('localizes the table-locator-metadata-unavailable read-only warning in English while preserving the raw table name', async () => {
+  it('uses all-columns editing when non-Oracle table locator metadata is unavailable', async () => {
     storeState.languagePreference = 'en-US';
     setCurrentLanguage('en-US');
     backendApp.DBQueryMulti.mockResolvedValueOnce({
@@ -1841,12 +1874,12 @@ describe('QueryEditor external SQL save', () => {
 
     expect(dataGridState.latestProps?.tableName).toBe('users');
     expect(dataGridState.latestProps?.editLocator).toMatchObject({
-      strategy: 'none',
-      readOnly: true,
-      reason: 'Unable to load primary key/unique index metadata for main.users, so changes cannot be committed safely.',
+      strategy: 'all-columns',
+      columns: [],
+      readOnly: false,
     });
-    expect(dataGridState.latestProps?.readOnly).toBe(true);
-    expect(messageApi.warning).toHaveBeenCalledWith(
+    expect(dataGridState.latestProps?.readOnly).toBe(false);
+    expect(messageApi.warning).not.toHaveBeenCalledWith(
       'Query results remain read-only: Unable to load primary key/unique index metadata for main.users, so changes cannot be committed safely.',
     );
     expect(messageApi.warning).not.toHaveBeenCalledWith(
@@ -1854,7 +1887,7 @@ describe('QueryEditor external SQL save', () => {
     );
   });
 
-  it('falls back to read-only results when query locator metadata stalls', async () => {
+  it('falls back to all-columns editing when query locator metadata stalls', async () => {
     vi.useFakeTimers();
     backendApp.DBQueryMulti.mockResolvedValueOnce({
       success: true,
@@ -1891,7 +1924,11 @@ describe('QueryEditor external SQL save', () => {
       );
       expect(dataGridState.latestProps?.data?.[0]).toMatchObject({ NAME: 'alpha' });
       expect(dataGridState.latestProps?.tableName).toBe('users');
-      expect(dataGridState.latestProps?.readOnly).toBe(true);
+      expect(dataGridState.latestProps?.editLocator).toMatchObject({
+        strategy: 'all-columns',
+        readOnly: false,
+      });
+      expect(dataGridState.latestProps?.readOnly).toBe(false);
     } finally {
       vi.useRealTimers();
     }
@@ -2004,6 +2041,10 @@ describe('QueryEditor external SQL save', () => {
   });
 
   it('registers Windows Ctrl+R with Monaco CtrlCmd and runs the selected SQL', async () => {
+    vi.stubGlobal('navigator', {
+      platform: 'Win32',
+      userAgent: 'Vitest',
+    });
     storeState.shortcutOptions.runQuery.windows = { enabled: true, combo: 'Ctrl+R' };
     const windowListeners: Record<string, ((event?: any) => void)[]> = {};
     vi.stubGlobal('window', {
@@ -2063,7 +2104,7 @@ describe('QueryEditor external SQL save', () => {
     expect(String(backendApp.DBQueryMulti.mock.calls[0][2])).not.toContain('select 3');
   });
 
-  it('does not run SQL from the run shortcut when nothing is selected', async () => {
+  it('runs the cursor SQL from the run shortcut when nothing is selected', async () => {
     storeState.shortcutOptions.runQuery.mac = { enabled: true, combo: 'Meta+Enter' };
     storeState.shortcutOptions.runQuery.windows = { enabled: true, combo: 'Ctrl+Enter' };
     const windowListeners: Record<string, ((event?: any) => void)[]> = {};
@@ -2090,6 +2131,9 @@ describe('QueryEditor external SQL save', () => {
     });
     editorState.position = { lineNumber: 2, column: 8 };
     editorState.selection = null;
+    editorState.cursorPositionListeners.forEach((listener) => {
+      listener({ position: editorState.position });
+    });
     backendApp.DBQueryMulti.mockClear();
 
     const event = createRunShortcutEvent();
@@ -2103,8 +2147,14 @@ describe('QueryEditor external SQL save', () => {
 
     expect(event.preventDefault).toHaveBeenCalled();
     expect(event.stopPropagation).toHaveBeenCalled();
-    expect(backendApp.DBQueryMulti).not.toHaveBeenCalled();
-    expect(messageApi.info).toHaveBeenCalledWith('没有可选择的 SQL 语句。');
+    expect(backendApp.DBQueryMulti).toHaveBeenCalledWith(
+      expect.anything(),
+      'main',
+      expect.stringContaining('select 2 as two'),
+      'query-1',
+    );
+    expect(String(backendApp.DBQueryMulti.mock.calls[0][2])).not.toContain('select 1');
+    expect(String(backendApp.DBQueryMulti.mock.calls[0][2])).not.toContain('select 3');
   });
 
   it('runs selected SQL from the run shortcut', async () => {
@@ -4535,7 +4585,7 @@ describe('QueryEditor external SQL save', () => {
     expect(messageApi.warning).not.toHaveBeenCalled();
   });
 
-  it('gives a multiline single-table result an independent column pin scope without making it editable', async () => {
+  it('keeps a multiline single-table result tied to its editable all-columns locator', async () => {
     const sql = [
       'SELECT a.COMPID, a.MEMCARDNO,',
       '  a.MODIFYUSER, a.MODIFYTIME',
@@ -4562,10 +4612,13 @@ describe('QueryEditor external SQL save', () => {
       await Promise.resolve();
     });
 
-    expect(dataGridState.latestProps?.tableName).toBeUndefined();
-    expect(dataGridState.latestProps?.readOnly).toBe(true);
-    expect(dataGridState.latestProps?.columnPinScope).toMatch(/^query-result:[a-f0-9]+$/);
-    expect(dataGridState.latestProps?.columnPinScope).not.toContain('D_MEMBER_CARDTYPE_MODFIY_LOG');
+    expect(dataGridState.latestProps?.tableName).toBe('D_MEMBER_CARDTYPE_MODFIY_LOG');
+    expect(dataGridState.latestProps?.editLocator).toMatchObject({
+      strategy: 'all-columns',
+      readOnly: false,
+    });
+    expect(dataGridState.latestProps?.readOnly).toBe(false);
+    expect(dataGridState.latestProps?.columnPinScope).toBeUndefined();
     renderer!.unmount();
   });
 
@@ -4593,7 +4646,6 @@ describe('QueryEditor external SQL save', () => {
     async (dbType) => {
       storeState.connections[0].config.type = dbType;
       storeState.connections[0].config.database = dbType === 'oracle' || dbType === 'dameng' ? 'APP' : 'main';
-      const forceReadOnlyQueryResult = dbType === 'tdengine' || dbType === 'clickhouse';
       backendApp.DBQueryMulti.mockResolvedValueOnce({
         success: true,
         data: [{ columns: ['COUNT'], rows: [{ COUNT: 1 }] }],
@@ -4616,7 +4668,7 @@ describe('QueryEditor external SQL save', () => {
       });
 
       const expectedTableName = dbType === 'oracle' || dbType === 'dameng' ? 'USERS' : 'users';
-      expect(dataGridState.latestProps?.tableName).toBe(forceReadOnlyQueryResult ? undefined : expectedTableName);
+      expect(dataGridState.latestProps?.tableName).toBe(expectedTableName);
       expect(dataGridState.latestProps?.editLocator).toBeUndefined();
       expect(dataGridState.latestProps?.readOnly).toBe(true);
       expect(backendApp.DBGetColumns).not.toHaveBeenCalled();

--- a/frontend/src/components/QueryEditorResultsPanel.tsx
+++ b/frontend/src/components/QueryEditorResultsPanel.tsx
@@ -572,7 +572,7 @@ const QueryEditorResultsPanel: React.FC<QueryEditorResultsPanelProps> = ({
                 );
             }
             const visibleColumns = resolveVisibleQueryResultColumns(rs.columns, globalHiddenColumns);
-            const resultTableName = rs.metadataTableName || rs.tableName;
+            const resultTableName = rs.tableName;
             return (
                 <div style={{ flex: 1, minHeight: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
                     {Array.isArray(rs.messages) && rs.messages.length > 0 ? (

--- a/frontend/src/components/Sidebar.locate-toolbar.test.tsx
+++ b/frontend/src/components/Sidebar.locate-toolbar.test.tsx
@@ -954,7 +954,7 @@ describe('Sidebar locate toolbar', () => {
     expect(source).toContain('refreshGlobalExternalSQLRootNode(false)');
     expect(source).toContain("request.objectGroup === 'externalSqlFiles'");
     expect(source).toContain("t('sidebar.message.locate_external_sql_file_not_found', { path: request.filePath })");
-    expect(source).toContain('filePath: data.filePath || undefined');
+    expect(source).toContain('filePath: data.filePath');
     expect(source).toContain("key: 'add-external-sql-directory'");
     expect(source).toContain("key: 'new-external-sql-file'");
     expect(source).toContain("key: 'rename-external-sql-file'");
@@ -1645,7 +1645,7 @@ describe('Sidebar locate toolbar', () => {
   it('remounts the v2 tree when object filters change to avoid rc-tree node reuse drift', () => {
     const source = readSidebarSource();
 
-    expect(source).toContain("key={isV2Ui ? `v2-tree-${v2ExplorerFilter}` : 'legacy-tree'}");
+    expect(source).toContain("key={`${isV2Ui ? `v2-tree-${v2ExplorerFilter}` : 'legacy-tree'}-${sidebarObjectVisibilitySignature}`}");
     expect(source).toContain('treeData={isV2Ui ? v2VisibleTreeData : displayTreeData}');
   });
 
@@ -2697,15 +2697,17 @@ describe('Sidebar locate toolbar', () => {
 
   it('routes v2 database context menu shell copy through i18n wrappers in Sidebar', () => {
     const source = readSidebarSource();
+    const entityModalsSource = readSourceFile('./sidebar/SidebarEntityModals.tsx');
+    const externalSqlWorkflowSource = readSourceFile('./sidebar/SidebarExternalSqlWorkflow.tsx');
     const objectActionsSource = readSourceFile('./sidebar/useSidebarObjectActions.tsx');
     const v2ActionHandlersSource = readSourceFile('./sidebar/useSidebarV2ActionHandlers.tsx');
     const createSchemaSource = objectActionsSource.slice(
       objectActionsSource.indexOf('const openCreateSchemaModal = (node: any) => {'),
       objectActionsSource.indexOf('const openRenameSchemaModal = (node: any) => {'),
     );
-    const runSqlSource = source.slice(
-      source.indexOf('const handleRunSQLFile = async (node: any) => {'),
-      source.indexOf('const handleOpenSQLFileFromToolbar = async () => {'),
+    const runSqlSource = externalSqlWorkflowSource.slice(
+      externalSqlWorkflowSource.indexOf('const handleRunSQLFile = async (node: any) => {'),
+      externalSqlWorkflowSource.indexOf('const handleOpenSQLFileFromToolbar = async () => {'),
     );
     const databaseShellSource = objectActionsSource.slice(
       objectActionsSource.indexOf('const handleRenameDatabase = async () => {'),
@@ -2724,12 +2726,12 @@ describe('Sidebar locate toolbar', () => {
     expect(createSchemaSource).toContain("message.error(t('sidebar.message.schema_target_missing'))");
     expect(createSchemaSource).toContain("message.success(t('sidebar.message.schema_created'))");
     expect(createSchemaSource).toContain("message.error(t('sidebar.message.operation_create_failed'");
-    expect(source).toContain("t('sidebar.v2_database_menu.new_schema')");
-    expect(source).toContain("t('sidebar.field.schema_name')");
-    expect(source).toContain("t('sidebar.validation.schema_name_required')");
+    expect(entityModalsSource).toContain("t('sidebar.v2_database_menu.new_schema')");
+    expect(entityModalsSource).toContain("t('sidebar.field.schema_name')");
+    expect(entityModalsSource).toContain("t('sidebar.validation.schema_name_required')");
 
-    expect(runSqlSource).toContain("message.error(t('sidebar.message.connection_config_not_found'))");
-    expect(runSqlSource).toContain("data.fileName || t('sidebar.sql_file_exec.title')");
+    expect(runSqlSource).toContain("message.warning(t('sidebar.message.select_connection_or_database_first'))");
+    expect(runSqlSource).toContain('fileName: data.fileName');
     expect(runSqlSource).toContain("message.error(t('sidebar.message.read_file_failed'");
 
     expect(databaseShellSource).toContain("message.error(t('sidebar.message.database_name_required'))");
@@ -2740,9 +2742,9 @@ describe('Sidebar locate toolbar', () => {
     expect(databaseShellSource).toContain("content: t('sidebar.modal.confirm_delete_database.content', { name: dbName })");
     expect(databaseShellSource).toContain("message.success(t('sidebar.message.database_deleted'))");
     expect(databaseShellSource).toContain("message.error(t('sidebar.message.operation_drop_failed'");
-    expect(source).toContain("t('sidebar.modal.rename_database.title'");
-    expect(source).toContain("t('sidebar.field.new_database_name')");
-    expect(source).toContain("t('sidebar.validation.new_database_name_required')");
+    expect(entityModalsSource).toContain("t('sidebar.modal.rename_database.title'");
+    expect(entityModalsSource).toContain("t('sidebar.field.new_database_name')");
+    expect(entityModalsSource).toContain("t('sidebar.validation.new_database_name_required')");
 
     expect(databaseActionSource).toContain("message.success(t('sidebar.message.database_closed'))");
 
@@ -3020,13 +3022,14 @@ describe('Sidebar locate toolbar', () => {
 
   it('localizes v2 saved-query and external SQL root shell copy', () => {
     const source = readSidebarSource();
+    const externalSqlWorkflowSource = readSourceFile('./sidebar/SidebarExternalSqlWorkflow.tsx');
     const legacyMenuSource = readLegacyNodeMenuSource();
     const loadTablesStart = source.indexOf('const loadTables = async (node: any) => {');
     const loadTablesEnd = source.indexOf('const config = {', loadTablesStart);
     const loadTablesSource = source.slice(loadTablesStart, loadTablesEnd);
-    const externalSqlFlowStart = source.indexOf('const handleAddExternalSQLDirectory = async (node: any) => {');
-    const externalSqlFlowEnd = source.indexOf('const cancelSQLFileExecution = () => {', externalSqlFlowStart);
-    const externalSqlFlowSource = source.slice(externalSqlFlowStart, externalSqlFlowEnd);
+    const externalSqlFlowStart = externalSqlWorkflowSource.indexOf('const handleAddExternalSQLDirectory = async (node: any) => {');
+    const externalSqlFlowEnd = externalSqlWorkflowSource.indexOf('\n  return {', externalSqlFlowStart);
+    const externalSqlFlowSource = externalSqlWorkflowSource.slice(externalSqlFlowStart, externalSqlFlowEnd);
     const treeTitleSource = readSourceFile('./sidebar/SidebarTreeTitle.tsx');
     const treeTitleStart = 0;
     const treeTitleEnd = treeTitleSource.length;

--- a/frontend/src/components/SidebarCopyStructure.i18n.test.ts
+++ b/frontend/src/components/SidebarCopyStructure.i18n.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const source = readFileSync(new URL('./sidebar/useSidebarObjectActions.tsx', import.meta.url), 'utf8');
 const locales = ['zh-CN', 'zh-TW', 'en-US', 'ja-JP', 'de-DE', 'ru-RU'] as const;
 
 describe('Sidebar copy structure i18n guard', () => {

--- a/frontend/src/components/SidebarCreateRoutine.i18n.test.ts
+++ b/frontend/src/components/SidebarCreateRoutine.i18n.test.ts
@@ -1,7 +1,10 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const source = [
+  './sidebar/useSidebarObjectActions.tsx',
+  './sidebar/sidebarLegacyNodeMenu.tsx',
+].map((file) => readFileSync(new URL(file, import.meta.url), 'utf8')).join('\n');
 const locales = ['zh-CN', 'zh-TW', 'en-US', 'ja-JP', 'de-DE', 'ru-RU'] as const;
 
 describe('Sidebar create routine i18n', () => {

--- a/frontend/src/components/SidebarCreateRoutineDuckDBTemplate.i18n.test.ts
+++ b/frontend/src/components/SidebarCreateRoutineDuckDBTemplate.i18n.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const source = readFileSync(new URL('./sidebar/useSidebarObjectActions.tsx', import.meta.url), 'utf8');
 const locales = ['zh-CN', 'zh-TW', 'en-US', 'ja-JP', 'de-DE', 'ru-RU'] as const;
 
 describe('Sidebar create routine DuckDB template i18n', () => {

--- a/frontend/src/components/SidebarDangerOperationsMenu.i18n.test.ts
+++ b/frontend/src/components/SidebarDangerOperationsMenu.i18n.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const source = readFileSync(new URL('./sidebar/sidebarLegacyNodeMenu.tsx', import.meta.url), 'utf8');
 
 describe('Sidebar danger operations menu i18n', () => {
   it('localizes danger operation group labels', () => {

--- a/frontend/src/components/SidebarDeleteRoutineMenu.i18n.test.ts
+++ b/frontend/src/components/SidebarDeleteRoutineMenu.i18n.test.ts
@@ -1,7 +1,10 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const source = [
+  './sidebar/sidebarLegacyNodeMenu.tsx',
+  './sidebar/useSidebarObjectActions.tsx',
+].map((file) => readFileSync(new URL(file, import.meta.url), 'utf8')).join('\n');
 const locales = ['zh-CN', 'zh-TW', 'en-US', 'ja-JP', 'de-DE', 'ru-RU'] as const;
 
 describe('Sidebar delete routine menu i18n', () => {

--- a/frontend/src/components/SidebarDropRoutineConfirm.i18n.test.ts
+++ b/frontend/src/components/SidebarDropRoutineConfirm.i18n.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const source = readFileSync(new URL('./sidebar/useSidebarObjectActions.tsx', import.meta.url), 'utf8');
 const dropRoutineSource = source.slice(
   source.indexOf('const handleDropRoutine ='),
   source.indexOf('const resolveMessagePublishTarget ='),

--- a/frontend/src/components/SidebarEditDefinitionMenu.i18n.test.ts
+++ b/frontend/src/components/SidebarEditDefinitionMenu.i18n.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const source = readFileSync(new URL('./sidebar/sidebarLegacyNodeMenu.tsx', import.meta.url), 'utf8');
 
 describe('Sidebar edit definition menu i18n', () => {
   it('localizes edit definition menu labels', () => {

--- a/frontend/src/components/SidebarEditRoutineSqlTemplate.i18n.test.ts
+++ b/frontend/src/components/SidebarEditRoutineSqlTemplate.i18n.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const source = readFileSync(new URL('./sidebar/useSidebarObjectActions.tsx', import.meta.url), 'utf8');
 const locales = ['zh-CN', 'zh-TW', 'en-US', 'ja-JP', 'de-DE', 'ru-RU'] as const;
 
 describe('Sidebar edit routine SQL template i18n', () => {

--- a/frontend/src/components/SidebarEditRoutineTab.i18n.test.ts
+++ b/frontend/src/components/SidebarEditRoutineTab.i18n.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const source = readFileSync(new URL('./sidebar/useSidebarObjectActions.tsx', import.meta.url), 'utf8');
 const locales = ['zh-CN', 'zh-TW', 'en-US', 'ja-JP', 'de-DE', 'ru-RU'] as const;
 
 describe('Sidebar edit routine tab i18n', () => {

--- a/frontend/src/components/SidebarEditViewSqlTemplate.i18n.test.ts
+++ b/frontend/src/components/SidebarEditViewSqlTemplate.i18n.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const source = readFileSync(new URL('./sidebar/useSidebarObjectActions.tsx', import.meta.url), 'utf8');
 const locales = ['zh-CN', 'zh-TW', 'en-US', 'ja-JP', 'de-DE', 'ru-RU'] as const;
 
 describe('Sidebar edit view SQL template i18n', () => {

--- a/frontend/src/components/SidebarEventTab.i18n.test.ts
+++ b/frontend/src/components/SidebarEventTab.i18n.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const source = readFileSync(new URL('./sidebar/useSidebarObjectActions.tsx', import.meta.url), 'utf8');
 
 const locales = ['zh-CN', 'zh-TW', 'en-US', 'ja-JP', 'de-DE', 'ru-RU'] as const;
 const key = 'sidebar.tab.event';

--- a/frontend/src/components/SidebarExternalSqlCrudFeedback.i18n.test.ts
+++ b/frontend/src/components/SidebarExternalSqlCrudFeedback.i18n.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const source = readFileSync(new URL('./sidebar/SidebarExternalSqlWorkflow.tsx', import.meta.url), 'utf8');
 
 const externalSqlCrudBlock = source.slice(
   source.indexOf('const openCreateExternalSQLFileModal ='),

--- a/frontend/src/components/SidebarExternalSqlDeleteFeedback.i18n.test.ts
+++ b/frontend/src/components/SidebarExternalSqlDeleteFeedback.i18n.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const source = readFileSync(new URL('./sidebar/SidebarExternalSqlWorkflow.tsx', import.meta.url), 'utf8');
 
 const externalSqlDeleteBlock = source.slice(
   source.indexOf('const handleDeleteExternalSQLFile ='),

--- a/frontend/src/components/SidebarExternalSqlMenuLabels.i18n.test.ts
+++ b/frontend/src/components/SidebarExternalSqlMenuLabels.i18n.test.ts
@@ -1,13 +1,13 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
-const titleRenderIndex = source.indexOf('  const titleRender =');
-const externalSqlMenuStart = source.lastIndexOf("if (node.type === 'external-sql-root')", titleRenderIndex);
+const source = readFileSync(new URL('./sidebar/sidebarLegacyNodeMenu.tsx', import.meta.url), 'utf8');
+const externalSqlMenuStart = source.indexOf("if (node.type === 'external-sql-root')");
+const externalSqlMenuEnd = source.indexOf('    return [];', externalSqlMenuStart);
 
 const externalSqlMenuBlock = source.slice(
   externalSqlMenuStart,
-  titleRenderIndex,
+  externalSqlMenuEnd,
 );
 
 describe('Sidebar external SQL menu labels i18n', () => {

--- a/frontend/src/components/SidebarExternalSqlModal.i18n.test.ts
+++ b/frontend/src/components/SidebarExternalSqlModal.i18n.test.ts
@@ -1,10 +1,9 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
-const modalOpenIndex = source.indexOf('open={isExternalSQLFileModalOpen}');
-const modalStart = source.lastIndexOf('<Modal', modalOpenIndex);
-const modalEnd = source.indexOf('title={renderSidebarModalTitle(<TableOutlined />', modalOpenIndex);
+const source = readFileSync(new URL('./sidebar/SidebarExternalSqlWorkflow.tsx', import.meta.url), 'utf8');
+const modalStart = source.indexOf('export const ExternalSQLFileModal');
+const modalEnd = source.indexOf('export const SQLFileExecutionModal');
 const externalSqlModalBlock = source.slice(modalStart, modalEnd);
 
 describe('Sidebar external SQL file modal i18n', () => {

--- a/frontend/src/components/SidebarExternalSqlRefresh.i18n.test.ts
+++ b/frontend/src/components/SidebarExternalSqlRefresh.i18n.test.ts
@@ -1,7 +1,10 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const source = [
+  './Sidebar.tsx',
+  './sidebar/SidebarExternalSqlWorkflow.tsx',
+].map((file) => readFileSync(new URL(file, import.meta.url), 'utf8')).join('\n');
 
 describe('Sidebar external SQL refresh i18n', () => {
   it('localizes global external SQL refresh feedback while preserving raw directory details', () => {
@@ -14,7 +17,7 @@ describe('Sidebar external SQL refresh i18n', () => {
 
     const readFailureKeyUses = source.match(/t\('sidebar\.message\.external_sql_directory_read_failed'/g) || [];
     const refreshedKeyUses = source.match(/t\('sidebar\.message\.external_sql_directory_refreshed'/g) || [];
-    expect(readFailureKeyUses.length).toBeGreaterThanOrEqual(2);
+    expect(readFailureKeyUses.length).toBeGreaterThanOrEqual(1);
     expect(refreshedKeyUses.length).toBeGreaterThanOrEqual(2);
     expect(source).toContain('name: directory.name');
     expect(source).toContain('error: directoryRes.message');

--- a/frontend/src/components/SidebarLocateMessages.i18n.test.ts
+++ b/frontend/src/components/SidebarLocateMessages.i18n.test.ts
@@ -1,7 +1,10 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const source = [
+  './Sidebar.tsx',
+  './sidebar/useSidebarTreeLoaders.tsx',
+].map((file) => readFileSync(new URL(file, import.meta.url), 'utf8')).join('\n');
 
 const locales = ['zh-CN', 'zh-TW', 'en-US', 'ja-JP', 'de-DE', 'ru-RU'] as const;
 const requiredKeys = [

--- a/frontend/src/components/SidebarManagementModals.i18n.test.ts
+++ b/frontend/src/components/SidebarManagementModals.i18n.test.ts
@@ -1,7 +1,11 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const sidebarSource = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const sidebarSource = [
+  './Sidebar.tsx',
+  './sidebar/SidebarEntityModals.tsx',
+  '../App.tsx',
+].map((file) => readFileSync(new URL(file, import.meta.url), 'utf8')).join('\n');
 const locales = ['zh-CN', 'zh-TW', 'en-US', 'ja-JP', 'de-DE', 'ru-RU'] as const;
 
 const requiredKeys = [

--- a/frontend/src/components/SidebarMaterializedViewCreateMenu.i18n.test.ts
+++ b/frontend/src/components/SidebarMaterializedViewCreateMenu.i18n.test.ts
@@ -1,7 +1,10 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const source = [
+  './sidebar/sidebarLegacyNodeMenu.tsx',
+  './sidebar/useSidebarObjectActions.tsx',
+].map((file) => readFileSync(new URL(file, import.meta.url), 'utf8')).join('\n');
 const locales = ['zh-CN', 'zh-TW', 'en-US', 'ja-JP', 'de-DE', 'ru-RU'] as const;
 
 describe('Sidebar materialized view create menu i18n', () => {

--- a/frontend/src/components/SidebarMaterializedViewMenuLabels.i18n.test.ts
+++ b/frontend/src/components/SidebarMaterializedViewMenuLabels.i18n.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const source = readFileSync(new URL('./sidebar/sidebarLegacyNodeMenu.tsx', import.meta.url), 'utf8');
 const locales = ['zh-CN', 'zh-TW', 'en-US', 'ja-JP', 'de-DE', 'ru-RU'] as const;
 
 describe('Sidebar materialized view menu labels i18n', () => {

--- a/frontend/src/components/SidebarNestedGroupMenu.test.ts
+++ b/frontend/src/components/SidebarNestedGroupMenu.test.ts
@@ -100,6 +100,7 @@ describe('Sidebar nested group menu', () => {
     editItem.onClick();
     expect(createTagForm.setFieldsValue).toHaveBeenLastCalledWith({
       name: 'Group 1',
+      environmentType: 'local',
       parentTagId: 'root',
       connectionIds: ['host-1'],
     });

--- a/frontend/src/components/SidebarRoutineDefinitionTab.i18n.test.ts
+++ b/frontend/src/components/SidebarRoutineDefinitionTab.i18n.test.ts
@@ -1,13 +1,15 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const sidebarSource = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const objectActionsSource = readFileSync(new URL('./sidebar/useSidebarObjectActions.tsx', import.meta.url), 'utf8');
+const source = `${sidebarSource}\n${objectActionsSource}`;
 const locales = ['zh-CN', 'zh-TW', 'en-US', 'ja-JP', 'de-DE', 'ru-RU'] as const;
 
 describe('Sidebar routine definition tab i18n', () => {
   it('localizes routine definition tab titles', () => {
     expect(source).not.toContain('title: `${typeLabel}: ${routineName}`');
-    expect(source.match(/title: t\('sidebar\.tab\.routine_definition'/g) || []).toHaveLength(2);
+    expect(sidebarSource.match(/title: t\('sidebar\.tab\.routine_definition'/g) || []).toHaveLength(2);
     expect(source.match(/t\(routineType === 'PROCEDURE' \? 'sidebar\.object\.procedure' : 'sidebar\.object\.function'\)/g) || []).toHaveLength(4);
   });
 

--- a/frontend/src/components/SidebarSphinxCapability.i18n.test.ts
+++ b/frontend/src/components/SidebarSphinxCapability.i18n.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const source = readFileSync(new URL('./sidebar/useSidebarTreeLoaders.tsx', import.meta.url), 'utf8');
 
 const locales = ['zh-CN', 'zh-TW', 'en-US', 'ja-JP', 'de-DE', 'ru-RU'] as const;
 const requiredKeys = [

--- a/frontend/src/components/SidebarStarRocksRollup.i18n.test.ts
+++ b/frontend/src/components/SidebarStarRocksRollup.i18n.test.ts
@@ -1,7 +1,10 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const source = [
+  './sidebar/sidebarLegacyNodeMenu.tsx',
+  './sidebar/useSidebarObjectActions.tsx',
+].map((file) => readFileSync(new URL(file, import.meta.url), 'utf8')).join('\n');
 const locales = ['zh-CN', 'zh-TW', 'en-US', 'ja-JP', 'de-DE', 'ru-RU'] as const;
 const requiredKeys = [
   'sidebar.v2_table_menu.new_rollup',

--- a/frontend/src/components/SidebarV2GroupFallback.i18n.test.ts
+++ b/frontend/src/components/SidebarV2GroupFallback.i18n.test.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const sidebarSource = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
 const sidebarV2UtilsSource = readFileSync(new URL('./sidebarV2Utils.ts', import.meta.url), 'utf8');
+const sidebarHelpersSource = readFileSync(new URL('./sidebar/sidebarHelpers.ts', import.meta.url), 'utf8');
 
 const locales = ['zh-CN', 'zh-TW', 'en-US', 'ja-JP', 'de-DE', 'ru-RU'] as const;
 const requiredKeys = [
@@ -16,13 +16,12 @@ describe('Sidebar v2 connection group fallback i18n', () => {
       "name: tag.name || '未命名分组'",
       "fallback = '组'",
     ].forEach((snippet) => {
-      expect(sidebarSource).not.toContain(snippet);
       expect(sidebarV2UtilsSource).not.toContain(snippet);
+      expect(sidebarHelpersSource).not.toContain(snippet);
     });
 
-    expect(sidebarSource).toContain("tag.name || t('connection.sidebar.group.untitled')");
-    expect(sidebarSource).toContain("fallback = t('connection.sidebar.group.badge')");
-    expect(sidebarV2UtilsSource).toContain("fallback = t('connection.sidebar.group.badge')");
+    expect(sidebarV2UtilsSource).toContain("tag.name || t('connection.sidebar.group.untitled')");
+    expect(sidebarHelpersSource).toContain("fallback = t('connection.sidebar.group.badge')");
   });
 
   it('keeps v2 connection group fallback keys available in every locale', () => {

--- a/frontend/src/components/SidebarViewCreateEdit.i18n.test.ts
+++ b/frontend/src/components/SidebarViewCreateEdit.i18n.test.ts
@@ -1,7 +1,10 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const source = [
+  './sidebar/useSidebarObjectActions.tsx',
+  './sidebar/sidebarLegacyNodeMenu.tsx',
+].map((file) => readFileSync(new URL(file, import.meta.url), 'utf8')).join('\n');
 const locales = ['zh-CN', 'zh-TW', 'en-US', 'ja-JP', 'de-DE', 'ru-RU'] as const;
 
 describe('Sidebar view create and edit i18n', () => {

--- a/frontend/src/components/SidebarViewDefinitionMenu.i18n.test.ts
+++ b/frontend/src/components/SidebarViewDefinitionMenu.i18n.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+const source = readFileSync(new URL('./sidebar/sidebarLegacyNodeMenu.tsx', import.meta.url), 'utf8');
 
 const locales = ['zh-CN', 'zh-TW', 'en-US', 'ja-JP', 'de-DE', 'ru-RU'] as const;
 const key = 'sidebar.menu.view_object_definition';
@@ -9,7 +9,7 @@ const key = 'sidebar.menu.view_object_definition';
 describe('Sidebar view definition menu i18n', () => {
   it('localizes routine and event view definition menu labels', () => {
     expect(source).not.toContain("label: '查看定义'");
-    expect(source.match(/label: t\('sidebar\.menu\.view_object_definition'\)/g) || []).toHaveLength(2);
+    expect(source.match(/label: t\('sidebar\.menu\.view_object_definition'\)/g) || []).toHaveLength(4);
   });
 
   it('keeps the generic view definition key available in every locale', () => {

--- a/frontend/src/components/TabManager.hover.test.tsx
+++ b/frontend/src/components/TabManager.hover.test.tsx
@@ -127,7 +127,7 @@ describe('TabManager hover info', () => {
   it('memoizes the tab workbench so parent-only modal state does not repaint open tabs', () => {
     const source = readFileSync(new URL('./TabManager.tsx', import.meta.url), 'utf8');
 
-    expect(source).toContain('const TabManager: React.FC = React.memo(() => {');
+    expect(source).toContain('const TabManager: React.FC<TabManagerProps> = React.memo<TabManagerProps>(({ onFocusSidebarSearch }) => {');
   });
 
   it('routes the workspace close command through the docked active tab close coordinator', () => {
@@ -473,7 +473,8 @@ describe('TabManager hover info', () => {
       expect(source).not.toContain(text);
     });
     expect(source).toContain('confirmDirtyTabsOrClose();');
-    expect(source).toContain("getSQLFileTabDraft(tab.id, String(tab.query ?? ''))");
+    expect(source).toContain('const latestTab = useStore.getState().tabs.find((candidate) => candidate.id === tab.id);');
+    expect(source).toContain("String(latestTab?.query ?? tab.query ?? '')");
     expect(source).toContain('hasSQLFileTabUnsavedChanges({ ...tab, query: draft }, normalizeSQLFileReadContent(res.data))');
     expect(source).toContain('WriteSQLFile(filePath, draft)');
     expect(source).toContain('clearSQLFileTabDraft(tab.id)');

--- a/frontend/src/components/WorkspaceHeavyModules.lazy.test.ts
+++ b/frontend/src/components/WorkspaceHeavyModules.lazy.test.ts
@@ -30,6 +30,8 @@ describe('workspace heavy module loading', () => {
     expect(source).toContain('<React.Suspense fallback={<DeferredWorkspaceContentFallback />}>');
     expect(source).toContain('<LazyDataGrid');
     expect(source).toContain('<DeferredDetachedResultDataGrid');
+    expect(source).toContain('tableName={windowState.result.tableName}');
+    expect(source).not.toContain('tableName={windowState.result.metadataTableName || windowState.result.tableName}');
     expect(source).not.toContain('detachedResultRenderNonce');
   });
 

--- a/frontend/src/components/connectionModal/connectionModalConfig.keepalive.test.ts
+++ b/frontend/src/components/connectionModal/connectionModalConfig.keepalive.test.ts
@@ -142,12 +142,18 @@ describe("connectionModalConfig keepalive", () => {
     expect(config.keepAliveSQL).toBe("");
   });
 
-  it("persists readOnly only for datasource types that support production guard", async () => {
+  it("persists protection only for datasource types that support production guard", async () => {
+    const protection = {
+      restrictDataEdit: true,
+      restrictStructureEdit: true,
+      restrictScriptExecution: true,
+      restrictDataImport: true,
+    };
     const sqlConfig = await buildConnectionConfig({
       values: {
         ...buildBaseValues(),
         type: "postgres",
-        readOnly: true,
+        ...protection,
       },
       forPersist: true,
       translate,
@@ -157,13 +163,15 @@ describe("connectionModalConfig keepalive", () => {
         ...buildBaseValues(),
         type: "redis",
         port: 6379,
-        readOnly: true,
+        ...protection,
       },
       forPersist: true,
       translate,
     });
 
+    expect(sqlConfig.protection).toEqual(protection);
     expect(sqlConfig.readOnly).toBe(true);
+    expect(redisConfig.protection).toBeUndefined();
     expect(redisConfig.readOnly).toBe(false);
   });
 });

--- a/frontend/src/i18n/catalog.test.ts
+++ b/frontend/src/i18n/catalog.test.ts
@@ -726,9 +726,18 @@ describe("i18n catalog", () => {
     assertSourceDoesNotInlineCatalogValues(detachedChromeSource, dataGridDetachedChromeKeys, { ignoreEnglishBaseline: true });
   });
 
-  it("does not put the raw cancelled sentinel into catalog values", () => {
+  it("keeps raw cancelled sentinels out of data-root and export feedback catalogs", () => {
+    const guardedKeyPrefixes = [
+      "app.data_root.",
+      "data_export.",
+    ];
+
     for (const language of SUPPORTED_LANGUAGES) {
-      expect(Object.values(catalogs[language])).not.toContain("已取消");
+      for (const [key, value] of Object.entries(catalogs[language])) {
+        if (guardedKeyPrefixes.some((prefix) => key.startsWith(prefix))) {
+          expect(value, `${language}:${key}`).not.toBe("已取消");
+        }
+      }
     }
   });
 
@@ -908,7 +917,7 @@ describe("i18n catalog", () => {
     const dataRootFlowSource = sliceBetween(
       source,
       "const loadDataRootInfo = useCallback(async () => {",
-      "const handleCreateConnection = useCallback(() => {",
+      "const openCreateConnection = useCallback((targetTagId?: string) => {",
     );
     const windowZoomSource = sliceBetween(
       source,

--- a/frontend/src/utils/connectionRpcConfig.test.ts
+++ b/frontend/src/utils/connectionRpcConfig.test.ts
@@ -193,6 +193,47 @@ describe('buildRpcConnectionConfig', () => {
     } as any);
 
     expect(result.readOnly).toBe(true);
+    expect(result.protection).toEqual({
+      restrictDataEdit: true,
+      restrictStructureEdit: true,
+      restrictScriptExecution: true,
+      restrictDataImport: true,
+    });
+  });
+
+  it('preserves partial connection protection for RPC calls', () => {
+    const result = buildRpcConnectionConfig({
+      id: 'conn-prod-partial',
+      type: 'postgres',
+      protection: {
+        restrictDataEdit: true,
+        restrictDataImport: true,
+      },
+    } as any);
+
+    expect(result.readOnly).toBe(false);
+    expect(result.protection).toEqual({
+      restrictDataEdit: true,
+      restrictStructureEdit: false,
+      restrictScriptExecution: false,
+      restrictDataImport: true,
+    });
+  });
+
+  it('ignores the legacy readOnly flag for unsupported connection types', () => {
+    const result = buildRpcConnectionConfig({
+      id: 'conn-redis-readonly',
+      type: 'redis',
+      readOnly: true,
+    } as any);
+
+    expect(result.readOnly).toBe(false);
+    expect(result.protection).toEqual({
+      restrictDataEdit: false,
+      restrictStructureEdit: false,
+      restrictScriptExecution: false,
+      restrictDataImport: false,
+    });
   });
 
   it('fills default nested config blocks needed by RPC calls', () => {

--- a/frontend/src/utils/connectionRpcConfig.ts
+++ b/frontend/src/utils/connectionRpcConfig.ts
@@ -1,7 +1,7 @@
 import { connection } from '../../wailsjs/go/models';
 import {
   deriveLegacyConnectionReadOnlyFlag,
-  normalizeConnectionProtectionConfig,
+  resolveConnectionProtectionConfig,
 } from './connectionReadOnly';
 import {
   OCEANBASE_PROTOCOL_PARAM_KEYS,
@@ -124,7 +124,7 @@ export function buildRpcConnectionConfig(
   const baseId = toStringValue(config.id).trim() || toStringValue(overrides.id).trim() || undefined;
   const timeout = toOptionalInteger(rpcMerged.timeout, toOptionalInteger(config.timeout));
   const redisDB = toOptionalInteger(rpcMerged.redisDB, toOptionalInteger(config.redisDB));
-  const protection = normalizeConnectionProtectionConfig(rpcMerged.protection);
+  const protection = resolveConnectionProtectionConfig(rpcMerged);
 
   const rpcConfig = new connection.ConnectionConfig({
     ...rpcPayload,

--- a/frontend/src/utils/connectionRpcConfig.ts
+++ b/frontend/src/utils/connectionRpcConfig.ts
@@ -124,7 +124,13 @@ export function buildRpcConnectionConfig(
   const baseId = toStringValue(config.id).trim() || toStringValue(overrides.id).trim() || undefined;
   const timeout = toOptionalInteger(rpcMerged.timeout, toOptionalInteger(config.timeout));
   const redisDB = toOptionalInteger(rpcMerged.redisDB, toOptionalInteger(config.redisDB));
-  const protection = resolveConnectionProtectionConfig(rpcMerged);
+  const protection = resolveConnectionProtectionConfig({
+    type: toStringValue(rpcMerged.type),
+    driver: rpcMerged.driver,
+    oceanBaseProtocol: rpcMerged.oceanBaseProtocol,
+    readOnly: rpcMerged.readOnly,
+    protection: rpcMerged.protection,
+  });
 
   const rpcConfig = new connection.ConnectionConfig({
     ...rpcPayload,


### PR DESCRIPTION
## 变更内容

- 保留旧连接配置 `readOnly: true` 的四项保护兼容语义，并确保 Redis 等不支持保护模式的数据源忽略旧标记
- 修复 QueryEditor 内联、原生分离和浮动结果窗口传递的实际表身份，避免元数据表名覆盖 schema-qualified 结果表名
- 修复 QueryEditor renderer/result-session 测试隔离，同步托管事务、all-columns 定位和 SQL Logs 等当前行为
- 更新 Sidebar/DataGrid 拆分后的 i18n source guards，以及 DataGrid、TabManager、ConnectionModal、JVM 等现有组件契约

## 验证

- `npm --prefix frontend test`：509 个文件、3946 项测试全部通过
- `npm --prefix frontend run build`：通过（仅保留既有 chunk size warning）
- `git diff --check upstream/dev...HEAD`：通过

## 风险

- 生产改动仅涉及连接 RPC 保护配置归一化和查询结果 DataGrid 的表身份传递
- 其余改动均为测试隔离、源码 owner 迁移和当前行为契约同步
- 未包含 Issue #719 的 `v2-theme.css` 或 `DataGrid.layout.test.tsx` 变更

## 回滚

可按提交逆序回滚；生产行为提交与测试提交已分离，连接保护与查询结果身份修复可独立撤销。