### PR TITLE
🐛 fix(sidebar): 延长连接树滚动条显示时间

### DIFF
--- a/frontend/src/components/Sidebar.locate-toolbar.test.tsx
+++ b/frontend/src/components/Sidebar.locate-toolbar.test.tsx
@@ -1186,6 +1186,8 @@ describe('Sidebar locate toolbar', () => {
     expect(source).toContain('onWheelCapture={handleTreeWheel}');
     expect(source).toContain('onTouchMoveCapture={markTreeScrollActivity}');
     expect(source).toContain('setIsTreeScrolling(false)');
+    expect(source).toContain('SIDEBAR_TREE_SCROLL_IDLE_DELAY_MS = 2000');
+    expect(source).toContain('}, SIDEBAR_TREE_SCROLL_IDLE_DELAY_MS);');
 
     const idleScrollbarCss = readCssRuleBlock(
       css,

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -335,6 +335,7 @@ const SIDEBAR_LOCATE_LOAD_WAIT_ATTEMPTS = 160;
 const SIDEBAR_CACHED_DATABASE_TREE_LIMIT = 12;
 const NACOS_SERVICES_CHANGED_EVENT = 'gonavi:nacos-services-changed';
 const SIDEBAR_GROUP_HOVER_EXPAND_DELAY_MS = 500;
+const SIDEBAR_TREE_SCROLL_IDLE_DELAY_MS = 2000;
 
 type SidebarTreeDragEventLike = {
   dataTransfer?: DataTransfer | null;
@@ -1048,7 +1049,7 @@ const Sidebar: React.FC<{
       treeScrollIdleTimerRef.current = window.setTimeout(() => {
           treeScrollIdleTimerRef.current = null;
           setIsTreeScrolling(false);
-      }, 500);
+      }, SIDEBAR_TREE_SCROLL_IDLE_DELAY_MS);
   }, [isV2Ui]);
 
   const handleTreeWheel = useCallback((event: React.WheelEvent<HTMLDivElement>) => {


### PR DESCRIPTION
## Summary

- 延长左侧 V2 连接树滚动条的显示时间，滚动停止 2 秒后再隐藏
- 增加回归断言，锁定滚动条空闲延迟配置

## Testing

- `npm --prefix frontend test -- Sidebar.locate-toolbar.test.tsx`（93/93 通过）
- `npm --prefix frontend run build`
- `npm --prefix frontend test`
- 浏览器桌面与窄窗口滚动条时序验证
- 用户手动自测通过
