### PR TITLE
🐛 fix(rabbitmq): 避免字段元数据读取队列消息

### DIFF
--- a/internal/db/rabbitmq_impl.go
+++ b/internal/db/rabbitmq_impl.go
@@ -384,19 +384,11 @@ func (r *RabbitMQDB) GetColumns(dbName, tableName string) ([]connection.ColumnDe
 	if r.client == nil {
 		return nil, fmt.Errorf("连接未打开")
 	}
-	vhost := rabbitmqResolveVHost(dbName, r.defaultVHost)
 	queue := rabbitmqResolveQueue(tableName, r.defaultQueue)
 	if queue == "" {
 		return nil, fmt.Errorf("RabbitMQ queue 不能为空")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 
-	items, err := r.getQueueMessages(ctx, vhost, queue, 20)
-	if err != nil {
-		return nil, err
-	}
-	rows := rabbitmqMessageRows(vhost, queue, items)
 	columns := []connection.ColumnDefinition{
 		{Name: "vhost", Type: "string", Nullable: "NO", Comment: "RabbitMQ virtual host"},
 		{Name: "queue", Type: "string", Nullable: "NO", Key: "PRI", Comment: "RabbitMQ queue"},
@@ -409,28 +401,6 @@ func (r *RabbitMQDB) GetColumns(dbName, tableName string) ([]connection.ColumnDe
 		{Name: "payload_bytes", Type: "int", Nullable: "YES", Comment: "Payload size in bytes"},
 		{Name: "properties", Type: "json", Nullable: "YES", Comment: "AMQP properties"},
 		{Name: "headers", Type: "json", Nullable: "YES", Comment: "AMQP headers"},
-	}
-	seen := map[string]struct{}{
-		"vhost": {}, "queue": {}, "exchange": {}, "routing_key": {}, "redelivered": {},
-		"message_count": {}, "payload": {}, "payload_encoding": {}, "payload_bytes": {},
-		"properties": {}, "headers": {},
-	}
-	for _, row := range rows {
-		for key, value := range row {
-			if _, exists := seen[key]; exists {
-				continue
-			}
-			if !strings.HasPrefix(key, "payload.") && !strings.HasPrefix(key, "properties.") && !strings.HasPrefix(key, "headers.") {
-				continue
-			}
-			seen[key] = struct{}{}
-			columns = append(columns, connection.ColumnDefinition{
-				Name:     key,
-				Type:     inferChromaValueType(value),
-				Nullable: "YES",
-				Comment:  "Derived RabbitMQ field",
-			})
-		}
 	}
 	return columns, nil
 }

--- a/internal/db/rabbitmq_impl_test.go
+++ b/internal/db/rabbitmq_impl_test.go
@@ -112,6 +112,7 @@ func TestNormalizeRabbitMQConfigParsesURIAndParams(t *testing.T) {
 
 func TestRabbitMQQueryExecAndColumns(t *testing.T) {
 	var lastGetCount int
+	var getRequestCount int
 	var lastPublishBody map[string]interface{}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -166,6 +167,7 @@ func TestRabbitMQQueryExecAndColumns(t *testing.T) {
 				"page_count": 1,
 			})
 		case req.Method == http.MethodPost && escapedPath == "/api/queues/%2F/orders.events.v1/get":
+			getRequestCount++
 			var body map[string]interface{}
 			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
 				t.Fatalf("decode get body failed: %v", err)
@@ -299,18 +301,22 @@ func TestRabbitMQQueryExecAndColumns(t *testing.T) {
 		t.Fatalf("unexpected publish payload: %#v", lastPublishBody)
 	}
 
+	getRequestCount = 0
 	columnDefs, err := client.GetColumns("/", "orders.events.v1")
 	if err != nil {
 		t.Fatalf("GetColumns failed: %v", err)
+	}
+	if getRequestCount != 0 {
+		t.Fatalf("GetColumns must not read queue messages, requests=%d", getRequestCount)
 	}
 	names := make([]string, 0, len(columnDefs))
 	for _, col := range columnDefs {
 		names = append(names, col.Name)
 	}
 	joined := strings.Join(names, ",")
-	for _, want := range []string{"queue", "payload.meta.ip", "headers.x-env", "properties.content_type"} {
+	for _, want := range []string{"queue", "payload", "headers", "properties"} {
 		if !strings.Contains(joined, want) {
-			t.Fatalf("expected derived rabbitmq column %q in %s", want, joined)
+			t.Fatalf("expected RabbitMQ column %q in %s", want, joined)
 		}
 	}
 


### PR DESCRIPTION
## 背景与问题

RabbitMQ 的 GetColumns 为推断 Payload 动态字段，会调用队列 /get 接口并使用 ck_requeue_true。该操作会实际读取并重新投递消息，使本应只读的字段元数据读取产生 Broker 副作用。

Closes #881

## 变更点

- GetColumns 仅返回 RabbitMQ 静态消息字段，不再读取队列样本消息。
- 保留 SELECT 查询的消息预览逻辑。
- 增加回归断言，确保普通字段元数据读取不会请求 /api/queues/{vhost}/{queue}/get。

## 影响范围

- 字段元数据和全库字段搜索不再触碰真实队列消息。
- payload.*、headers.*、properties.* 等样本推断字段不再自动出现在元数据中；项目当前没有显式样本读取入口。

## 验证方式

`	ext
go test ./internal/db -run RabbitMQ -count=1
` 

## 风险与回滚

不涉及数据迁移或构建链路。若需要恢复隐式动态字段推断，可回滚本 PR。