### PR TITLE
🐛 fix(datagrid): 保留多列筛选条件

### DIFF
--- a/frontend/src/components/useDataGridFilters.test.tsx
+++ b/frontend/src/components/useDataGridFilters.test.tsx
@@ -80,4 +80,52 @@ describe('useDataGridFilters', () => {
 
     renderer?.unmount();
   });
+
+  it('preserves earlier value selections when a second column filter is applied', () => {
+    let latest: UseDataGridFiltersResult | undefined;
+    let renderer: ReactTestRenderer | undefined;
+
+    const Harness = () => {
+      const [appliedConditions, setAppliedConditions] = React.useState<Parameters<typeof useDataGridFilters>[0]['appliedFilterConditions']>([]);
+      latest = useDataGridFilters(createFilterHookProps({
+        appliedFilterConditions: appliedConditions,
+        onApplyFilter: setAppliedConditions,
+      }));
+      return null;
+    };
+
+    act(() => {
+      renderer = create(<Harness />);
+    });
+
+    act(() => {
+      latest?.applyColumnFilter({
+        column: 'code',
+        op: 'IN',
+        valueSelection: { values: ['A'] },
+      });
+    });
+    act(() => {
+      latest?.applyColumnFilter({
+        column: 'title',
+        op: 'IN',
+        valueSelection: { values: ['B'] },
+      });
+    });
+
+    expect(latest?.filterConditions).toEqual([
+      expect.objectContaining({
+        column: 'code',
+        op: 'IN',
+        valueSelection: { values: ['A'] },
+      }),
+      expect.objectContaining({
+        column: 'title',
+        op: 'IN',
+        valueSelection: { values: ['B'] },
+      }),
+    ]);
+
+    renderer?.unmount();
+  });
 });

--- a/frontend/src/components/useDataGridFilters.tsx
+++ b/frontend/src/components/useDataGridFilters.tsx
@@ -126,6 +126,11 @@ export const useDataGridFilters = ({
         op,
         value: String(cond?.value ?? ''),
         value2: String(cond?.value2 ?? ''),
+        valueSelection: cond?.valueSelection ? {
+          values: Array.from(new Set((cond.valueSelection.values || []).map((value) => String(value)))),
+          ...(cond.valueSelection.includeNull ? { includeNull: true } : {}),
+          ...(cond.valueSelection.includeEmpty ? { includeEmpty: true } : {}),
+        } : undefined,
       };
     });
   }, [normalizeFilterLogic]);


### PR DESCRIPTION
## 背景\nPR #814 合并后发现，先应用字段 A 筛选，再应用字段 B 筛选时，字段 A 的筛选条件会被丢弃，导致结果集与筛选图标状态不一致。\n\n## 变更\n- 在条件规范化过程中保留已有列的筛选条件。\n- 增加多列筛选的回归测试。\n\n## 验证\n- 
pm --prefix frontend test -- src/components/useDataGridFilters.test.tsx\n\n本 PR 基于已合并的 #814，仅包含后续修复。