### PR TITLE
🐛 fix(sidebar): 修复连接树末项无法完整显示

### DIFF
--- a/frontend/src/components/sidebar/useSidebarSearchModel.tsx
+++ b/frontend/src/components/sidebar/useSidebarSearchModel.tsx
@@ -37,6 +37,7 @@ import {
   filterV2CommandSearchTreeItems,
   filterV2ExplorerTreeByKind,
   resolveSidebarNodeConnectionId,
+  resolveSidebarTreeVirtualHeight,
   resolveV2ActiveConnectionId,
   type SidebarTreeNode as TreeNode,
   type V2CommandSearchItem,
@@ -619,7 +620,7 @@ export const useSidebarSearchModel = ({
     ),
     [sidebarTableMetadataFields, treeViewportWidth, v2VisibleTreeData],
   );
-  const effectiveTreeHeight = treeHeight;
+  const effectiveTreeHeight = resolveSidebarTreeVirtualHeight(treeHeight, isV2Ui);
   const v2TreeMetrics = useMemo(() => {
     const databaseTableCounts = new Map<React.Key, number>();
     const objectGroupCounts = new Map<React.Key, number>();

--- a/frontend/src/components/sidebarV2Utils.tree-height.test.ts
+++ b/frontend/src/components/sidebarV2Utils.tree-height.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveSidebarTreeVirtualHeight } from './sidebarV2Utils';
+
+describe('resolveSidebarTreeVirtualHeight', () => {
+  it('matches the V2 tree virtual viewport to the visible holder height', () => {
+    expect(resolveSidebarTreeVirtualHeight(500, true)).toBe(464);
+  });
+
+  it('keeps the legacy tree height unchanged', () => {
+    expect(resolveSidebarTreeVirtualHeight(500, false)).toBe(500);
+  });
+
+  it('never returns a negative height and preserves subpixel measurements', () => {
+    expect(resolveSidebarTreeVirtualHeight(20, true)).toBe(0);
+    expect(resolveSidebarTreeVirtualHeight(Number.NaN, true)).toBe(0);
+    expect(resolveSidebarTreeVirtualHeight(500.9, true)).toBeCloseTo(464.9);
+    expect(resolveSidebarTreeVirtualHeight(500.9, false)).toBe(500.9);
+  });
+});

--- a/frontend/src/components/sidebarV2Utils.ts
+++ b/frontend/src/components/sidebarV2Utils.ts
@@ -76,6 +76,26 @@ export interface SidebarTreeNode {
   type?: SidebarTreeNodeType;
 }
 
+// Keep these values aligned with the V2 explorer tree layout in v2-theme.css.
+const V2_TREE_HORIZONTAL_SCROLL_RESERVE_PX = 32;
+const V2_TREE_CONTENT_TOP_PADDING_PX = 4;
+
+export const resolveSidebarTreeVirtualHeight = (
+  containerHeight: number,
+  isV2Ui: boolean,
+): number => {
+  if (!Number.isFinite(containerHeight)) return 0;
+  const normalizedHeight = Math.max(0, containerHeight);
+  return Math.max(
+    0,
+    normalizedHeight - (
+      isV2Ui
+        ? V2_TREE_HORIZONTAL_SCROLL_RESERVE_PX + V2_TREE_CONTENT_TOP_PADDING_PX
+        : 0
+    ),
+  );
+};
+
 export const hasSidebarLazyChildren = (children: unknown): boolean => {
   return Array.isArray(children) && children.length > 0;
 };


### PR DESCRIPTION
## 背景

V2 左侧连接树内容超过可视区域时，虚拟滚动高度按外层完整高度计算，而实际列表区域还需避开顶部间距和横向滚动条预留，导致最末项无法完整滚入视图。

## 修改内容

- 按 V2 实际可见区域计算连接树虚拟滚动高度
- 保持旧版侧边栏原有高度行为不变
- 补充正常高度、极小高度与高 DPI 小数高度的回归测试

## 影响范围

- 仅 V2 左侧连接树的虚拟滚动边界
- 不修改连接数据、展开状态或旧版 UI 布局

## 验证

- `npm test -- --minWorkers=1 --maxWorkers=1`（前端全量测试）
- `npm run build`（前端生产构建）
- `npm test -- --run src/components/sidebarV2Utils.tree-height.test.ts`
- `npm test -- --run src/components/Sidebar.locate-toolbar.test.tsx`