### PR TITLE
🐛 fix(data-grid): 为文本视图所有列显示截断提示

### DIFF
--- a/frontend/src/components/DataGridRecordViews.tsx
+++ b/frontend/src/components/DataGridRecordViews.tsx
@@ -86,13 +86,13 @@ interface DataGridTextCellProps extends React.HTMLAttributes<HTMLDivElement> {
   'data-grid-text-value-copy'?: string;
 }
 
-interface DataGridTextValueCellProps extends DataGridTextCellProps {
+interface DataGridTextOverflowCellProps extends DataGridTextCellProps {
   value: string;
   cellBaseStyle: React.CSSProperties;
   tooltipInnerStyle: React.CSSProperties;
 }
 
-const DataGridTextValueCell: React.FC<DataGridTextValueCellProps> = ({
+const DataGridTextOverflowCell: React.FC<DataGridTextOverflowCellProps> = ({
   value,
   cellBaseStyle,
   tooltipInnerStyle,
@@ -192,18 +192,6 @@ export const DataGridTextView: React.FC<DataGridTextViewProps> = ({
     }
   }, [translate]);
 
-  const renderCell = (
-    value: string,
-    style: React.CSSProperties,
-    props?: DataGridTextCellProps,
-  ) => {
-    return (
-      <div {...props} style={{ ...cellBaseStyle, ...style }}>
-        {value}
-      </div>
-    );
-  };
-
   return (
     <div style={{ height: '100%', minHeight: 0, display: 'flex', flexDirection: 'column' }}>
       <div style={{ padding: '8px 12px', borderBottom: darkMode ? '1px solid rgba(255,255,255,0.08)' : '1px solid rgba(0,0,0,0.08)', display: 'flex', alignItems: 'center', gap: 8 }}>
@@ -267,18 +255,28 @@ export const DataGridTextView: React.FC<DataGridTextViewProps> = ({
                 role="row"
                 style={{ display: 'grid', gridTemplateColumns, borderBottom }}
               >
-                {renderCell(col, { fontWeight: 600, color: primaryTextColor }, { 'data-grid-text-view-cell': 'field' })}
-                {renderCell(
-                  showColumnType ? columnType : '',
-                  { color: metaTextColor },
-                  { 'data-grid-text-view-cell': 'type' },
-                )}
-                {renderCell(
-                  showColumnComment ? columnComment : '',
-                  { color: metaTextColor },
-                  { 'data-grid-text-view-cell': 'comment' },
-                )}
-                <DataGridTextValueCell
+                <DataGridTextOverflowCell
+                  value={col}
+                  cellBaseStyle={cellBaseStyle}
+                  tooltipInnerStyle={tooltipInnerStyle}
+                  style={{ fontWeight: 600, color: primaryTextColor }}
+                  data-grid-text-view-cell="field"
+                />
+                <DataGridTextOverflowCell
+                  value={showColumnType ? columnType : ''}
+                  cellBaseStyle={cellBaseStyle}
+                  tooltipInnerStyle={tooltipInnerStyle}
+                  style={{ color: metaTextColor }}
+                  data-grid-text-view-cell="type"
+                />
+                <DataGridTextOverflowCell
+                  value={showColumnComment ? columnComment : ''}
+                  cellBaseStyle={cellBaseStyle}
+                  tooltipInnerStyle={tooltipInnerStyle}
+                  style={{ color: metaTextColor }}
+                  data-grid-text-view-cell="comment"
+                />
+                <DataGridTextOverflowCell
                   value={formattedValue}
                   cellBaseStyle={cellBaseStyle}
                   tooltipInnerStyle={tooltipInnerStyle}


### PR DESCRIPTION
## 背景
PR #816 合并后，文本视图字段、类型和注释列虽然会以省略号截断，但悬浮时无法查看完整内容。

## 变更
- 字段、类型、注释和值四列统一使用实际宽度检测。
- 只有检测到内容被截断时才显示完整内容 Tooltip。
- 未截断或空值时不显示 Tooltip，保持原有界面简洁。

## 验证
- 
pm --prefix frontend test -- --run src/components/DataGrid.layout.test.tsx src/components/DataGridRecordViews.interaction.test.tsx src/i18n/catalog.test.ts（90/90 通过）

补充已合并的 #816。