### PR TITLE
🐛 fix: 修复 Issue #762

### DIFF
--- a/frontend/src/components/QueryEditor.external-sql-save.test.tsx
+++ b/frontend/src/components/QueryEditor.external-sql-save.test.tsx
@@ -4550,6 +4550,32 @@ describe('QueryEditor external SQL save', () => {
     expect(messageApi.success).toHaveBeenCalledWith('已还原到美化前 SQL');
   });
 
+  it('formats OceanBase Oracle SQL with parameter placeholders', async () => {
+    let renderer!: ReactTestRenderer;
+    storeState.connections[0].config.type = 'oceanbase';
+    (storeState.connections[0].config as any).oceanBaseProtocol = 'oracle';
+    const oracleSql = 'select * from users where id = #{id,jdbcType=NUMBER} and tenant = ${tenant} and status = :status and code = ?';
+
+    await act(async () => {
+      renderer = create(<QueryEditor tab={createTab({ query: oracleSql, dbName: 'main' })} />);
+    });
+
+    const formatButton = findButton(renderer, '美化');
+    await act(async () => {
+      await formatButton.props.onClick();
+    });
+
+    expect(messageApi.error).not.toHaveBeenCalled();
+    expect(editorState.editor.executeEdits).toHaveBeenCalledWith(
+      'gonavi-format-sql',
+      expect.arrayContaining([
+        expect.objectContaining({
+          text: expect.stringMatching(/#\{id,jdbcType=NUMBER\}[\s\S]*\$\{tenant\}[\s\S]*:status[\s\S]*\?/),
+        }),
+      ]),
+    );
+  });
+
   it('formats postgres window-function SQL with cast syntax through Monaco edits', async () => {
     let renderer!: ReactTestRenderer;
     storeState.connections[0].config.type = 'postgres';

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -221,6 +221,13 @@ const QUERY_EDITOR_MAC_FIND_WITH_SELECTION_GUARD_ACTION_ID = 'gonavi.suppressMac
 const QUERY_EDITOR_AI_INLINE_DEBOUNCE_MS = 220;
 const QUERY_EDITOR_AI_INLINE_CONTEXT_KEY = 'gonaviAiInlineSuggestionVisible';
 const QUERY_EDITOR_IME_FALLBACK_DELAY_MS = 80;
+const QUERY_EDITOR_FORMAT_PARAM_TYPES = {
+    positional: true,
+    custom: [
+        { regex: String.raw`#\{[^{}]+\}` },
+        { regex: String.raw`\$\{[^{}]+\}` },
+    ],
+};
 const EMPTY_QUERY_EDITOR_SQL_LOGS: SqlLog[] = [];
 
 const isOceanBaseOracleConnection = (config: any): boolean => {
@@ -6149,7 +6156,11 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
           const formatSelection = !!selection && !!selectedRaw.trim();
           const fullQuery = getCurrentQuery();
           const sourceSql = formatSelection ? selectedRaw : fullQuery;
-          const formatted = format(sourceSql, { language: formatterLanguage, keywordCase: sqlFormatOptions.keywordCase });
+          const formatted = format(sourceSql, {
+              language: formatterLanguage,
+              keywordCase: sqlFormatOptions.keywordCase,
+              paramTypes: QUERY_EDITOR_FORMAT_PARAM_TYPES,
+          });
           if (sourceSql === formatted) {
               return;
           }


### PR DESCRIPTION
## 关联 Issue

Closes #762

## 变更内容

SQL 美化入口此前未配置模板参数类型，`sql-formatter` 在 OceanBase Oracle 方言下遇到 MyBatis 风格占位符时会抛出语法解析错误。

本次为 SQL 美化补充参数占位符识别：

- 支持位置参数 `?`
- 支持 `#{...}` 与 `${...}` 模板参数
- 保留各数据库方言原有的命名参数规则，例如 Oracle 的 `:name`
- 占位符仅作为参数 Token 参与格式化，不替换或修改其内容
- 补充 OceanBase Oracle 占位符格式化回归测试

影响范围仅限 SQL 编辑器美化功能。

## 测试结果

- `npm --prefix frontend test -- src/components/QueryEditor.external-sql-save.test.tsx`：通过，281 个测试全部通过
- `npm --prefix frontend run build`：通过
- `npm --prefix frontend test`：3374 个通过，2 个上游既有测试失败；分别为 Nacos 连接类型目录期望未更新、工具栏 hover CSS 断言过期，均与本 PR 修改无关且已由其他 PR 修复
- `git diff --check`：通过

## 风险说明

- 不涉及数据变更或数据库迁移
- 不改变 SQL 执行逻辑
- 仅扩展格式化器可识别的参数占位符语法
- 回滚时还原本 PR 提交即可