### PR TITLE
🐛 fix: 修复 Issue #734

### DIFF
--- a/internal/redis/redis_impl.go
+++ b/internal/redis/redis_impl.go
@@ -649,9 +649,6 @@ func (r *RedisClientImpl) ScanKeys(pattern string, cursor uint64, count int64) (
 			}
 			seen[key] = struct{}{}
 			keys = append(keys, key)
-			if len(keys) >= int(targetCount) {
-				break
-			}
 		}
 
 		currentCursor = nextCursor

--- a/internal/redis/redis_impl_test.go
+++ b/internal/redis/redis_impl_test.go
@@ -97,6 +97,50 @@ func redisBulkString(value string) string {
 	return fmt.Sprintf("$%d\r\n%s\r\n", len(value), value)
 }
 
+func TestScanKeysKeepsEntireRedisScanBatch(t *testing.T) {
+	addr := startRedisProtocolTestServer(t, func(args []string) string {
+		switch strings.ToUpper(strings.TrimSpace(args[0])) {
+		case "HELLO":
+			return "-ERR unknown command 'HELLO'\r\n"
+		case "CLIENT":
+			return "-ERR unknown subcommand\r\n"
+		case "SCAN":
+			return "*2\r\n$2\r\n42\r\n*3\r\n$5\r\nalpha\r\n$4\r\nbeta\r\n$5\r\ngamma\r\n"
+		case "TYPE":
+			return "+string\r\n"
+		case "TTL":
+			return ":-1\r\n"
+		}
+		return "+OK\r\n"
+	})
+
+	rawClient := goredis.NewClient(&goredis.Options{
+		Addr:     addr,
+		Protocol: 2,
+	})
+	client := &RedisClientImpl{
+		client:       rawClient,
+		singleClient: rawClient,
+	}
+	defer client.Close()
+
+	result, err := client.ScanKeys("*", 0, 1)
+	if err != nil {
+		t.Fatalf("ScanKeys returned error: %v", err)
+	}
+	if result.Cursor != "42" {
+		t.Fatalf("expected next cursor 42, got %q", result.Cursor)
+	}
+	if len(result.Keys) != 3 {
+		t.Fatalf("expected all 3 keys from the Redis SCAN batch, got %#v", result.Keys)
+	}
+	for index, key := range []string{"alpha", "beta", "gamma"} {
+		if result.Keys[index].Key != key {
+			t.Fatalf("expected key %q at index %d, got %#v", key, index, result.Keys)
+		}
+	}
+}
+
 // 回归保护：HGETALL 在 RESP3 下返回 map[interface{}]interface{}（go-redis v9 默认 RESP3），
 // 这种类型 encoding/json 无法序列化，原值穿透到 Wails RPC 会让 Windows 进程退出（用户感知闪退）。
 // formatCommandResult 必须把 map 平展成交错 [k1, v1, k2, v2, ...] array，前端按 array 渲染。


### PR DESCRIPTION
## 关联 Issue

Closes #734

## 变更内容

Redis 的 `SCAN COUNT` 参数仅是返回数量提示，服务端单个批次可能返回超过请求数量的 Key。原实现达到目标数量后会在批次内部提前退出，同时继续使用该批次返回的下一游标，导致批次尾部未处理的 Key 被永久跳过。

本次修复改为完整保留当前 `SCAN` 批次返回的 Key，再推进游标；并增加协议级回归测试，覆盖服务端返回数量超过 `COUNT` 的场景。影响范围仅限非集群 Redis Key 扫描。

## 测试结果

- `go test ./internal/redis -run '^TestScanKeysKeepsEntireRedisScanBatch$' -count=1`：通过
- `go test ./internal/redis -count=1`：通过
- `go test ./internal/ai/provider -run '^TestClaudeCLIProvider_ChatStreamAllowsDelayedMeaningfulResponse$' -count=5`：通过，用于确认首次全量测试中的超时为时序抖动
- `go test ./...`：存在失败；在相同环境、相同提交基点 `2d1034e7` 上对 `upstream/dev` 运行同一命令后，失败用例名称集合与本分支完全一致，均来自 `internal/ai/service`、`internal/app`、`internal/db`、`internal/jvm`；`internal/redis` 在两次全量测试中均通过
- `git diff --check`：通过

## 风险说明

不涉及数据写入、数据迁移或配置格式变化。单批扫描结果可能略多于前端请求的目标数量，这是 Redis `SCAN COUNT` 语义允许的行为，可避免游标推进造成 Key 遗漏。回滚方式为撤销本 PR 提交。
