### PR TITLE
✅ test(sidebar): 移除失效源码契约断言

### DIFF
--- a/frontend/src/components/Sidebar.locate-toolbar.test.tsx
+++ b/frontend/src/components/Sidebar.locate-toolbar.test.tsx
@@ -2311,58 +2311,7 @@ describe('Sidebar locate toolbar', () => {
     });
   });
 
-  it('localizes v2 saved-query and external SQL root shell copy', () => {
-    const source = readSidebarSource();
-    const externalSqlWorkflowSource = readSourceFile('./sidebar/SidebarExternalSqlWorkflow.tsx');
-    const legacyMenuSource = readLegacyNodeMenuSource();
-    const loadTablesStart = source.indexOf('const loadTables = async (node: any) => {');
-    const loadTablesEnd = source.indexOf('const config = {', loadTablesStart);
-    const loadTablesSource = source.slice(loadTablesStart, loadTablesEnd);
-    const externalSqlFlowStart = externalSqlWorkflowSource.indexOf('const handleAddExternalSQLDirectory = async (node: any) => {');
-    const externalSqlFlowEnd = externalSqlWorkflowSource.indexOf('\n  return {', externalSqlFlowStart);
-    const externalSqlFlowSource = externalSqlWorkflowSource.slice(externalSqlFlowStart, externalSqlFlowEnd);
-    const treeTitleSource = readSourceFile('./sidebar/SidebarTreeTitle.tsx');
-    const treeTitleStart = 0;
-    const treeTitleEnd = treeTitleSource.length;
-    const externalSqlMenuStart = legacyMenuSource.indexOf("if (node.type === 'external-sql-root') {", legacyMenuSource.indexOf('// 已存查询节点的右键菜单'));
-    const externalSqlMenuEnd = legacyMenuSource.indexOf("if (node.type === 'external-sql-directory') {", externalSqlMenuStart);
-    const externalSqlMenuSource = legacyMenuSource.slice(externalSqlMenuStart, externalSqlMenuEnd);
-    const externalSqlDirectoryMenuStart = externalSqlMenuEnd;
-    const externalSqlDirectoryMenuEnd = legacyMenuSource.indexOf("if (node.type === 'external-sql-file') {", externalSqlDirectoryMenuStart);
-    const externalSqlDirectoryMenuSource = legacyMenuSource.slice(externalSqlDirectoryMenuStart, externalSqlDirectoryMenuEnd);
-    const externalSqlFileMenuStart = externalSqlDirectoryMenuEnd;
-    const externalSqlFileMenuEnd = legacyMenuSource.indexOf('return [];', externalSqlFileMenuStart);
-    const externalSqlFileMenuSource = legacyMenuSource.slice(externalSqlFileMenuStart, externalSqlFileMenuEnd);
-    const titleRenderSource = readSourceFile('./sidebar/useSidebarTitleRender.tsx');
-    const titleRenderStart = titleRenderSource.indexOf('export const useSidebarTitleRender =');
-    const titleRenderEnd = titleRenderSource.length;
-
-    [
-      loadTablesStart,
-      loadTablesEnd,
-      externalSqlFlowStart,
-      externalSqlFlowEnd,
-      treeTitleStart,
-      treeTitleEnd,
-      externalSqlMenuStart,
-      externalSqlMenuEnd,
-      externalSqlDirectoryMenuStart,
-      externalSqlDirectoryMenuEnd,
-      externalSqlFileMenuStart,
-      externalSqlFileMenuEnd,
-      titleRenderStart,
-      titleRenderEnd,
-    ].forEach((index) => expect(index).toBeGreaterThanOrEqual(0));
-    [
-      '选择 SQL 目录失败',
-      '未获取到有效的 SQL 目录路径',
-      '外部 SQL 目录已添加',
-      '未找到可移除的 SQL 目录',
-      '外部 SQL 目录已移除',
-      '外部 SQL 目录已刷新',
-    ].forEach((rawSnippet) => {
-    });
-
+  it('resolves saved-query and external SQL localization keys for every supported language', () => {
     [
       'sidebar.tree.saved_queries',
       'sidebar.external_sql.root',


### PR DESCRIPTION
## 问题背景

`frontend/src/components/Sidebar.locate-toolbar.test.tsx` 中的 saved-query / external SQL 本地化用例仍通过 `indexOf` 检查旧的 `const loadTables = async ...` 源码签名。Sidebar 加载器已重构为 `runLoadTables` 加调度包装，等价行为保持不变，但该源码字符串门禁返回 `-1`，导致当前 `dev` 的前端全量测试失败。

该失败已在通过 `git archive upstream/dev` 导出的纯净快照中执行 `npm ci` 后独立复现，与其他功能分支无关。

## 修复方案

- 删除该用例中已经没有断言消费方的源码读取、字符串切片、index 门禁和空循环。
- 保留 14 个 saved-query / external SQL 翻译键在全部 6 种支持语言中的实际解析断言。
- 更新测试名称，使其准确描述仍在验证的行为。

不修改 Sidebar 生产代码，也不恢复已被调度器替代的旧函数签名。

## 验证结果

| 验证项 | 命令 | 结果 |
| --- | --- | --- |
| 目标回归测试 | `npm --prefix frontend test -- src/components/Sidebar.locate-toolbar.test.tsx -t 'resolves saved-query and external SQL localization keys for every supported language'` | 通过，1/1 |
| Sidebar 测试文件 | `npm --prefix frontend test -- src/components/Sidebar.locate-toolbar.test.tsx` | 通过，85/85 |
| 测试策略门禁 | `npm --prefix frontend test -- src/testPolicy.test.ts` | 通过，3/3 |
| 依赖补丁测试 | `npm --prefix frontend test -- src/utils/rcResizeObserverSidebarLifecycle.test.ts` | 通过，4/4 |
| 前端全量测试 | `npm --prefix frontend test` | 通过，444/444 个测试文件、3739/3739 个测试 |
| 生产构建 | `npm --prefix frontend run build` | 通过 |
| 差异检查 | `git diff --check`、`git diff --cached --check` | 通过 |

## 风险与兼容性

- 仅修改测试，不影响生产运行行为、公共 API、数据或配置。
- 删除的是未使用变量、空循环和对实现排版敏感的源码字符串门禁。
- 翻译键覆盖范围未减少，实际跨语言解析断言完整保留。

## 回滚方式

回滚提交 `1a95b8c7c5bbf576660d1300fc8ce90947122981` 即可恢复原测试。回滚不影响生产数据或配置。
