### PR TITLE
🐛 fix(query-editor): 修复 SQL 美化后横向视口偏移

### DIFF
--- a/frontend/src/components/QueryEditor.external-sql-save.test.tsx
+++ b/frontend/src/components/QueryEditor.external-sql-save.test.tsx
@@ -209,6 +209,7 @@ const editorState = vi.hoisted(() => {
     },
     position: { lineNumber: 1, column: 1 },
     selection: null as any,
+    scrollLeft: 0,
     providers: [] as any[],
     providerLanguages: [] as string[],
     hoverProviders: [] as any[],
@@ -291,6 +292,10 @@ const editorState = vi.hoisted(() => {
     }),
     setSelections: vi.fn((selections: any[]) => {
       state.selection = Array.isArray(selections) ? selections[0] ?? null : null;
+    }),
+    getScrollLeft: vi.fn(() => state.scrollLeft),
+    setScrollLeft: vi.fn((scrollLeft: number) => {
+      state.scrollLeft = scrollLeft;
     }),
     executeEdits: vi.fn((_source: string, edits: any[]) => {
       edits.forEach((edit) => {
@@ -897,6 +902,7 @@ describe('QueryEditor external SQL save', () => {
     editorState.value = '';
     editorState.position = { lineNumber: 1, column: 1 };
     editorState.selection = null;
+    editorState.scrollLeft = 0;
     monacoEditorMockState.latestProps = null;
     editorState.domNode.style.cursor = '';
     editorState.providers = [];
@@ -919,6 +925,8 @@ describe('QueryEditor external SQL save', () => {
     editorState.editor.getModel().getValueLength.mockClear();
     editorState.editor.setValue.mockClear();
     editorState.editor.executeEdits.mockClear();
+    editorState.editor.getScrollLeft.mockClear();
+    editorState.editor.setScrollLeft.mockClear();
     editorState.editor.deltaDecorations.mockClear();
     editorState.editor.updateOptions.mockClear();
     editorState.editor.pushUndoStop.mockClear();
@@ -4425,6 +4433,26 @@ describe('QueryEditor external SQL save', () => {
         createdAt: expect.any(Number),
       },
     });
+  });
+
+  it('resets stale horizontal scroll after formatting a long single-line SQL statement', async () => {
+    let renderer!: ReactTestRenderer;
+    const longSql = `select ${Array.from({ length: 80 }, (_, index) => `column_${index + 1}`).join(', ')} from users where id=1`;
+
+    await act(async () => {
+      renderer = create(<QueryEditor tab={createTab({ query: longSql })} />);
+    });
+
+    editorState.scrollLeft = 2400;
+
+    const formatButton = findButton(renderer, '美化');
+    await act(async () => {
+      await formatButton.props.onClick();
+    });
+
+    expect(editorState.editor.executeEdits).toHaveBeenCalled();
+    expect(editorState.editor.setScrollLeft).toHaveBeenCalledWith(0);
+    expect(editorState.scrollLeft).toBe(0);
   });
 
   it('formats only the selected SQL when a non-empty selection exists', async () => {

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -6178,6 +6178,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
               const nextValue = editor.getValue?.();
               applyQueryState(typeof nextValue === 'string' ? nextValue : (formatSelection ? currentValue : formatted));
               refreshObjectDecorations();
+              editor.setScrollLeft?.(0);
               return;
       }
       if (formatSelection) {


### PR DESCRIPTION
## 背景

关闭自动换行时，超长单行 SQL 会把 Monaco 编辑器横向滚动到右侧。执行 SQL 美化后，文本已经被拆成多行并回到左侧，但编辑器仍保留格式化前的横向滚动位置，导致当前视口停留在右侧空白区域，直到用户再次点击编辑器。

Closes #696

## 修复内容

- SQL 格式化通过 Monaco executeEdits 成功更新文本后，将横向滚动位置重置到起点
- 保留原有格式化内容、选区处理、纵向滚动和 undo/redo 行为
- 补充超长单行 SQL 在关闭自动换行时的横向滚动回归测试

## 影响范围

- 仅影响查询编辑器中成功执行 SQL 美化后的横向视口位置
- 不修改 SQL formatter 配置、格式化结果、快捷键注册或编辑器布局
- 开启自动换行时归零操作为幂等行为，不改变现有展示

## 验证

- QueryEditor 完整组件测试通过：280/280
- TypeScript 类型检查通过
- Vite 生产打包通过，仅有项目现有 chunk-size warning