### PR TITLE
🐛 fix(data-grid): 修复单元格编辑框重复边框 (#837)

### DIFF
--- a/frontend/src/components/DataGrid.layout.test.tsx
+++ b/frontend/src/components/DataGrid.layout.test.tsx
@@ -481,6 +481,19 @@ describe('DataGrid layout', () => {
     expect(css).not.toContain('.react-resizable-handle:hover::after');
   });
 
+  it('uses the table cell as the only V2 inline edit frame', () => {
+    const css = readV2ThemeCss();
+    const inlineEditorCss = css.slice(
+      css.indexOf('body[data-ui-version="v2"] .gn-v2-data-grid .data-grid-virtual-inline-editing .ant-input,'),
+      css.indexOf('body[data-ui-version="v2"] .gn-v2-data-grid-statusbar'),
+    );
+
+    expect(inlineEditorCss).toContain('border: 0 !important;');
+    expect(inlineEditorCss).toContain('border-radius: 0 !important;');
+    expect(inlineEditorCss).toContain('background: transparent !important;');
+    expect(inlineEditorCss).toContain('box-shadow: none !important;');
+  });
+
   it('avoids duplicating legacy pagination page text beside the pager', () => {
     const markup = renderToStaticMarkup(
       <DataGridPaginationBar

--- a/frontend/src/v2-theme.css
+++ b/frontend/src/v2-theme.css
@@ -4752,6 +4752,10 @@ body[data-ui-version="v2"] .gn-v2-data-grid .data-grid-virtual-inline-editing .a
   min-height: 24px !important;
   line-height: 24px !important;
   margin: 0 !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
   box-sizing: border-box !important;
   position: static !important;
 }


### PR DESCRIPTION
## 关联 Issue

Closes #837

## 问题根因

V2 数据表格双击可编辑单元格后，表格单元格本身已经提供矩形编辑边界，内部 Ant Design `Input`、`Input` 包装层或 `DatePicker` 又保留默认圆角边框和焦点阴影，形成方框内嵌圆角框的重复边界。

## 修复方案

仅在 V2 DataGrid 虚拟内联编辑上下文中去除内部编辑控件的边框、圆角、背景和阴影，保留表格单元格作为唯一编辑边界。组件结构、表单校验、双击激活和失焦保存逻辑均未修改。

新增布局回归测试，约束内联编辑控件保持无独立边框、无圆角、透明背景且无阴影。该测试在修复前因缺少无边框规则而失败，修复后通过。

## 验证结果

| 验证项 | 命令或步骤 | 结果 |
| --- | --- | --- |
| 修复前回归测试 | `npm --prefix frontend test -- src/components/DataGrid.layout.test.tsx -t 'uses the table cell as the only V2 inline edit frame'` | 按预期失败：缺少 `border: 0 !important` |
| DataGrid 回归测试 | `npm --prefix frontend test -- src/components/dataGridVirtualScroll.test.ts src/components/DataGrid.layout.test.tsx` | 通过，49/49 |
| 双击编辑与失焦保存 | `npm --prefix frontend test -- src/components/DataGrid.ddl.test.tsx -t 'shows a pending edited value when the field later becomes read-only'` | 通过，1/1 |
| 依赖补丁测试 | `npm --prefix frontend test -- src/utils/rcResizeObserverSidebarLifecycle.test.ts` | 通过，4/4 |
| 生产构建 | `npm --prefix frontend run build` | 通过 |
| 差异检查 | `git diff --check`、`git diff --cached --check` | 通过 |
| 前端全量测试 | `npm --prefix frontend test` | 3739/3740 通过；唯一失败为 `Sidebar.locate-toolbar.test.tsx` 的既有基线错误 |

全量测试中的 Sidebar 失败已使用 `git archive upstream/dev` 导出的纯净快照、`npm ci` 和同一目标命令独立复现，确认与本 PR 的 DataGrid 两文件改动无关。该基线测试会在独立分支和 PR 中修复，避免混入本 Issue。

GUI 桌面与窄屏验证未完成：本会话唯一可用的 IAB 浏览器后端在创建验证标签时持续返回 `browser guest not attached (webview not ready)`，且没有其他浏览器后端可用，因此未将 GUI 检查写为通过。DatePicker 也未在真实数据库元数据场景中手动验证；其 selector 与 Input 共用本次 CSS 规则，并由回归契约覆盖。

## 风险与兼容性

- 不涉及数据或配置格式变化。
- 不修改公共 API、编辑状态或保存行为。
- 不涉及并发或算法复杂度变化。
- CSS 作用域限定为 V2 DataGrid 虚拟内联编辑控件，不影响弹窗和其他页面输入框。
- 已知验证边界是缺少实际 GUI 截图以及真实时间字段 DatePicker 的手动操作；相关自动化、CSS 契约和生产构建已通过。

## 回滚方式

回滚提交 `0d2f021fd85f0cc41af1740d995a823f8202d4d2` 即可恢复原样。回滚仅恢复内联编辑控件样式和对应测试，不影响数据或配置。
