### PR TITLE
🐛 fix: 修复 Issue #764

### DIFF
--- a/frontend/src/components/TabManager.empty-workbench.layout.test.ts
+++ b/frontend/src/components/TabManager.empty-workbench.layout.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { readV2ThemeCss } from '../test/readV2ThemeCss';
+
+describe('empty workbench layout', () => {
+  it('keeps hero actions from overlapping recent cards in small windows', () => {
+    const css = readV2ThemeCss();
+    const heroSelector = 'body[data-ui-version="v2"] .gn-v2-empty-hero {';
+    const firstHeroRule = css.indexOf(heroSelector);
+    const heroRule = css.slice(
+      css.indexOf(heroSelector, firstHeroRule + heroSelector.length),
+      css.indexOf('body[data-ui-version="v2"] .gn-v2-empty-eyebrow {'),
+    );
+
+    expect(heroRule).toContain('flex: 0 0 auto;');
+  });
+});

--- a/frontend/src/v2-theme.css
+++ b/frontend/src/v2-theme.css
@@ -3342,6 +3342,7 @@ body[data-ui-version="v2"] .gn-v2-empty-hero {
 }
 
 body[data-ui-version="v2"] .gn-v2-empty-hero {
+  flex: 0 0 auto;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;


### PR DESCRIPTION
## 关联 Issue

Closes #764

## 变更内容

工作台首页使用纵向 Flex 布局，窗口缩小后下方卡片区域增高，Hero 区域会被压缩，但其内容仍向外绘制，导致操作按钮与最近记录卡片重叠。

- 将工作台首页 Hero 设置为不可收缩，确保按钮区域始终按内容高度占位
- 保留现有响应式换行和工作台滚动行为
- 新增布局契约测试，防止该约束回退

影响范围仅限 v2 工作台空白首页布局。

## 测试结果

- `npm --prefix frontend test -- --run src/components/TabManager.empty-workbench.layout.test.ts`：通过，1 个测试通过
- `git diff --check`：通过
- `npm --prefix frontend test`：受 `upstream/dev` 已知的 `frontend/wailsjs/go/models.ts:806` 生成代码语法错误阻断；该基线错误已在另一 PR 修复
- `npm --prefix frontend run build`：受同一已知基线错误阻断

## 风险说明

不涉及数据变更、接口变更或兼容性变化。回滚时撤销 Hero 的 `flex: 0 0 auto` 及对应回归测试即可。