### PR TITLE
🐛 fix(test): 修复前端基线测试断言

### DIFF
--- a/frontend/src/components/QueryEditorToolbar.layout.test.tsx
+++ b/frontend/src/components/QueryEditorToolbar.layout.test.tsx
@@ -65,8 +65,10 @@ describe('QueryEditorToolbar layout', () => {
 
     expect(css).toContain('.gn-v2-query-transaction-commit-button:hover');
     expect(css).toContain('.gn-v2-query-transaction-commit-button:focus-visible');
-    expect(commitBaseCss).toContain('background: var(--gn-accent-soft) !important;');
-    expect(commitHoverCss).not.toContain('background: var(--gn-accent-soft) !important;');
+    expect(commitBaseCss).toContain('background: var(--gn-warn) !important;');
+    expect(commitHoverCss).toContain(
+      'background: var(--gn-warn-hover, var(--gn-warn)) !important;',
+    );
     expect(commitHoverCss).toContain('box-shadow:');
     expect(commitKbdHoverCss).toContain('background:');
   });

--- a/frontend/src/utils/connectionTypeCatalog.test.ts
+++ b/frontend/src/utils/connectionTypeCatalog.test.ts
@@ -15,6 +15,7 @@ const translatedCopy: Record<string, string> = {
   'connection_modal.step1.group.vector': 'T:vector',
   'connection_modal.step1.group.timeseries': 'T:timeseries',
   'connection_modal.step1.group.message_queue': 'T:message-queue',
+  'connection_modal.step1.group.config_center': 'T:config-center',
   'connection_modal.step1.group.other': 'T:other',
   'connection_modal.step1.hint.redis': 'T:redis',
   'connection_modal.step1.hint.mongodb': 'T:mongodb',
@@ -22,6 +23,7 @@ const translatedCopy: Record<string, string> = {
   'connection_modal.step1.hint.chroma': 'T:chroma',
   'connection_modal.step1.hint.qdrant': 'T:qdrant',
   'connection_modal.step1.hint.milvus': 'T:milvus',
+  'connection_modal.step1.hint.nacos': 'T:nacos',
   'connection_modal.step1.hint.oceanBase': 'T:oceanbase',
   'connection_modal.step1.hint.goldendb': 'T:goldendb',
   'connection_modal.step1.hint.file': 'T:file',
@@ -40,6 +42,7 @@ describe('connectionTypeCatalog', () => {
       'connection_modal.step1.group.vector',
       'connection_modal.step1.group.timeseries',
       'connection_modal.step1.group.message_queue',
+      'connection_modal.step1.group.config_center',
       'connection_modal.step1.group.other',
     ]);
     expect(buildConnectionTypeGroups(translate).map((group) => group.label)).toEqual([
@@ -49,6 +52,7 @@ describe('connectionTypeCatalog', () => {
       'T:vector',
       'T:timeseries',
       'T:message-queue',
+      'T:config-center',
       'T:other',
     ]);
     expect(
@@ -71,6 +75,7 @@ describe('connectionTypeCatalog', () => {
     expect(keys).toContain('milvus');
     expect(keys).toContain('iotdb');
     expect(keys).toContain('kafka');
+    expect(keys).toContain('nacos');
     expect(keys).toContain('jvm');
     expect(keys).toContain('custom');
     expect(new Set(keys).size).toBe(keys.length);
@@ -93,6 +98,7 @@ describe('connectionTypeCatalog', () => {
     expect(getConnectionTypeDefaultPort('milvus')).toBe(19530);
     expect(getConnectionTypeDefaultPort('iotdb')).toBe(6667);
     expect(getConnectionTypeDefaultPort('kafka')).toBe(9092);
+    expect(getConnectionTypeDefaultPort('nacos')).toBe(8848);
     expect(getConnectionTypeDefaultPort('sqlite')).toBe(0);
     expect(getConnectionTypeDefaultPort('duckdb')).toBe(0);
     expect(getConnectionTypeDefaultPort('unknown')).toBe(3306);
@@ -107,6 +113,7 @@ describe('connectionTypeCatalog', () => {
     expect(getConnectionTypeHint('milvus', translate)).toBe('T:milvus');
     expect(getConnectionTypeHint('iotdb')).toContain('Timeseries');
     expect(getConnectionTypeHint('kafka')).toContain('Consumer Group');
+    expect(getConnectionTypeHint('nacos', translate)).toBe('T:nacos');
     expect(getConnectionTypeHint('oceanbase', translate)).toBe('T:oceanbase');
     expect(getConnectionTypeHint('goldendb', translate)).toBe('T:goldendb');
     expect(getConnectionTypeHint('trino')).toBe('HTTP / HTTPS / catalog.schema');


### PR DESCRIPTION
## 变更内容

同步两处落后于当前生产实现的前端测试契约：

- 更新 SQL 工具栏提交按钮断言：基础态使用 `--gn-warn`，交互态使用 `--gn-warn-hover`
- 补齐 Nacos 配置中心分组的 catalog 测试，覆盖分组顺序、支持类型、默认端口 `8848` 和本地化提示

两项生产实现均为既有有意变更，本 PR 只修复遗漏的测试维护，不改变运行时行为。

## 测试结果

- `npm --prefix frontend test -- src/components/QueryEditorToolbar.layout.test.tsx src/utils/connectionTypeCatalog.test.ts`：通过，10 tests
- 主题、连接弹窗及 i18n 相关测试：通过，47 tests
- `npm --prefix frontend test`：通过，3375 tests / 411 test files
- `npm --prefix frontend run build`：通过
- `git diff --check`：通过

当前 upstream 的 `frontend/wailsjs/go/models.ts` 存在 `StartSecurityUpdateRequest` 与 Nacos 类型结构错位，原始状态会阻塞部分测试收集和构建。完整验证期间仅临时归位该生成类型，验证结束后已恢复为 upstream 原状；该文件未包含在本 PR。

## 风险说明

- 不涉及生产代码、数据或接口变更
- 仅更新测试对既有 UI token 和连接类型目录的预期
- 回滚方式为撤销本 PR 提交
