### PR TITLE
🐛 fix: 修复 Issue #763

### DIFF
--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -114,6 +114,7 @@ import {
     collectDataGridFindResult,
     findDataGridTextRanges,
     hasDataGridFindRenderVersionChanged,
+    matchesDataGridColumnQuickFind,
     normalizeDataGridFindQuery,
     resolveDataGridColumnQuickFindTarget,
     resolveDataGridFindNavigationIndex,
@@ -4446,7 +4447,7 @@ const DataGrid: React.FC<DataGridProps> = ({
   const visibleColumnQuickFindMatches = useMemo(() => {
       if (!normalizedColumnQuickFindText) return [];
       return displayColumnNames.filter((columnName) => (
-          normalizeDataGridFindQuery(columnName).includes(normalizedColumnQuickFindText)
+          matchesDataGridColumnQuickFind(columnName, normalizedColumnQuickFindText)
       ));
   }, [displayColumnNames, normalizedColumnQuickFindText]);
 

--- a/frontend/src/utils/dataGridFind.test.ts
+++ b/frontend/src/utils/dataGridFind.test.ts
@@ -6,6 +6,7 @@ import {
   collectDataGridFindResult,
   findDataGridTextRanges,
   hasDataGridFindRenderVersionChanged,
+  matchesDataGridColumnQuickFind,
   normalizeDataGridFindQuery,
   resolveDataGridColumnQuickFindTarget,
   resolveDataGridFindNavigationIndex,
@@ -118,6 +119,16 @@ describe('dataGridFind', () => {
     expect(resolveDataGridColumnQuickFindTarget(columnNames, 'user')).toBe('user_id');
     expect(resolveDataGridColumnQuickFindTarget(columnNames, '  ')).toBe('');
     expect(resolveDataGridColumnQuickFindTarget(columnNames, 'missing')).toBe('');
+  });
+
+  it('matches quick-find column names without case sensitivity', () => {
+    const columnNames = ['USER_NAME_ARCHIVE', 'USER_NAME', 'CREATED_AT'];
+
+    expect(matchesDataGridColumnQuickFind('USER_NAME', 'user')).toBe(true);
+    expect(matchesDataGridColumnQuickFind('user_name', 'USER')).toBe(true);
+    expect(matchesDataGridColumnQuickFind('USER_NAME', 'missing')).toBe(false);
+    expect(resolveDataGridColumnQuickFindTarget(columnNames, 'user_name')).toBe('USER_NAME');
+    expect(resolveDataGridColumnQuickFindTarget(columnNames, 'created')).toBe('CREATED_AT');
   });
 
   it('tracks render version changes without exposing metadata as row data', () => {

--- a/frontend/src/utils/dataGridFind.ts
+++ b/frontend/src/utils/dataGridFind.ts
@@ -179,6 +179,16 @@ export const resolveDataGridFindNavigationIndex = (
   return currentIndex < 0 || currentIndex >= matchCount - 1 ? 0 : currentIndex + 1;
 };
 
+export const matchesDataGridColumnQuickFind = (
+  columnName: string,
+  query: string,
+): boolean => {
+  const normalizedQuery = normalizeDataGridFindQuery(query).toLocaleLowerCase();
+  if (!normalizedQuery) return false;
+
+  return normalizeDataGridFindQuery(columnName).toLocaleLowerCase().includes(normalizedQuery);
+};
+
 export const resolveDataGridColumnQuickFindTarget = (
   columnNames: string[],
   query: string,
@@ -186,12 +196,13 @@ export const resolveDataGridColumnQuickFindTarget = (
   const normalizedQuery = normalizeDataGridFindQuery(query);
   if (!normalizedQuery) return '';
 
+  const lowerQuery = normalizedQuery.toLocaleLowerCase();
   const exactMatch = columnNames.find((columnName) => (
-    normalizeDataGridFindQuery(columnName) === normalizedQuery
+    normalizeDataGridFindQuery(columnName).toLocaleLowerCase() === lowerQuery
   ));
   if (exactMatch) return exactMatch;
 
   return columnNames.find((columnName) => (
-    normalizeDataGridFindQuery(columnName).includes(normalizedQuery)
+    matchesDataGridColumnQuickFind(columnName, normalizedQuery)
   )) || '';
 };


### PR DESCRIPTION
## 关联 Issue

Closes #763

## 变更内容

跳列功能此前直接按原始大小写比较输入内容与字段名，导致 OceanBase Oracle 等返回大写字段名时，小写输入无法匹配。

本次将跳列候选过滤、精确匹配和模糊匹配统一调整为大小写无关匹配，同时保留原有的精确匹配优先顺序。影响范围仅限表数据视图的跳列功能。

## 测试结果

- `npm --prefix frontend test -- src/utils/dataGridFind.test.ts`：通过，13/13
- `git diff --check`：通过
- `npm --prefix frontend test`：未全部通过；上游 `dev` 的 `frontend/wailsjs/go/models.ts` 存在语法错误，导致 62 个测试文件转换失败，另有 2 个与本次改动无关的基线断言失败
- `npm --prefix frontend run build`：未通过；同一上游 `frontend/wailsjs/go/models.ts` 语法错误导致 TypeScript 编译失败，该文件与 `upstream/dev` 一致且未被本 PR 修改

## 风险说明

不涉及数据变更或数据库兼容性变化。行为变化仅为跳列字段名匹配忽略大小写；回滚本 PR 即可恢复原行为。