### PR TITLE
🐛 fix(datagrid): 修复固定选择列透明问题 (#901)

### DIFF
--- a/frontend/src/components/DataGrid.layout.test.tsx
+++ b/frontend/src/components/DataGrid.layout.test.tsx
@@ -504,6 +504,52 @@ describe('DataGrid layout', () => {
     expect(css).not.toContain('modified-hover');
   });
 
+  it('keeps fixed row controls opaque when their row is hovered or selected', () => {
+    const css = buildDataGridCssText({
+      darkMode: false,
+      densityParams: { dataFontSize: 12 },
+      gridId: 'row-number-state-grid',
+      bgContent: '#ffffff',
+    });
+
+    const transparentHover = css.indexOf(
+      '.row-number-state-grid.data-grid-root .ant-table-tbody .ant-table-row:hover > .ant-table-cell',
+    );
+    expect(transparentHover).toBeGreaterThanOrEqual(0);
+
+    const fixedRowControl = ':is(.data-grid-row-number-cell, .ant-table-selection-column)';
+    const fixedRowControlHoverSelectors = [
+      `.row-number-state-grid.data-grid-root .ant-table-tbody-virtual-holder .ant-table-row:hover > .ant-table-cell${fixedRowControl}`,
+      `.row-number-state-grid.data-grid-root .ant-table-tbody-virtual .ant-table-row:hover > .ant-table-cell${fixedRowControl}`,
+      `.row-number-state-grid.data-grid-root .ant-table-tbody-virtual-holder-inner .ant-table-row:hover > .ant-table-cell${fixedRowControl}`,
+      `.row-number-state-grid.data-grid-root .ant-table-tbody > tr:hover > td${fixedRowControl}`,
+    ];
+    fixedRowControlHoverSelectors.forEach((selector) => {
+      const ruleStart = css.indexOf(selector);
+      expect(ruleStart).toBeGreaterThan(transparentHover);
+      const ruleEnd = css.indexOf('}', ruleStart);
+      const rule = css.slice(ruleStart, ruleEnd + 1);
+      expect(rule).toContain('background: var(--gn-bg-panel, #ffffff) !important;');
+      expect(rule).toContain('background-image: none !important;');
+    });
+
+    const fixedRowControlSelectedSelectors = [
+      `.row-number-state-grid.data-grid-root .ant-table-tbody-virtual-holder .ant-table-row:is(.ant-table-row-selected, .ant-table-row-selected:hover) > .ant-table-cell${fixedRowControl}`,
+      `.row-number-state-grid.data-grid-root .ant-table-tbody-virtual .ant-table-row:is(.ant-table-row-selected, .ant-table-row-selected:hover) > .ant-table-cell${fixedRowControl}`,
+      `.row-number-state-grid.data-grid-root .ant-table-tbody-virtual-holder-inner .ant-table-row:is(.ant-table-row-selected, .ant-table-row-selected:hover) > .ant-table-cell${fixedRowControl}`,
+      `.row-number-state-grid.data-grid-root .ant-table-tbody > tr:is(.ant-table-row-selected, .ant-table-row-selected:hover) > td${fixedRowControl}`,
+    ];
+    fixedRowControlSelectedSelectors.forEach((selector) => {
+      const ruleStart = css.indexOf(selector);
+      expect(ruleStart).toBeGreaterThan(transparentHover);
+      const ruleEnd = css.indexOf('}', ruleStart);
+      const rule = css.slice(ruleStart, ruleEnd + 1);
+      expect(rule).toContain('background-color: var(--gn-bg-panel, #ffffff) !important;');
+      expect(rule).toContain('background-image: linear-gradient(');
+      expect(rule).toContain('var(--gn-bg-selected, rgba(34, 197, 94, 0.14))');
+    });
+  });
+
   it('uses the table cell as the only V2 inline edit frame', () => {
     const css = readV2ThemeCss();
     const inlineEditorCss = css.slice(

--- a/frontend/src/components/dataGridStyles.ts
+++ b/frontend/src/components/dataGridStyles.ts
@@ -426,6 +426,15 @@ export const buildDataGridCssText = ({
 
                 .${gridId}.data-grid-root .ant-table-tbody .ant-table-row:hover > .ant-table-cell { background-color: transparent !important; }
 
+                /* 固定行控制列（序号/单选/多选）在整行 hover 透明时仍保持实心底。 */
+                .${gridId}.data-grid-root .ant-table-tbody-virtual-holder .ant-table-row:hover > .ant-table-cell:is(.data-grid-row-number-cell, .ant-table-selection-column),
+                .${gridId}.data-grid-root .ant-table-tbody-virtual .ant-table-row:hover > .ant-table-cell:is(.data-grid-row-number-cell, .ant-table-selection-column),
+                .${gridId}.data-grid-root .ant-table-tbody-virtual-holder-inner .ant-table-row:hover > .ant-table-cell:is(.data-grid-row-number-cell, .ant-table-selection-column),
+                .${gridId}.data-grid-root .ant-table-tbody > tr:hover > td:is(.data-grid-row-number-cell, .ant-table-selection-column) {
+                    background: var(--gn-bg-panel, ${bgContent}) !important;
+                    background-image: none !important;
+                }
+
                 /*
                  * 行选中：整行统一绿色。
                  * 关键：virtual-holder 下有
@@ -455,6 +464,18 @@ export const buildDataGridCssText = ({
                     background: rgba(34, 197, 94, 0.14) !important;
                     background-color: rgba(34, 197, 94, 0.14) !important;
                     background-image: none !important;
+                }
+
+                /* 选中行同样覆盖固定行控制列，保持与整行一致的选中底色。 */
+                .${gridId}.data-grid-root .ant-table-tbody-virtual-holder .ant-table-row:is(.ant-table-row-selected, .ant-table-row-selected:hover) > .ant-table-cell:is(.data-grid-row-number-cell, .ant-table-selection-column),
+                .${gridId}.data-grid-root .ant-table-tbody-virtual .ant-table-row:is(.ant-table-row-selected, .ant-table-row-selected:hover) > .ant-table-cell:is(.data-grid-row-number-cell, .ant-table-selection-column),
+                .${gridId}.data-grid-root .ant-table-tbody-virtual-holder-inner .ant-table-row:is(.ant-table-row-selected, .ant-table-row-selected:hover) > .ant-table-cell:is(.data-grid-row-number-cell, .ant-table-selection-column),
+                .${gridId}.data-grid-root .ant-table-tbody > tr:is(.ant-table-row-selected, .ant-table-row-selected:hover) > td:is(.data-grid-row-number-cell, .ant-table-selection-column) {
+                    background-color: var(--gn-bg-panel, ${bgContent}) !important;
+                    background-image: linear-gradient(
+                        var(--gn-bg-selected, rgba(34, 197, 94, 0.14)),
+                        var(--gn-bg-selected, rgba(34, 197, 94, 0.14))
+                    ) !important;
                 }
 
                 .${gridId} .row-added td,


### PR DESCRIPTION
## Summary

- Keep the row-number and selection columns opaque while a DataGrid row is hovered or selected.
- Cover regular and virtual table body layouts, including selected plus hovered controls.

## Testing

- `npm test -- --run src/components/DataGrid.layout.test.tsx`
- `npm run build`
- `npm test`

Fixes #901
