### PR TITLE
🔧 fix(message):修复打开表数据时，提示 data_viewer.edit_hint.all_columns_locator …

### DIFF
--- a/frontend/src/utils/rowLocator.ts
+++ b/frontend/src/utils/rowLocator.ts
@@ -81,6 +81,8 @@ export const buildAllColumnsLocator = (
     .filter(Boolean)
     .filter((column) => !isInternalLocatorColumn(column))
     .filter((column) => !hidden.has(column.toLowerCase()));
+  console.log(options);
+
   return {
     strategy: 'all-columns',
     columns,
@@ -88,7 +90,7 @@ export const buildAllColumnsLocator = (
     hiddenColumns: options?.hiddenColumns,
     writableColumns: options?.writableColumns,
     readOnly: false,
-    reason: translateReason(options?.translate, ALL_COLUMNS_LOCATOR_HINT_KEY),
+    reason: translateReason(options?.translate, translateCatalog(ALL_COLUMNS_LOCATOR_HINT_KEY)),
   };
 };
 


### PR DESCRIPTION
问题：当表没有主键是提示为应为字符没有翻译成友好提示
<img width="1226" height="157" alt="image" src="https://github.com/user-attachments/assets/5650fe6c-fc67-4281-a361-b967f89f21b6" />
增加i18n转换
修复后如下
<img width="1318" height="112" alt="image" src="https://github.com/user-attachments/assets/213cf541-4ed8-4e89-b652-a01194673d8b" />
