### PR TITLE
✨ feat(data-grid): 支持隐藏表格行号列 (#790)

### DIFF
--- a/frontend/src/components/DataGrid.layout.test.tsx
+++ b/frontend/src/components/DataGrid.layout.test.tsx
@@ -58,6 +58,7 @@ vi.mock('../store', () => ({
       dataTableDensity: 'comfortable',
       uiVersion: mockStoreState.uiVersion,
     },
+    setAppearance: vi.fn(),
     queryOptions: {
       showColumnComment: false,
       showColumnType: false,

--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -327,6 +327,7 @@ const DataGrid: React.FC<DataGridProps> = ({
   const addSqlLog = useStore(state => state.addSqlLog);
   const theme = useStore(state => state.theme);
   const appearance = useStore(state => state.appearance);
+  const setAppearance = useStore(state => state.setAppearance);
   const uiScale = useStore(state => state.uiScale);
   const queryOptions = useStore(state => state.queryOptions);
   const setQueryOptions = useStore(state => state.setQueryOptions);
@@ -3897,6 +3898,7 @@ const DataGrid: React.FC<DataGridProps> = ({
           darkMode={darkMode}
           showColumnComment={showColumnComment}
           showColumnType={showColumnType}
+          showRowNumberColumn={resolvedShowRowNumberColumn}
           columnSearchText={columnSearchText}
           allOrderedColumnNames={allOrderedColumnNames}
           localHiddenColumns={localHiddenColumns}
@@ -3907,6 +3909,7 @@ const DataGrid: React.FC<DataGridProps> = ({
           translate={translateDataGrid}
           onShowColumnCommentChange={(checked) => setQueryOptions({ showColumnComment: checked })}
           onShowColumnTypeChange={(checked) => setQueryOptions({ showColumnType: checked })}
+          onShowRowNumberColumnChange={(checked) => setAppearance({ showDataTableRowNumber: checked })}
           onToggleAllColumnsVisibility={toggleAllColumnsVisibility}
           onColumnSearchTextChange={setColumnSearchText}
           onToggleColumnVisibility={toggleColumnVisibility}

--- a/frontend/src/components/DataGridColumnInfoPopoverContent.test.tsx
+++ b/frontend/src/components/DataGridColumnInfoPopoverContent.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('antd', async () => {
+  const ReactModule = await import('react');
+  const Checkbox = ({ checked, children, onChange }: any) => ReactModule.createElement(
+    'label',
+    null,
+    ReactModule.createElement('input', {
+      type: 'checkbox',
+      checked,
+      'data-label': children,
+      onChange,
+    }),
+    children,
+  );
+  const Input = ({ value, onChange }: any) => ReactModule.createElement('input', { value, onChange });
+  Input.TextArea = ({ value, onChange }: any) => ReactModule.createElement('textarea', { value, onChange });
+  const Button = ({ children, onClick }: any) => ReactModule.createElement('button', { onClick }, children);
+  return { Button, Checkbox, Input };
+});
+
+import DataGridColumnInfoPopoverContent from './DataGridColumnInfoPopoverContent';
+
+describe('DataGridColumnInfoPopoverContent', () => {
+  it('allows the row number column to be hidden from the column settings', () => {
+    const onShowRowNumberColumnChange = vi.fn();
+    const renderer = create(
+      <DataGridColumnInfoPopoverContent
+        darkMode={false}
+        showColumnComment
+        showColumnType
+        showRowNumberColumn
+        columnSearchText=""
+        allOrderedColumnNames={['id', 'name']}
+        localHiddenColumns={[]}
+        enableColumnOrderMemory={false}
+        enableHiddenColumnMemory={false}
+        canResetOrder={false}
+        canResetHidden={false}
+        translate={(key) => key === 'app.theme.data_table.row_number' ? 'Show row numbers' : key}
+        onShowColumnCommentChange={() => {}}
+        onShowColumnTypeChange={() => {}}
+        onShowRowNumberColumnChange={onShowRowNumberColumnChange}
+        onToggleAllColumnsVisibility={() => {}}
+        onColumnSearchTextChange={() => {}}
+        onToggleColumnVisibility={() => {}}
+        onEnableColumnOrderMemoryChange={() => {}}
+        onEnableHiddenColumnMemoryChange={() => {}}
+        onResetOrder={() => {}}
+        onResetHidden={() => {}}
+      />,
+    );
+
+    const rowNumberCheckbox = renderer.root.findAllByType('input')
+      .find((input) => input.props['data-label'] === 'Show row numbers');
+    expect(rowNumberCheckbox).toBeDefined();
+
+    act(() => rowNumberCheckbox?.props.onChange({ target: { checked: false } }));
+    expect(onShowRowNumberColumnChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/frontend/src/components/DataGridColumnInfoPopoverContent.tsx
+++ b/frontend/src/components/DataGridColumnInfoPopoverContent.tsx
@@ -15,6 +15,7 @@ export interface DataGridColumnInfoPopoverContentProps {
   darkMode: boolean;
   showColumnComment: boolean;
   showColumnType: boolean;
+  showRowNumberColumn: boolean;
   columnSearchText: string;
   allOrderedColumnNames: string[];
   localHiddenColumns: string[];
@@ -25,6 +26,7 @@ export interface DataGridColumnInfoPopoverContentProps {
   translate?: DataGridColumnInfoTranslate;
   onShowColumnCommentChange: (checked: boolean) => void;
   onShowColumnTypeChange: (checked: boolean) => void;
+  onShowRowNumberColumnChange: (checked: boolean) => void;
   onToggleAllColumnsVisibility: (visible: boolean) => void;
   onColumnSearchTextChange: (value: string) => void;
   onToggleColumnVisibility: (columnName: string, visible: boolean) => void;
@@ -40,6 +42,7 @@ const DataGridColumnInfoPopoverContent: React.FC<DataGridColumnInfoPopoverConten
   darkMode,
   showColumnComment,
   showColumnType,
+  showRowNumberColumn,
   columnSearchText,
   allOrderedColumnNames,
   localHiddenColumns,
@@ -50,6 +53,7 @@ const DataGridColumnInfoPopoverContent: React.FC<DataGridColumnInfoPopoverConten
   translate = defaultTranslate,
   onShowColumnCommentChange,
   onShowColumnTypeChange,
+  onShowRowNumberColumnChange,
   onToggleAllColumnsVisibility,
   onColumnSearchTextChange,
   onToggleColumnVisibility,
@@ -112,6 +116,13 @@ const DataGridColumnInfoPopoverContent: React.FC<DataGridColumnInfoPopoverConten
         allowClear
       />
       <div className="custom-scrollbar" style={{ maxHeight: 220, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 4 }}>
+        <Checkbox
+          checked={showRowNumberColumn}
+          onChange={(e) => onShowRowNumberColumnChange(e.target.checked)}
+          style={{ marginLeft: 0 }}
+        >
+          {translate('app.theme.data_table.row_number')}
+        </Checkbox>
         {allOrderedColumnNames
           .filter((col) => !columnSearchText || col.toLowerCase().includes(columnSearchText.toLowerCase()))
           .map((col) => (


### PR DESCRIPTION
## 关联 Issue

Closes #790

## 问题根因

表格行号列原本只能通过应用外观设置控制，表格高频使用的“字段显示”入口没有提供隐藏“#”列的操作。

## 修复方案

在现有“字段显示”面板的列可见性列表中增加“显示数据表行号”复选框，复用已有的 `appearance.showDataTableRowNumber` 状态和持久化逻辑。关闭后移除行号表头及行号单元格，重新勾选即可恢复；默认行为保持为显示行号。

## 验证结果

| 验证项 | 命令或步骤 | 结果 |
| --- | --- | --- |
| 回归测试 | `npm --prefix frontend test -- src/components/DataGridColumnInfoPopoverContent.test.tsx src/components/DataGrid.layout.test.tsx src/i18n/catalog.test.ts` | 通过，86 个测试 |
| 生产构建 | `npm --prefix frontend run build` | 通过 |
| 差异检查 | `git diff --check` | 通过 |
| 手动 GUI 验证 | `?devHarness=datagrid-perf&rows=20&uiVersion=v2`，在 1280×720 视口打开 Column display，取消并重新勾选 Show Data Table Row Numbers | 通过：默认表头存在，取消后表头消失，恢复后表头重新出现 |

完整前端测试 `npm --prefix frontend test` 在 upstream/dev 基线中已有 5 个失败用例（ConnectionModal.i18n 4 个、QueryEditor.results-and-drop 1 个），本 PR 未修改相关代码，已单独记录并另开分支处理。

## 风险与兼容性

- 不改变数据、配置格式、公共 API 或数据库行为。
- 复用现有外观设置字段，因此旧配置和默认显示行为保持兼容。
- 仅影响 DataGrid 行号列的可见性；表格数据列、分页和编辑逻辑不变。
- 已验证范围覆盖 V2 UI 的 1280×720 视口；未在真实数据库连接上执行数据操作验证。

## 回滚方式

回滚提交 `f4856e2580a34c9b6f07bed777a729f9f88d20b3` 即可恢复原有字段显示面板和行号开关入口，不涉及数据或配置迁移。
