### PR TITLE
🐛 fix(sqlserver): 避免 DDL 查看伪成功

### DIFF
--- a/internal/app/methods_db_create_statement_test.go
+++ b/internal/app/methods_db_create_statement_test.go
@@ -623,7 +623,7 @@ func TestResolveCreateStatementWithFallback_SQLServerBuildsFallbackDDL(t *testin
 
 	defaultValue := "((0))"
 	dbInst := &fakeCreateStatementDB{
-		createSQL: "-- SHOW CREATE TABLE not supported for SQL Server in this version.",
+		createErr: errors.New("SQL Server DDL unsupported"),
 		columns: []connection.ColumnDefinition{
 			{Name: "id", Type: "int", Nullable: "NO", Key: "PRI", Extra: "auto_increment", Comment: "主键"},
 			{Name: "display_name", Type: "nvarchar(128)", Nullable: "YES", Default: &defaultValue, Comment: "显示名's"},

--- a/internal/db/sqlserver_impl.go
+++ b/internal/db/sqlserver_impl.go
@@ -530,7 +530,7 @@ ORDER BY s.name, t.name`, safeDB, safeDB)
 }
 
 func (s *SqlServerDB) GetCreateStatement(dbName, tableName string) (string, error) {
-	return fmt.Sprintf("-- SHOW CREATE TABLE not supported for SQL Server in this version.\n-- Table: %s.%s", dbName, tableName), nil
+	return "", localizedDatabaseRuntimeError("db.backend.error.sqlserver_create_statement_unsupported", nil)
 }
 
 func (s *SqlServerDB) GetColumns(dbName, tableName string) ([]connection.ColumnDefinition, error) {

--- a/internal/db/sqlserver_impl_test.go
+++ b/internal/db/sqlserver_impl_test.go
@@ -398,6 +398,13 @@ func TestSQLServerMetadataErrorsUseCurrentLanguage(t *testing.T) {
 		call func() error
 	}{
 		{
+			name: "create statement unsupported",
+			call: func() error {
+				_, err := sqlServer.GetCreateStatement("dbo", "orders")
+				return err
+			},
+		},
+		{
 			name: "columns table name required",
 			call: func() error {
 				_, err := sqlServer.GetColumns("", " ")
@@ -432,6 +439,12 @@ func TestSQLServerMetadataErrorsUseCurrentLanguage(t *testing.T) {
 			err := tc.call()
 			if err == nil {
 				t.Fatal("expected SQL Server metadata call to fail")
+			}
+			if tc.name == "create statement unsupported" {
+				if err.Error() != "Viewing SQL Server table DDL is not supported by the current backend" {
+					t.Fatalf("expected English unsupported DDL error, got %q", err.Error())
+				}
+				return
 			}
 			if err.Error() != "Table name is required" {
 				t.Fatalf("expected English table-name-required error, got %q", err.Error())

--- a/shared/i18n/de-DE.json
+++ b/shared/i18n/de-DE.json
@@ -5164,6 +5164,7 @@
   "db.backend.error.connection_open_failed_prefix": "Datenbankverbindung konnte nicht geöffnet werden: ",
   "db.backend.error.connection_verify_failed_prefix": "Verbindung konnte nach dem Aufbau nicht verifiziert werden: ",
   "db.backend.error.create_table_statement_not_found": "Die CREATE TABLE-Anweisung wurde nicht gefunden",
+  "db.backend.error.sqlserver_create_statement_unsupported": "Das Anzeigen der SQL Server-Tabellen-DDL wird vom aktuellen Backend nicht unterstützt",
   "db.backend.error.custom_clickhouse_dsn_invalid": "Die DSN der benutzerdefinierten ClickHouse-Verbindung ist ungültig. Verwenden Sie eine Einzelknoten-Adresse im Format clickhouse://, http(s)://, jdbc:clickhouse:// oder jdbc:ch://",
   "db.backend.error.custom_clickhouse_dsn_required": "Für eine benutzerdefinierte ClickHouse-Verbindung ist eine DSN im Format clickhouse://, http(s)://, jdbc:clickhouse:// oder jdbc:ch:// erforderlich",
   "db.backend.error.custom_driver_system_odbc_unsupported_prefix": "Datenbankverbindung konnte nicht geöffnet werden: Benutzerdefinierte Verbindungen unterstützen es nicht, den System-ODBC/JDBC-Treibernamen \"{{driver}}\" direkt einzugeben. Geben Sie stattdessen einen bereits in GoNavi registrierten Go database/sql-Treibernamen ein. Der aktuelle Build registriert keinen generischen ODBC-Treiber, daher wird eine Verbindung zu InterSystems IRIS über \"{{driver}}\" derzeit noch nicht unterstützt: ",

--- a/shared/i18n/en-US.json
+++ b/shared/i18n/en-US.json
@@ -5164,6 +5164,7 @@
   "db.backend.error.connection_open_failed_prefix": "Failed to open database connection: ",
   "db.backend.error.connection_verify_failed_prefix": "Failed to verify the established connection: ",
   "db.backend.error.create_table_statement_not_found": "The CREATE TABLE statement was not found",
+  "db.backend.error.sqlserver_create_statement_unsupported": "Viewing SQL Server table DDL is not supported by the current backend",
   "db.backend.error.custom_clickhouse_dsn_invalid": "The ClickHouse custom connection DSN is invalid. Use a single-node clickhouse://, http(s)://, jdbc:clickhouse://, or jdbc:ch:// address",
   "db.backend.error.custom_clickhouse_dsn_required": "A ClickHouse custom connection requires a clickhouse://, http(s)://, jdbc:clickhouse://, or jdbc:ch:// DSN",
   "db.backend.error.custom_driver_system_odbc_unsupported_prefix": "Failed to open database connection: custom connections do not support entering the system ODBC/JDBC driver name \"{{driver}}\" directly. Enter a Go database/sql driver name already registered by GoNavi. The current build does not register a generic ODBC driver, so connecting to InterSystems IRIS through \"{{driver}}\" is not supported yet: ",

--- a/shared/i18n/ja-JP.json
+++ b/shared/i18n/ja-JP.json
@@ -5164,6 +5164,7 @@
   "db.backend.error.connection_open_failed_prefix": "データベース接続を開けませんでした: ",
   "db.backend.error.connection_verify_failed_prefix": "接続確立後の検証に失敗しました: ",
   "db.backend.error.create_table_statement_not_found": "CREATE TABLE 文が見つかりませんでした",
+  "db.backend.error.sqlserver_create_statement_unsupported": "現在のバックエンドでは SQL Server テーブル DDL の表示はサポートされていません",
   "db.backend.error.custom_clickhouse_dsn_invalid": "ClickHouse カスタム接続の DSN が無効です。clickhouse://、http(s)://、jdbc:clickhouse://、または jdbc:ch:// 形式の単一ノードアドレスを使用してください",
   "db.backend.error.custom_clickhouse_dsn_required": "ClickHouse カスタム接続には clickhouse://、http(s)://、jdbc:clickhouse://、または jdbc:ch:// 形式の DSN が必要です",
   "db.backend.error.custom_driver_system_odbc_unsupported_prefix": "データベース接続を開けませんでした: カスタム接続ではシステム ODBC/JDBC ドライバー名 \"{{driver}}\" を直接入力できません。GoNavi に登録済みの Go database/sql ドライバー名を入力してください。現在のビルドには汎用 ODBC ドライバーが登録されていないため、\"{{driver}}\" 経由で InterSystems IRIS に接続することはまだサポートされていません: ",

--- a/shared/i18n/ru-RU.json
+++ b/shared/i18n/ru-RU.json
@@ -5164,6 +5164,7 @@
   "db.backend.error.connection_open_failed_prefix": "Не удалось открыть подключение к базе данных: ",
   "db.backend.error.connection_verify_failed_prefix": "Не удалось проверить подключение после установления: ",
   "db.backend.error.create_table_statement_not_found": "Инструкция CREATE TABLE не найдена",
+  "db.backend.error.sqlserver_create_statement_unsupported": "Текущий бэкенд не поддерживает просмотр DDL таблиц SQL Server",
   "db.backend.error.custom_clickhouse_dsn_invalid": "Недопустимая DSN пользовательского подключения ClickHouse. Используйте адрес одного узла в формате clickhouse://, http(s)://, jdbc:clickhouse:// или jdbc:ch://",
   "db.backend.error.custom_clickhouse_dsn_required": "Для пользовательского подключения ClickHouse требуется DSN в формате clickhouse://, http(s)://, jdbc:clickhouse:// или jdbc:ch://",
   "db.backend.error.custom_driver_system_odbc_unsupported_prefix": "Не удалось открыть подключение к базе данных: пользовательские подключения не поддерживают прямой ввод имени системного драйвера ODBC/JDBC \"{{driver}}\". Укажите имя драйвера Go database/sql, уже зарегистрированного в GoNavi. Текущая сборка не регистрирует универсальный ODBC-драйвер, поэтому подключение к InterSystems IRIS через \"{{driver}}\" пока не поддерживается: ",

--- a/shared/i18n/zh-CN.json
+++ b/shared/i18n/zh-CN.json
@@ -5164,6 +5164,7 @@
   "db.backend.error.connection_open_failed_prefix": "打开数据库连接失败：",
   "db.backend.error.connection_verify_failed_prefix": "连接建立后验证失败：",
   "db.backend.error.create_table_statement_not_found": "未找到 CREATE TABLE 语句",
+  "db.backend.error.sqlserver_create_statement_unsupported": "当前后端暂不支持查看 SQL Server 表 DDL",
   "db.backend.error.custom_clickhouse_dsn_invalid": "ClickHouse 自定义连接 DSN 无效；请使用 clickhouse://、http(s)://、jdbc:clickhouse:// 或 jdbc:ch:// 格式的单节点地址",
   "db.backend.error.custom_clickhouse_dsn_required": "ClickHouse 自定义连接需要填写 clickhouse://、http(s)://、jdbc:clickhouse:// 或 jdbc:ch:// 格式的 DSN",
   "db.backend.error.custom_driver_system_odbc_unsupported_prefix": "打开数据库连接失败：自定义连接不支持直接填写系统 ODBC/JDBC 驱动名 \"{{driver}}\"。请填写 GoNavi 已注册的 Go database/sql 驱动名。当前构建未注册通用 ODBC 驱动，因此暂不支持通过 \"{{driver}}\" 连接 InterSystems IRIS：",

--- a/shared/i18n/zh-TW.json
+++ b/shared/i18n/zh-TW.json
@@ -5164,6 +5164,7 @@
   "db.backend.error.connection_open_failed_prefix": "開啟資料庫連線失敗：",
   "db.backend.error.connection_verify_failed_prefix": "連線建立後驗證失敗：",
   "db.backend.error.create_table_statement_not_found": "未找到 CREATE TABLE 語句",
+  "db.backend.error.sqlserver_create_statement_unsupported": "目前後端暫不支援查看 SQL Server 表格 DDL",
   "db.backend.error.custom_clickhouse_dsn_invalid": "ClickHouse 自訂連線 DSN 無效；請使用 clickhouse://、http(s)://、jdbc:clickhouse:// 或 jdbc:ch:// 格式的單一節點位址",
   "db.backend.error.custom_clickhouse_dsn_required": "ClickHouse 自訂連線需要填寫 clickhouse://、http(s)://、jdbc:clickhouse:// 或 jdbc:ch:// 格式的 DSN",
   "db.backend.error.custom_driver_system_odbc_unsupported_prefix": "開啟資料庫連線失敗：自訂連線不支援直接填寫系統 ODBC/JDBC 驅動名稱 \"{{driver}}\"。請填寫 GoNavi 已註冊的 Go database/sql 驅動名稱。目前建置未註冊通用 ODBC 驅動，因此暫不支援透過 \"{{driver}}\" 連線 InterSystems IRIS：",


### PR DESCRIPTION
## 背景与问题

SQL Server 的 GetCreateStatement 会返回未支持的占位注释且不返回错误，调用方会将其视为成功 DDL。

Closes #882

## 变更点

- 原生 SQL Server DDL 不可用时返回明确、本地化的 unsupported 错误。
- 让既有 DDL fallback 使用字段和索引元数据生成可执行的 CREATE TABLE。
- 补充 SQL Server 原生错误和 fallback 控制流回归测试。
- 补齐六种语言的错误提示。

## 影响范围

- SQL Server DDL 查看不再显示伪成功的占位注释。
- 元数据可读取时，DDL 视图将展示 fallback 生成的表定义、主键、默认值和索引。
- 若 fallback 元数据读取失败，既有 UI 将展示后端错误。

## 验证方式

`	ext
go test -tags gonavi_sqlserver_driver ./internal/db -run TestSQLServerMetadataErrorsUseCurrentLanguage -count=1
go test ./internal/app -run TestResolveCreateStatementWithFallback_SQLServerBuildsFallbackDDL -count=1
go test ./shared/i18n -run Test -count=1
` 

## 风险与回滚

未涉及数据库迁移或构建链路。没有真实 SQL Server Driver Agent 环境，真实服务端元数据兼容性仍待补充验证；如需回滚可直接回滚本 PR。