### PR TITLE
🐛 fix(tabs): 恢复活动标签顶部强调条

### DIFF
--- a/frontend/src/components/TabManager.adaptive-width.test.ts
+++ b/frontend/src/components/TabManager.adaptive-width.test.ts
@@ -52,12 +52,12 @@ describe('v2 workbench adaptive tab width', () => {
     );
   });
 
-  it('rounds all four corners without drawing an accent bar above the active tab', () => {
+  it('rounds all four corners and highlights the active tab from within its border', () => {
     expect(themeSource).toMatch(
       /\.gn-v2-main-tabs \.ant-tabs-tab \{[^}]*border-radius: 8px !important;/s,
     );
-    expect(themeSource).not.toMatch(
-      /\.gn-v2-main-tabs \.ant-tabs-tab\.ant-tabs-tab-active \{[^}]*box-shadow:/s,
+    expect(themeSource).toMatch(
+      /\.gn-v2-main-tabs \.ant-tabs-tab\.ant-tabs-tab-active \{[^}]*box-shadow: inset 0 2px 0 var\(--gn-accent\) !important;/s,
     );
     expect(themeSource).toMatch(
       /\.gn-v2-main-tabs \.ant-tabs-tab\.ant-tabs-tab-active::after \{[^}]*display: none;/s,

--- a/frontend/src/v2-theme.css
+++ b/frontend/src/v2-theme.css
@@ -3713,6 +3713,10 @@ body[data-ui-version="v2"] .gn-v2-main-tabs .ant-tabs-tab {
   border-radius: 8px !important;
 }
 
+body[data-ui-version="v2"] .gn-v2-main-tabs .ant-tabs-tab.ant-tabs-tab-active {
+  box-shadow: inset 0 2px 0 var(--gn-accent) !important;
+}
+
 body[data-ui-version="v2"] .gn-v2-main-tabs .ant-tabs-tab.ant-tabs-tab-active::after {
   display: none;
 }


### PR DESCRIPTION
## 变更内容

- 恢复 V2 工作区活动标签顶部绿色强调条
- 保留标签四角圆角与顶部伪元素屏蔽逻辑
- 更新活动标签视觉回归断言

## 验证

- `npm test -- --run src/components/TabManager.adaptive-width.test.ts`（7/7 通过）
- `npx tsc --noEmit --pretty false`（通过）
- `git diff --check origin/dev...HEAD`（通过）

## 影响范围

- 仅影响 V2 工作区活动标签的顶部强调样式
- 不修改标题栏主题逻辑、legacy UI 或 Wails 生成文件