### PR TITLE
✅ test(frontend): 同步基线测试契约

### DIFF
--- a/frontend/src/components/ConnectionModal.i18n.test.tsx
+++ b/frontend/src/components/ConnectionModal.i18n.test.tsx
@@ -768,8 +768,8 @@ describe("ConnectionModal i18n", () => {
     pageText = textContent(renderer!.toJSON());
     expect(pageText).toContain("Replica set / multi-node");
     expect(pageText).toContain("Standard address");
-    expect(pageText).toContain("Auth database (authSource)");
-    expect(pageText).toContain("Read preference (readPreference)");
+    expect(pageText).toContain("Auth");
+    expect(pageText).toContain("Mode");
     expect(pageText).toContain("Read from the primary node only.");
     expect(pageText).toContain("Auth");
     expect(pageText).toContain("Auto-negotiate");
@@ -1051,7 +1051,7 @@ describe("ConnectionModal i18n", () => {
       );
     });
     await act(async () => {
-      findClickableByAnyText(renderer!, ["Basic information", "基础信息"]).props.onClick();
+      findClickableByAnyText(renderer!, ["Basic", "基础信息"]).props.onClick();
     });
     expect(textContent(renderer!.toJSON())).toContain("Auto");
 
@@ -1175,7 +1175,7 @@ describe("ConnectionModal i18n", () => {
     });
 
     await act(async () => {
-      findButton(renderer!, "Generate URI").props.onClick();
+      findButton(renderer!, "Generate from fields").props.onClick();
     });
 
     expect(textContent(renderer!.toJSON())).toContain("URI generated.");
@@ -1226,7 +1226,7 @@ describe("ConnectionModal i18n", () => {
     await act(async () => {
       expandUriSection(renderer!);
     });
-    const parseUriButton = findButton(renderer!, "Parse from URI");
+    const parseUriButton = findButton(renderer!, "Parse & fill");
     expect(parseUriButton, textContent(renderer!.toJSON())).toBeDefined();
     await act(async () => {
       parseUriButton.props.onClick();

--- a/frontend/src/components/QueryEditor.results-and-drop.test.tsx
+++ b/frontend/src/components/QueryEditor.results-and-drop.test.tsx
@@ -4464,6 +4464,15 @@ describe('QueryEditor external SQL save', () => {
         rows: [{ COMPID: 1, MEMCARDNO: 'M-1', MODIFYUSER: 'admin', MODIFYTIME: '2026-07-10' }],
       }],
     });
+    backendApp.DBGetColumns.mockResolvedValueOnce({
+      success: true,
+      data: [
+        { name: 'COMPID', key: '' },
+        { name: 'MEMCARDNO', key: '' },
+        { name: 'MODIFYUSER', key: '' },
+        { name: 'MODIFYTIME', key: '' },
+      ],
+    });
 
     let renderer: ReactTestRenderer;
     await act(async () => {


### PR DESCRIPTION
## 背景

`upstream/dev` 的完整前端测试存在 5 个基线失败：ConnectionModal i18n 4 个、QueryEditor 1 个。本 PR 仅同步测试契约和 fixture，不修改生产逻辑。

## 根因

- ConnectionModal 测试仍使用 UI 重构前的完整导航和 URI 操作文案；当前界面已使用密排短标签 `Auth`、`Mode`、`Basic`、`Generate from fields`、`Parse & fill`。
- QueryEditor 多行单表测试没有提供结果列元数据，触发当前生产代码对空列元数据的只读保护，导致测试期望的 `all-columns` 定位器无法生成。

## 修复方案

- 更新 ConnectionModal i18n 测试中的过时可见文案和按钮定位。
- 为 QueryEditor 目标测试补充四个结果列的 `DBGetColumns` mock，保留可编辑 `all-columns` 行为断言。
- 保留生产代码的空元数据只读保护，不回退近期系统视图安全修复。

## 验证结果

| 验证项 | 命令 | 结果 |
| --- | --- | --- |
| 失败用例修复 | `npm --prefix frontend test -- src/components/ConnectionModal.i18n.test.tsx src/components/QueryEditor.results-and-drop.test.tsx` | 通过，134 个测试 |
| 完整前端测试 | `npm --prefix frontend test` | 通过，424 个测试文件、3506 个测试 |
| 生产构建 | `npm --prefix frontend run build` | 通过 |
| 差异检查 | `git diff --check` | 通过 |

## 影响范围

仅测试文案和测试 fixture 变化，不改变生产行为、配置、依赖或数据格式。

## 回滚方式

回滚提交 `d42e2ad8e8d3056904d9eb3fb6dc94a96a179717` 即可恢复原测试文件。
