### PR TITLE
🐛 fix: 修复 Issue #753

### DIFF
--- a/frontend/src/components/QueryEditor.external-sql-save.test.tsx
+++ b/frontend/src/components/QueryEditor.external-sql-save.test.tsx
@@ -225,6 +225,8 @@ const editorState = vi.hoisted(() => {
     decorationIds: [] as string[],
     contentHoverCalls: [] as any[],
     latestOnChange: null as null | ((value?: string) => void),
+    transformToUppercaseRun: vi.fn(),
+    transformToLowercaseRun: vi.fn(),
   };
   const offsetAt = (position: { lineNumber: number; column: number }) => {
     const text = state.value;
@@ -303,6 +305,15 @@ const editorState = vi.hoisted(() => {
         const end = offsetAt({ lineNumber: edit.range.endLineNumber, column: edit.range.endColumn });
         state.value = state.value.slice(0, start) + edit.text + state.value.slice(end);
       });
+    }),
+    getAction: vi.fn((id: string) => {
+      if (id === 'editor.action.transformToUppercase') {
+        return { run: state.transformToUppercaseRun };
+      }
+      if (id === 'editor.action.transformToLowercase') {
+        return { run: state.transformToLowercaseRun };
+      }
+      return null;
     }),
     addAction: vi.fn(),
     addCommand: vi.fn(),
@@ -925,6 +936,9 @@ describe('QueryEditor external SQL save', () => {
     editorState.editor.getModel().getValueLength.mockClear();
     editorState.editor.setValue.mockClear();
     editorState.editor.executeEdits.mockClear();
+    editorState.editor.getAction.mockClear();
+    editorState.transformToUppercaseRun.mockReset();
+    editorState.transformToLowercaseRun.mockReset();
     editorState.editor.getScrollLeft.mockClear();
     editorState.editor.setScrollLeft.mockClear();
     editorState.editor.deltaDecorations.mockClear();
@@ -4824,6 +4838,36 @@ describe('QueryEditor external SQL save', () => {
     }));
   });
 
+  it('registers SQL case conversion context-menu actions and delegates to Monaco', async () => {
+    await act(async () => {
+      create(<QueryEditor tab={createTab()} />);
+    });
+
+    const uppercaseAction = findEditorAction('gonavi.queryEditor.transformToUppercase');
+    const lowercaseAction = findEditorAction('gonavi.queryEditor.transformToLowercase');
+
+    expect(uppercaseAction).toMatchObject({
+      label: '转大写',
+      precondition: '!editorReadonly',
+      contextMenuGroupId: '1_modification',
+      contextMenuOrder: 1,
+    });
+    expect(lowercaseAction).toMatchObject({
+      label: '转小写',
+      precondition: '!editorReadonly',
+      contextMenuGroupId: '1_modification',
+      contextMenuOrder: 2,
+    });
+
+    await uppercaseAction.run(editorState.editor);
+    await lowercaseAction.run(editorState.editor);
+
+    expect(editorState.editor.getAction).toHaveBeenNthCalledWith(1, 'editor.action.transformToUppercase');
+    expect(editorState.editor.getAction).toHaveBeenNthCalledWith(2, 'editor.action.transformToLowercase');
+    expect(editorState.transformToUppercaseRun).toHaveBeenCalledOnce();
+    expect(editorState.transformToLowercaseRun).toHaveBeenCalledOnce();
+  });
+
   it('localizes Monaco action labels for the active language', async () => {
     setCurrentLanguage('en-US');
     storeState.shortcutOptions.runQuery.mac = { enabled: true, combo: 'Meta+Q' };
@@ -4845,6 +4889,12 @@ describe('QueryEditor external SQL save', () => {
     });
     expect(findEditorAction('gonavi.insertSqlSnippet')).toMatchObject({
       label: 'Insert SQL Snippet',
+    });
+    expect(findEditorAction('gonavi.queryEditor.transformToUppercase')).toMatchObject({
+      label: 'convert to uppercase',
+    });
+    expect(findEditorAction('gonavi.queryEditor.transformToLowercase')).toMatchObject({
+      label: 'convert to lowercase',
     });
     expect(findEditorAction('gonavi.selectCurrentStatement')).toMatchObject({
       label: 'GoNavi: Select Current Line and Copy',
@@ -4878,6 +4928,12 @@ describe('QueryEditor external SQL save', () => {
     expect(findEditorAction('gonavi.insertSqlSnippet')).toMatchObject({
       label: '插入 SQL 片段',
     });
+    expect(findEditorAction('gonavi.queryEditor.transformToUppercase')).toMatchObject({
+      label: '转大写',
+    });
+    expect(findEditorAction('gonavi.queryEditor.transformToLowercase')).toMatchObject({
+      label: '转小写',
+    });
     expect(findEditorAction('gonavi.selectCurrentStatement')).toMatchObject({
       label: 'GoNavi: 选择当前行并复制',
     });
@@ -4897,6 +4953,8 @@ describe('QueryEditor external SQL save', () => {
     expect(findEditorActionLabels('gonavi.queryEditor.showObjectInfo')).toContain('GoNavi: Show Object Info');
     expect(findEditorActionLabels('gonavi.runQuery')).toContain('GoNavi: Run SQL');
     expect(findEditorActionLabels('gonavi.insertSqlSnippet')).toContain('Insert SQL Snippet');
+    expect(findEditorActionLabels('gonavi.queryEditor.transformToUppercase')).toContain('convert to uppercase');
+    expect(findEditorActionLabels('gonavi.queryEditor.transformToLowercase')).toContain('convert to lowercase');
     expect(findEditorActionLabels('gonavi.selectCurrentStatement')).toContain('GoNavi: Select Current Line and Copy');
     expect(findEditorActionLabels('gonavi.duplicateCurrentLine')).toContain('GoNavi: Duplicate Current Line Below');
     expect(findEditorActionLabels('gonavi.saveQuery')).toContain('GoNavi: Save Query');
@@ -4908,6 +4966,12 @@ describe('QueryEditor external SQL save', () => {
     });
     expect(findEditorAction('gonavi.insertSqlSnippet')).toMatchObject({
       label: 'Insert SQL Snippet',
+    });
+    expect(findEditorAction('gonavi.queryEditor.transformToUppercase')).toMatchObject({
+      label: 'convert to uppercase',
+    });
+    expect(findEditorAction('gonavi.queryEditor.transformToLowercase')).toMatchObject({
+      label: 'convert to lowercase',
     });
     expect(findEditorAction('gonavi.selectCurrentStatement')).toMatchObject({
       label: 'GoNavi: Select Current Line and Copy',

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -1365,6 +1365,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
   const triggerSqlAiCompletionActionRef = useRef<any>(null);
   const triggerSqlAiCompletionKeydownDisposableRef = useRef<any>(null);
   const insertSqlSnippetActionRef = useRef<any>(null);
+  const transformCaseActionDisposablesRef = useRef<any[]>([]);
   const aiContextMenuActionDisposablesRef = useRef<any[]>([]);
   const toggleQueryResultsPanelActionRef = useRef<any>(null);
   const lastExternalQueryRef = useRef<string>(getTabQueryValue(tab));
@@ -1628,6 +1629,36 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
           run: handleOpenSqlSnippetPicker,
       });
   }, [handleOpenSqlSnippetPicker]);
+
+  const disposeTransformCaseContextMenuActions = useCallback(() => {
+      transformCaseActionDisposablesRef.current.forEach((disposable) => disposable?.dispose?.());
+      transformCaseActionDisposablesRef.current = [];
+  }, []);
+
+  const registerTransformCaseContextMenuActions = useCallback((editor: any) => {
+      disposeTransformCaseContextMenuActions();
+      transformCaseActionDisposablesRef.current = [
+          {
+              id: 'gonavi.queryEditor.transformToUppercase',
+              label: translate('query_editor.completion.action.uppercase'),
+              actionId: 'editor.action.transformToUppercase',
+              contextMenuOrder: 1,
+          },
+          {
+              id: 'gonavi.queryEditor.transformToLowercase',
+              label: translate('query_editor.completion.action.lowercase'),
+              actionId: 'editor.action.transformToLowercase',
+              contextMenuOrder: 2,
+          },
+      ].map((action) => editor.addAction({
+          id: action.id,
+          label: action.label,
+          precondition: '!editorReadonly',
+          contextMenuGroupId: '1_modification',
+          contextMenuOrder: action.contextMenuOrder,
+          run: (ed: any) => ed.getAction?.(action.actionId)?.run?.(),
+      }));
+  }, [disposeTransformCaseContextMenuActions]);
 
   // SQL 诊断 / 慢 SQL 历史的快捷键监听（必须在 binding 声明之后）
   useEffect(() => {
@@ -4795,6 +4826,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
               sharedActiveEditorModelUri = '';
           }
           disposeQueryEditorAiContextMenuActions();
+          disposeTransformCaseContextMenuActions();
           window.removeEventListener('keydown', syncModifierState);
           window.removeEventListener('keyup', syncModifierState);
           window.removeEventListener('blur', handleWindowBlur);
@@ -4811,6 +4843,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
       // 注册 AI 右键菜单操作
       registerQueryEditorAiContextMenuActions(editor);
       registerInsertSqlSnippetContextMenuAction(editor);
+      registerTransformCaseContextMenuActions(editor);
       registerTriggerSqlAiCompletionAction(editor, monaco);
 
       // Register runQuery shortcut inside Monaco so it overrides Monaco's default keybinding
@@ -7738,6 +7771,17 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
           }
       };
   }, [languagePreference, registerInsertSqlSnippetContextMenuAction]);
+
+  useEffect(() => {
+      const editor = editorRef.current;
+      if (!editor) return;
+
+      registerTransformCaseContextMenuActions(editor);
+
+      return () => {
+          disposeTransformCaseContextMenuActions();
+      };
+  }, [languagePreference, disposeTransformCaseContextMenuActions, registerTransformCaseContextMenuActions]);
 
   useEffect(() => {
       const editor = editorRef.current;


### PR DESCRIPTION
## 关联 Issue

Closes #753

## 变更内容

SQL 查询编辑器此前未将 Monaco 已内置的文本大小写转换能力暴露到右键菜单。

- 新增“转大写”和“转小写”右键菜单项
- 复用 Monaco 内建 action，保留选区、多光标、Unicode 与撤销栈行为；无选区时转换当前词
- 在编辑器销毁及语言切换时清理、重建 action，确保菜单文案实时本地化
- 补充菜单注册、配置、内建 action 转发和中英文刷新回归测试

影响范围仅限 SQL 查询编辑器，不修改通用 Monaco 编辑器及其他编辑器类型。

## 测试结果

- `npm --prefix frontend test -- src/components/QueryEditor.external-sql-save.test.tsx`：通过，281 tests
- `npm --prefix frontend run build`：通过
- `npm --prefix frontend test`：3374/3376 通过；2 项 upstream 基线测试失败，与本 PR 修改文件无关：
  - `QueryEditorToolbar.layout.test.tsx` 仍断言旧的 `--gn-accent-soft`，当前 upstream CSS 已改为 `--gn-warn`
  - `connectionTypeCatalog.test.ts` 未纳入 upstream 新增的 `config_center` 分组

测试前还发现 upstream 生成文件 `frontend/wailsjs/go/models.ts` 中 `StartSecurityUpdateRequest` 与 Nacos 类型结构错位，导致 Vitest 无法收集；验证时临时归位后运行测试和构建，随后已恢复为 upstream 原状，未包含在本 PR。

## 风险说明

- 不涉及数据结构、数据库数据或后端接口变更
- 不涉及兼容性变化，行为委托给当前 Monaco 内建转换 action
- 回滚方式为撤销本 PR 提交；仅会移除新增右键菜单及其测试
