### PR TITLE
fix(query-editor): support fuzzy table and column completion

### DIFF
--- a/frontend/src/components/QueryEditor.external-sql-save.test.tsx
+++ b/frontend/src/components/QueryEditor.external-sql-save.test.tsx
@@ -3444,7 +3444,10 @@ describe('QueryEditor external SQL save', () => {
     backendApp.DBGetTables.mockResolvedValueOnce({ success: true, data: [{ Tables_in_main: 'fs_org_auth_application' }] });
     backendApp.DBGetAllColumns.mockResolvedValueOnce({
       success: true,
-      data: [{ tableName: 'fs_org_auth_application', name: 'orgi', type: 'varchar(32)' }],
+      data: [
+        { tableName: 'fs_org_auth_application', name: 'orgi', type: 'varchar(32)' },
+        { tableName: 'fs_org_auth_application', name: 'auth_code', type: 'varchar(32)' },
+      ],
     });
 
     await act(async () => {
@@ -3466,6 +3469,24 @@ describe('QueryEditor external SQL save', () => {
 
     expect(labels).toContain('fs_org_auth_application');
     expect(labels).not.toContain('orgi');
+
+    editorState.value = 'SELECT * FROM auth';
+    editorState.latestOnChange?.(editorState.value);
+    const fuzzyTableResult = await sqlProvider.provideCompletionItems(
+      editorState.editor.getModel(),
+      { lineNumber: 1, column: editorState.value.length + 1 },
+    );
+    const fuzzyTable = fuzzyTableResult.suggestions.find((item: any) => item.label === 'fs_org_auth_application');
+    expect(fuzzyTable).toMatchObject({ filterText: 'auth_application' });
+
+    editorState.value = 'SELECT * FROM fs_org_auth_application WHERE code';
+    editorState.latestOnChange?.(editorState.value);
+    const fuzzyColumnResult = await sqlProvider.provideCompletionItems(
+      editorState.editor.getModel(),
+      { lineNumber: 1, column: editorState.value.length + 1 },
+    );
+    const fuzzyColumn = fuzzyColumnResult.suggestions.find((item: any) => item.label === 'auth_code');
+    expect(fuzzyColumn).toMatchObject({ filterText: 'code' });
     await act(async () => {
       renderer.unmount();
     });

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -198,6 +198,7 @@ import {
     resolveQueryEditorNavigationDecorations,
     resolveQueryEditorNavigationTarget,
     rankQueryEditorCompletionCandidate,
+    resolveQueryEditorCompletionFilterText,
     resolveQueryLocatorPlan,
     rewriteLeadingSelectTableReference,
     selectUnqualifiedCompletionSynonyms,
@@ -5385,13 +5386,20 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                       dbQualifiedLabel,
                   };
               };
-              const buildTableSuggestion = (label: string, prefix: string, comment?: string) => ({
+              const buildTableSuggestion = (
+                  label: string,
+                  detailPrefix: string,
+                  comment?: string,
+                  filterPrefix = '',
+                  filterCandidates: readonly string[] = [label],
+              ) => ({
                   label: buildQueryEditorTableSuggestionLabel(
                       label,
-                      appendCommentToDetail(prefix, comment),
+                      appendCommentToDetail(detailPrefix, comment),
                       useStructuredCompletionLabel,
                   ),
-                  filterText: normalizeQueryEditorTableSuggestionText(label),
+                  filterText: resolveQueryEditorCompletionFilterText(filterPrefix, filterCandidates)
+                      || normalizeQueryEditorTableSuggestionText(label),
               });
               const normalizeRoutineType = (routineType: string) => (
                   String(routineType || '').trim().toUpperCase().includes('PROC') ? 'PROCEDURE' : 'FUNCTION'
@@ -5698,16 +5706,17 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                   const suggestions = buildBoundedQueryEditorCompletionSuggestions({
                       candidates: cols,
                       prefix: colPrefix,
-                      getMatchRank: (column, prefix) => rankQueryEditorCompletionCandidate(prefix, [column.name], false),
-                      getSelectionKey: (column) => '0' + column.name,
+                      getMatchRank: (column, prefix) => rankQueryEditorCompletionCandidate(prefix, [column.name]),
+                      getSelectionKey: (column, _prefix, matchRank) => `0${matchRank}${column.name}`,
                       buildSuggestion: (column) => ({
                           label: column.name,
                           kind: monaco.languages.CompletionItemKind.Field,
                           insertText: quoteCompletionPart(column.name),
                           detail: buildColumnCompletionDetail(column),
                           documentation: buildColumnCompletionDocumentation(column),
+                          filterText: resolveQueryEditorCompletionFilterText(colPrefix, [column.name]) || column.name,
                           range,
-                          sortText: '0' + column.name,
+                          sortText: `0${rankQueryEditorCompletionCandidate(colPrefix, [column.name]) ?? 9}${column.name}`,
                       }),
                   });
                   return { suggestions };
@@ -5956,16 +5965,17 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                       const suggestions = buildBoundedQueryEditorCompletionSuggestions({
                           candidates: cols,
                           prefix,
-                          getMatchRank: (column, normalizedPrefix) => rankQueryEditorCompletionCandidate(normalizedPrefix, [column.name], false),
-                          getSelectionKey: (column) => '0' + column.name,
+                          getMatchRank: (column, normalizedPrefix) => rankQueryEditorCompletionCandidate(normalizedPrefix, [column.name]),
+                          getSelectionKey: (column, _prefix, matchRank) => `0${matchRank}${column.name}`,
                           buildSuggestion: (column) => ({
                               label: column.name,
                               kind: monaco.languages.CompletionItemKind.Field,
                               insertText: quoteCompletionPart(column.name),
                               detail: buildColumnCompletionDetail(column),
                               documentation: buildColumnCompletionDocumentation(column),
+                              filterText: resolveQueryEditorCompletionFilterText(prefix, [column.name]) || column.name,
                               range,
-                              sortText: '0' + column.name,
+                              sortText: `0${rankQueryEditorCompletionCandidate(prefix, [column.name]) ?? 9}${column.name}`,
                           }),
                       });
                       return { suggestions };
@@ -6099,7 +6109,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                       if (!foundTables.has(fullIdent) && !foundTables.has(shortIdent) && (!pureIdent || !foundTables.has(pureIdent))) {
                           return null;
                       }
-                      return rankQueryEditorCompletionCandidate(normalizedPrefix, [column.name], false);
+                      return rankQueryEditorCompletionCandidate(normalizedPrefix, [column.name]);
                   },
                   getSelectionKey: (column) => (
                       isCurrentCompletionDatabase(column.dbName || '')
@@ -6114,6 +6124,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                           insertText: quoteCompletionPart(column.name),
                           detail: buildColumnCompletionDetail(column),
                           documentation: buildColumnCompletionDocumentation(column),
+                          filterText: resolveQueryEditorCompletionFilterText(wordPrefix, [column.name]) || column.name,
                           range,
                           sortText: isCurrentDb ? sortGroups.columnCurrent + column.name : sortGroups.columnOther + column.name,
                       };
@@ -6166,6 +6177,8 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                                   label,
                                   `${translate('query_editor.object_info.table')} (${table.dbName})`,
                                   table.comment,
+                                  wordPrefix,
+                                  [label, table.tableName || '', pureTable],
                               ),
                               kind: monaco.languages.CompletionItemKind.Class,
                               insertText: quoteCompletionPath(label),
@@ -6183,6 +6196,8 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                               label,
                               `${translate('query_editor.object_info.table')}${schemaInfo}`,
                               table.comment,
+                              wordPrefix,
+                              [label, table.tableName || '', pureTable],
                           ),
                           kind: monaco.languages.CompletionItemKind.Class,
                           insertText: quoteCompletionPath(hasDuplicate ? table.tableName : pureTable),
@@ -6224,6 +6239,10 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                               kind: monaco.languages.CompletionItemKind.Class,
                               insertText: meta.insertText,
                               detail: `${getViewTypeLabel(materialized)} (${getViewSuggestionScope(view, meta)})`,
+                              filterText: resolveQueryEditorCompletionFilterText(
+                                  wordPrefix,
+                                  [meta.dbQualifiedLabel, meta.displayName, meta.objectName, view.viewName || ''],
+                              ) || label,
                               range,
                               sortText: (isCurrentDb ? sortGroups.tableCurrent : sortGroups.tableOther)
                                   + '1'

--- a/frontend/src/components/queryEditor/QueryEditorHelpers.test.ts
+++ b/frontend/src/components/queryEditor/QueryEditorHelpers.test.ts
@@ -11,6 +11,7 @@ import {
     isOracleBaseTableReference,
     materializeBoundedQueryEditorCompletionBatches,
     rankQueryEditorCompletionCandidate,
+    resolveQueryEditorCompletionFilterText,
     resolveOracleLikeDefaultSchemaName,
     resolveOracleLikeExecutionSchemaName,
     resolveOracleLikeLookupSchemaCandidates,
@@ -19,6 +20,20 @@ import {
     selectUnqualifiedCompletionSynonyms,
     shouldHandleQueryEditorRunShortcutFallback,
 } from './QueryEditorHelpers';
+
+describe('QueryEditor fuzzy completion matching', () => {
+    it('ranks substring matches after exact and prefix matches', () => {
+        expect(rankQueryEditorCompletionCandidate('new', ['new'])).toBe(0);
+        expect(rankQueryEditorCompletionCandidate('new', ['new_table'])).toBe(1);
+        expect(rankQueryEditorCompletionCandidate('new', ['tabel_new_1'])).toBe(2);
+    });
+
+    it('returns Monaco filter text that preserves a substring match', () => {
+        expect(resolveQueryEditorCompletionFilterText('new', ['tabel_new_1'])).toBe('new_1');
+        expect(resolveQueryEditorCompletionFilterText('NEW', ['tabel_new_1'])).toBe('new_1');
+        expect(resolveQueryEditorCompletionFilterText('missing', ['tabel_new_1'])).toBeUndefined();
+    });
+});
 
 describe('QueryEditor result merge identity', () => {
     it('keeps zero-based Elasticsearch request indexes distinct', () => {

--- a/frontend/src/components/queryEditor/QueryEditorHelpers.ts
+++ b/frontend/src/components/queryEditor/QueryEditorHelpers.ts
@@ -83,6 +83,27 @@ export const rankQueryEditorCompletionCandidate = (
     return null;
 };
 
+/**
+ * Monaco applies its own fuzzy filter after a completion provider returns.
+ * Expose the matching portion so a candidate matched in the middle of its
+ * name remains visible (for example `new` in `tabel_new_1`).
+ */
+export const resolveQueryEditorCompletionFilterText = (
+    prefix: string,
+    candidates: readonly string[],
+): string | undefined => {
+    const normalizedPrefix = String(prefix || '').trim().toLowerCase();
+    if (!normalizedPrefix) return undefined;
+    for (const candidate of candidates) {
+        const value = String(candidate || '').trim();
+        const matchIndex = value.toLowerCase().indexOf(normalizedPrefix);
+        if (matchIndex >= 0) {
+            return value.slice(matchIndex);
+        }
+    }
+    return undefined;
+};
+
 type RankedQueryEditorCompletionCandidate<Candidate> = {
     candidate: Candidate;
     selectionKey: string;


### PR DESCRIPTION
## Summary\n- support case-insensitive substring matching for SQL table and column completion\n- preserve Monaco completion items matched in the middle of an identifier\n- add provider and helper regression coverage\n\n## Validation\n- rontend Vitest: 325 tests passed\n- TypeScript check passed\n- Vite production build passed\n- Wails packaged build passed and launched successfully\n\nCloses #880