### PR TITLE
🐛 fix(sidebar): 优化数据库树纵向滚动条显示 (#838)

### DIFF
--- a/frontend/src/components/Sidebar.locate-toolbar.test.tsx
+++ b/frontend/src/components/Sidebar.locate-toolbar.test.tsx
@@ -1175,6 +1175,37 @@ describe('Sidebar locate toolbar', () => {
     expect(css).not.toContain('.gn-v2-tree-connection-meta');
   });
 
+  it('shows the v2 tree vertical scrollbar only during user scrolling', () => {
+    const css = readV2ThemeCss();
+    const source = readSourceFile('./Sidebar.tsx');
+
+    expect(source).toContain("isTreeScrolling ? ' is-vertical-scrolling' : ''");
+    expect(source).toContain('onWheelCapture={handleTreeWheel}');
+    expect(source).toContain('onTouchMoveCapture={markTreeScrollActivity}');
+    expect(source).toContain('setIsTreeScrolling(false)');
+
+    const idleScrollbarCss = readCssRuleBlock(
+      css,
+      'body[data-ui-version="v2"] .gn-v2-explorer-tree-shell .ant-tree-list-scrollbar-vertical',
+    );
+    expect(idleScrollbarCss).toContain('visibility: hidden !important;');
+    expect(idleScrollbarCss).toContain('pointer-events: none;');
+
+    const activeScrollbarCss = readCssRuleBlock(
+      css,
+      'body[data-ui-version="v2"] .gn-v2-explorer-tree-shell.is-vertical-scrolling .ant-tree-list-scrollbar-vertical',
+    );
+    expect(activeScrollbarCss).toContain('visibility: visible !important;');
+    expect(activeScrollbarCss).toContain('pointer-events: auto;');
+
+    const movingScrollbarCss = readCssRuleBlock(
+      css,
+      'body[data-ui-version="v2"] .gn-v2-explorer-tree-shell .ant-tree-list-scrollbar-vertical:has(.ant-tree-list-scrollbar-thumb-moving)',
+    );
+    expect(movingScrollbarCss).toContain('visibility: visible !important;');
+    expect(movingScrollbarCss).toContain('pointer-events: auto;');
+  });
+
   it('estimates a v2 tree scroll width only when content is wider than the viewport', () => {
     const narrowWidth = estimateV2TreeHorizontalScrollWidth([
       {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -931,7 +931,9 @@ const Sidebar: React.FC<{
   // Virtual Scroll State
   const [treeHeight, setTreeHeight] = useState(500);
   const [treeViewportWidth, setTreeViewportWidth] = useState(0);
+  const [isTreeScrolling, setIsTreeScrolling] = useState(false);
   const treeContainerRef = useRef<HTMLDivElement>(null);
+  const treeScrollIdleTimerRef = useRef<number | null>(null);
   const treeRef = useRef<any>(null);
   const treeDataRef = useRef<TreeNode[]>([]);
   const externalSQLDirectoryTreesRef = useRef<Record<string, ExternalSQLTreeEntry[]>>({});
@@ -981,6 +983,30 @@ const Sidebar: React.FC<{
           resizeObserver.disconnect();
           scheduler.dispose();
       };
+  }, []);
+
+  const markTreeScrollActivity = useCallback(() => {
+      if (!isV2Ui) return;
+      setIsTreeScrolling(true);
+      if (treeScrollIdleTimerRef.current !== null) {
+          window.clearTimeout(treeScrollIdleTimerRef.current);
+      }
+      treeScrollIdleTimerRef.current = window.setTimeout(() => {
+          treeScrollIdleTimerRef.current = null;
+          setIsTreeScrolling(false);
+      }, 500);
+  }, [isV2Ui]);
+
+  const handleTreeWheel = useCallback((event: React.WheelEvent<HTMLDivElement>) => {
+      if (Math.abs(event.deltaY) > Math.abs(event.deltaX)) {
+          markTreeScrollActivity();
+      }
+  }, [markTreeScrollActivity]);
+
+  useEffect(() => () => {
+      if (treeScrollIdleTimerRef.current !== null) {
+          window.clearTimeout(treeScrollIdleTimerRef.current);
+      }
   }, []);
 
   useEffect(() => {
@@ -3992,7 +4018,9 @@ const Sidebar: React.FC<{
 
         <div
             ref={treeContainerRef}
-            className={`sidebar-tree-scroll-shell${isV2Ui ? ' gn-v2-explorer-tree-shell' : ''}`}
+            className={`sidebar-tree-scroll-shell${isV2Ui ? ' gn-v2-explorer-tree-shell' : ''}${isTreeScrolling ? ' is-vertical-scrolling' : ''}`}
+            onWheelCapture={handleTreeWheel}
+            onTouchMoveCapture={markTreeScrollActivity}
             style={{
                 flex: 1,
                 overflow: 'hidden',

--- a/frontend/src/v2-theme.css
+++ b/frontend/src/v2-theme.css
@@ -3021,6 +3021,21 @@ body[data-ui-version="v2"] .gn-v2-explorer-tree-shell .ant-tree-list-holder {
   scrollbar-width: thin;
 }
 
+body[data-ui-version="v2"] .gn-v2-explorer-tree-shell .ant-tree-list-scrollbar-vertical {
+  visibility: hidden !important;
+  pointer-events: none;
+}
+
+body[data-ui-version="v2"] .gn-v2-explorer-tree-shell.is-vertical-scrolling .ant-tree-list-scrollbar-vertical {
+  visibility: visible !important;
+  pointer-events: auto;
+}
+
+body[data-ui-version="v2"] .gn-v2-explorer-tree-shell .ant-tree-list-scrollbar-vertical:has(.ant-tree-list-scrollbar-thumb-moving) {
+  visibility: visible !important;
+  pointer-events: auto;
+}
+
 body[data-ui-version="v2"] .gn-v2-explorer-tree-shell .ant-tree-list-scrollbar-horizontal {
   height: 12px !important;
   left: 8px !important;


### PR DESCRIPTION
## 关联 Issue

Fixes #838

## 问题根因

新版侧边栏使用 Ant Design 虚拟树。其纵向虚拟滚动条会随树内容高度变化参与显示状态更新，数据库节点展开或收起时滑块长度持续变化，造成右侧滚动条闪动和卡顿感。

## 修复方案

- 在新版侧边栏树容器捕获真实纵向滚轮和触摸滚动活动。
- 默认隐藏纵向虚拟滚动条，仅在用户滚动后的 500ms 活动窗口内显示，停止后自动隐藏。
- 拖动滑块期间保持滚动条可见。
- 保持现有横向滚动条、树虚拟化参数、数据库加载及展开逻辑不变。
- 补充侧边栏纵向滚动条显隐规则回归测试。

## 验证结果

| 验证项 | 命令或步骤 | 结果 |
| --- | --- | --- |
| 目标回归测试 | `npm --prefix frontend test -- src/components/Sidebar.locate-toolbar.test.tsx` | 通过，86/86 |
| 完整前端测试 | `npm --prefix frontend test` | 通过，444 个测试文件、3747 个用例 |
| 前端生产构建 | `npm --prefix frontend run build` | 通过，TypeScript 与 Vite 构建成功 |
| 桌面视口 GUI | 1280x720 下展开 24 个模拟数据库节点并静置，检查 DOM 与截图 | 通过；纵向滚动条存在但保持 `visibility: hidden`，树壳无滚动活动类 |
| 窄屏 GUI | 640x720 下展开、收起同一数据库树，检查 DOM、截图和布局 | 通过；展开/收起不显示纵向滚动条，侧边栏与主内容无重叠 |
| 滚轮瞬态 GUI | 内置浏览器在虚拟树区域执行滚轮手势 | 未执行成功；浏览器运行时未向虚拟树产生有效位移或 `wheel` 活动，因此未把该项记为通过；显隐状态由回归测试覆盖 |

GUI 测试使用浏览器 mock 临时准备一条 MySQL 连接和 24 个数据库节点，测试后已完全还原，未进入提交。浏览器工具未提供控制台日志读取能力；测试期间未观察到白屏、错误弹窗或布局异常。

## 风险与兼容性

- 改动仅作用于 v2 侧边栏树的纵向虚拟滚动条，不影响旧版 UI 和现有横向滚动条。
- 不改变公共 API、配置、持久化数据、数据库请求、树节点结构或虚拟滚动尺寸。
- 500ms 空闲窗口只控制视觉显隐；滚动和拖动仍由 Ant Design 虚拟列表处理。
- GUI 工具未能直接验证滚轮活动期间的瞬态显示，这是当前验证边界。

## 回滚方式

回滚提交 `95703065223d7c06cad6179bea7657ba7d69a1e9` 即可恢复原滚动条行为。该回滚不涉及数据、配置或迁移。
