### PR TITLE
🐛 fix(sidebar): 刷新连接资源后保留展开状态

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -199,6 +199,7 @@ import {
   isConnectionTagDescendant,
   normalizeSidebarTreeRelativeDropPosition,
   resolveSidebarConnectionIdFromKey,
+  resolveSidebarConnectionRefreshKeys,
   resolveSidebarDropInsertBefore,
   resolveSidebarDropNodeFromDomEvent,
   resolveSidebarDropTargetMetricsFromDomEvent,
@@ -234,6 +235,7 @@ export {
   isConnectionTagDescendant,
   normalizeSidebarTreeRelativeDropPosition,
   resolveSidebarConnectionIdFromKey,
+  resolveSidebarConnectionRefreshKeys,
   resolveSidebarDropInsertBefore,
   resolveSidebarDropNodeFromDomEvent,
   resolveSidebarDropTargetMetricsFromDomEvent,
@@ -2291,6 +2293,76 @@ const Sidebar: React.FC<{
   loadNacosServiceGroupsRef.current = loadNacosServiceGroups;
   replaceTreeNodeChildrenRef.current = replaceTreeNodeChildren;
 
+  // Rehydrate descendants that were open before the connection loader replaces its tree.
+  const refreshConnectionResources = async (node: any): Promise<void> => {
+      const connectionId = String(node?.key || node?.dataRef?.id || '').trim();
+      if (!connectionId) return;
+
+      const expandedKeysToReload = resolveSidebarConnectionRefreshKeys({
+          treeData: treeDataRef.current,
+          expandedKeys: expandedKeysRef.current,
+          connectionId,
+      });
+
+      setLoadedKeys((previous) => previous.filter((key) => !isConnectionTreeKey(key, connectionId)));
+      Array.from(loadingNodesRef.current).forEach((loadingKey) => {
+          if (loadingKey === `dbs-${connectionId}` || loadingKey.startsWith(`tables-${connectionId}-`)) {
+              loadingNodesRef.current.delete(loadingKey);
+          }
+      });
+
+      await loadDatabases(node);
+
+      const loadedKeysToRestore = new Set<string>();
+      const refreshedConnection = findTreeNodeByKeyRef.current(treeDataRef.current, connectionId);
+      if (refreshedConnection?.children?.length) {
+          loadedKeysToRestore.add(connectionId);
+      }
+
+      for (const key of expandedKeysToReload) {
+          if (key === connectionId) continue;
+          if (!expandedKeysRef.current.some((expandedKey) => String(expandedKey) === key)) {
+              continue;
+          }
+          const currentNode = findTreeNodeByKeyRef.current(treeDataRef.current, key);
+          if (!currentNode) continue;
+
+          await onLoadData(currentNode);
+          const loadedNode = findTreeNodeByKeyRef.current(treeDataRef.current, key);
+          if (loadedNode?.children?.length) {
+              loadedKeysToRestore.add(key);
+          }
+      }
+
+      const availableConnectionKeys = new Set<string>();
+      const collectConnectionKeys = (nodes: TreeNode[]) => {
+          nodes.forEach((treeNode) => {
+              const key = String(treeNode.key || '').trim();
+              if (key && isConnectionTreeKey(key, connectionId)) {
+                  availableConnectionKeys.add(key);
+              }
+              if (treeNode.children?.length) collectConnectionKeys(treeNode.children);
+          });
+      };
+      collectConnectionKeys(treeDataRef.current);
+      const expandedKeysBeforeRefresh = new Set(expandedKeysToReload);
+
+      setExpandedKeys((previous) => previous.filter((key) => {
+          const keyText = String(key);
+          return !isConnectionTreeKey(keyText, connectionId)
+              || !expandedKeysBeforeRefresh.has(keyText)
+              || availableConnectionKeys.has(keyText);
+      }));
+      setLoadedKeys((previous) => {
+          const next = previous.filter((key) => {
+              const keyText = String(key);
+              return !isConnectionTreeKey(keyText, connectionId) || availableConnectionKeys.has(keyText);
+          });
+          loadedKeysToRestore.forEach((key) => next.push(key));
+          return Array.from(new Set(next));
+      });
+  };
+
   useEffect(() => {
       const handleNacosServicesChanged = (event: Event) => {
           const target = resolveNacosServiceGroupsRefreshTarget(
@@ -2606,6 +2678,7 @@ const Sidebar: React.FC<{
       pinnedSidebarTables,
       loadingNodesRef,
       treeDataRef,
+      refreshConnectionResources,
       findTreeNodeByKeyRef,
       refreshV2TableContextMenuStatsRef,
       setConnectionStates,
@@ -2858,6 +2931,7 @@ const Sidebar: React.FC<{
     setLoadedKeys,
     loadingNodesRef,
     loadDatabases,
+    refreshConnectionResources,
     buildConnectionRootRedisCommandTabTitle,
     buildConnectionRootRedisMonitorTabTitle,
     onEditConnection,

--- a/frontend/src/components/sidebar/sidebarLegacyNodeMenu.tsx
+++ b/frontend/src/components/sidebar/sidebarLegacyNodeMenu.tsx
@@ -309,6 +309,7 @@ export const buildSidebarLegacyNodeMenuItems = (
     setLoadedKeys,
     loadingNodesRef,
     loadDatabases,
+    refreshConnectionResources: refreshConnectionResourcesFromContext,
     buildConnectionRootRedisCommandTabTitle,
     buildConnectionRootRedisMonitorTabTitle,
     onEditConnection,
@@ -375,6 +376,10 @@ export const buildSidebarLegacyNodeMenuItems = (
     handleDeleteExternalSQLFile,
     extractObjectName,
   } = context;
+    const refreshConnectionResources = refreshConnectionResourcesFromContext || ((targetNode: any) => {
+      loadDatabases(targetNode);
+      return Promise.resolve();
+    });
     const conn = node.dataRef as SavedConnection;
     const isRedis = conn?.config?.type === 'redis';
     const isNacos = conn?.config?.type === 'nacos';
@@ -591,15 +596,7 @@ export const buildSidebarLegacyNodeMenuItems = (
                     label: t('sidebar.menu.refresh'),
                     icon: <ReloadOutlined />,
                     onClick: () => {
-                        const connKey = String(node.key);
-                        // 清除子节点的展开/已加载状态，确保刷新后重新展开时能触发 onLoadData
-                        setExpandedKeys((prev: any[]) => prev.filter((k: any) => !k.toString().startsWith(`${connKey}-`)));
-                        setLoadedKeys((prev: any[]) => prev.filter((k: any) => !k.toString().startsWith(`${connKey}-`)));
-                        // 清除 loadingNodesRef 中残留的子节点加载标记
-                        Array.from(loadingNodesRef.current as Set<string>).forEach(lk => {
-                            if (lk.startsWith(`tables-${connKey}-`)) loadingNodesRef.current.delete(lk);
-                        });
-                        loadDatabases(node);
+                        void refreshConnectionResources(node);
                     }
                 },
                 { type: 'divider' },
@@ -680,10 +677,7 @@ export const buildSidebarLegacyNodeMenuItems = (
                     label: t('sidebar.menu.refresh'),
                     icon: <ReloadOutlined />,
                     onClick: () => {
-                        const connKey = String(node.key);
-                        setExpandedKeys((prev: any[]) => prev.filter((k: any) => !k.toString().startsWith(`${connKey}-`)));
-                        setLoadedKeys((prev: any[]) => prev.filter((k: any) => !k.toString().startsWith(`${connKey}-`)));
-                        loadDatabases(node);
+                        void refreshConnectionResources(node);
                     },
                 },
                 {
@@ -770,15 +764,7 @@ export const buildSidebarLegacyNodeMenuItems = (
                 label: t('sidebar.menu.refresh'),
                 icon: <ReloadOutlined />,
                 onClick: () => {
-                    const connKey = String(node.key);
-                    // 清除子节点的展开/已加载状态，确保刷新后重新展开时能触发 onLoadData
-                    setExpandedKeys((prev: any[]) => prev.filter((k: any) => !k.toString().startsWith(`${connKey}-`)));
-                    setLoadedKeys((prev: any[]) => prev.filter((k: any) => !k.toString().startsWith(`${connKey}-`)));
-                    // 清除 loadingNodesRef 中残留的子节点加载标记
-                    Array.from(loadingNodesRef.current as Set<string>).forEach(lk => {
-                        if (lk.startsWith(`tables-${connKey}-`)) loadingNodesRef.current.delete(lk);
-                    });
-                    loadDatabases(node);
+                    void refreshConnectionResources(node);
                 }
             },
             { type: 'divider' },

--- a/frontend/src/components/sidebar/useSidebarV2ActionHandlers.tsx
+++ b/frontend/src/components/sidebar/useSidebarV2ActionHandlers.tsx
@@ -32,6 +32,7 @@ type UseSidebarV2ActionHandlersArgs = {
   pinnedSidebarTables: any[];
   loadingNodesRef: MutableRefObject<Set<string>>;
   treeDataRef: MutableRefObject<TreeNode[]>;
+  refreshConnectionResources: (node: any) => Promise<void>;
   findTreeNodeByKeyRef: MutableRefObject<(nodes: TreeNode[], targetKey: React.Key) => TreeNode | null>;
   refreshV2TableContextMenuStatsRef: MutableRefObject<(node: any) => void>;
   setConnectionStates: Dispatch<SetStateAction<Record<string, SidebarConnectionState>>>;
@@ -98,6 +99,7 @@ export const useSidebarV2ActionHandlers = ({
   pinnedSidebarTables,
   loadingNodesRef,
   treeDataRef,
+  refreshConnectionResources,
   findTreeNodeByKeyRef,
   refreshV2TableContextMenuStatsRef,
   setConnectionStates,
@@ -368,19 +370,6 @@ export const useSidebarV2ActionHandlers = ({
     }
   };
 
-  const refreshConnectionNode = (node: any) => {
-    const connKey = String(node?.key || node?.dataRef?.id || '');
-    if (!connKey) return;
-    setExpandedKeys(prev => prev.filter(k => k !== connKey && !k.toString().startsWith(`${connKey}-`)));
-    setLoadedKeys(prev => prev.filter(k => k !== connKey && !k.toString().startsWith(`${connKey}-`)));
-    Array.from(loadingNodesRef.current).forEach((loadingKey) => {
-      if (loadingKey === `dbs-${connKey}` || loadingKey.startsWith(`tables-${connKey}-`)) {
-        loadingNodesRef.current.delete(loadingKey);
-      }
-    });
-    loadDatabases(node);
-  };
-
   const releaseConnectionResources = async (conn: SavedConnection | undefined) => {
     if (!conn?.config) return;
     const res = await DBReleaseConnection(buildRpcConnectionConfig(conn.config, { id: conn.id }) as any);
@@ -465,7 +454,7 @@ export const useSidebarV2ActionHandlers = ({
         setIsCreateDbModalOpen(true);
         return;
       case 'refresh':
-        refreshConnectionNode(node);
+        void refreshConnectionResources(node);
         return;
       case 'new-query':
         addTab({

--- a/frontend/src/components/sidebarV2Utils.single-database-expansion.test.ts
+++ b/frontend/src/components/sidebarV2Utils.single-database-expansion.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  resolveSidebarConnectionRefreshKeys,
   resolveSidebarSingleDatabaseExpandedKeys,
   type SidebarTreeNode,
 } from './sidebarV2Utils';
@@ -45,6 +46,24 @@ const treeData: SidebarTreeNode[] = [
 ];
 
 describe('resolveSidebarSingleDatabaseExpandedKeys', () => {
+  it('orders expanded connection resources from parent to child for refresh reloads', () => {
+    expect(resolveSidebarConnectionRefreshKeys({
+      treeData,
+      expandedKeys: [
+        'conn-a-main-tables',
+        'conn-a',
+        'external-sql-root',
+        'conn-a-main',
+        'conn-a-missing',
+      ],
+      connectionId: 'conn-a',
+    })).toEqual([
+      'conn-a',
+      'conn-a-main',
+      'conn-a-main-tables',
+    ]);
+  });
+
   it('keeps the newly expanded database and collapses its siblings only', () => {
     expect(resolveSidebarSingleDatabaseExpandedKeys({
       previousExpandedKeys: [

--- a/frontend/src/components/sidebarV2Utils.ts
+++ b/frontend/src/components/sidebarV2Utils.ts
@@ -934,6 +934,43 @@ export const resolveSidebarConnectionIdFromKey = (
   return sortedIds.find((id) => keyText === id || keyText.startsWith(`${id}-`)) || '';
 };
 
+export const resolveSidebarConnectionRefreshKeys = ({
+  treeData,
+  expandedKeys,
+  connectionId,
+}: {
+  treeData: SidebarTreeNode[];
+  expandedKeys: Key[];
+  connectionId: string;
+}): string[] => {
+  const normalizedConnectionId = String(connectionId || '').trim();
+  if (!normalizedConnectionId) return [];
+
+  const expandedKeySet = new Set(
+    expandedKeys
+      .map((key) => String(key || '').trim())
+      .filter((key) => key === normalizedConnectionId || key.startsWith(`${normalizedConnectionId}-`)),
+  );
+  if (expandedKeySet.size === 0) return [];
+
+  const depthByKey = new Map<string, number>();
+  const collectDepths = (nodes: SidebarTreeNode[], depth: number) => {
+    nodes.forEach((node) => {
+      const key = String(node.key || '').trim();
+      if (key) depthByKey.set(key, depth);
+      if (node.children?.length) collectDepths(node.children, depth + 1);
+    });
+  };
+  collectDepths(treeData, 0);
+
+  return Array.from(expandedKeySet)
+    .filter((key) => depthByKey.has(key))
+    .sort((left, right) => {
+      const depthDifference = (depthByKey.get(left) || 0) - (depthByKey.get(right) || 0);
+      return depthDifference || left.localeCompare(right);
+    });
+};
+
 export const resolveSidebarNodeConnectionId = (
   node: { key?: unknown; dataRef?: Record<string, unknown> } | null | undefined,
   connectionIds: string[],


### PR DESCRIPTION
## 背景
修复 Issue #800：连接资源刷新后，原先展开的连接、数据库和表资源会被折叠，需要用户重新展开。

## 变更
- 统一 V2 与 legacy 连接刷新入口。
- 保留刷新前的展开状态，并按父级到子级顺序重新加载展开资源。
- 刷新期间新展开的节点继续保留；已移除资源的无效 key 会清理。
- 增加连接刷新展开顺序回归测试。

## 验证
- `tsc --noEmit`
- `vitest run src/components/sidebarV2Utils.single-database-expansion.test.ts`
- `vitest run src/components/sidebar/useSidebarTreeLoaders.nacos-services.test.tsx src/components/sidebar/sidebarLegacyNodeMenu.nacos-services.test.tsx`
- `vitest run src/components/Sidebar.locate-toolbar.test.tsx`

Closes #800