### PR TITLE
🐛 fix(ai): 修复 Windows CodeBuddy Git Bash 解析

### DIFF
--- a/internal/ai/provider/claude_cli.go
+++ b/internal/ai/provider/claude_cli.go
@@ -732,17 +732,22 @@ func resolveClaudeCodeGitBashPath(env []string, goos string, lookPath func(strin
 
 	if configured := strings.TrimSpace(envValue(env, "CLAUDE_CODE_GIT_BASH_PATH")); configured != "" {
 		if exists(configured) {
+			if isWindowsWSLBashLauncher(configured) {
+				return "", fmt.Errorf("Claude Code CLI requires Git Bash on Windows, but CLAUDE_CODE_GIT_BASH_PATH points to a WSL launcher: %s", configured)
+			}
 			return configured, nil
 		}
 		return "", fmt.Errorf("Claude Code CLI requires git-bash on Windows, but CLAUDE_CODE_GIT_BASH_PATH points to a missing bash.exe: %s", configured)
 	}
 
-	for _, command := range []string{"bash.exe", "bash"} {
-		if bashPath, err := lookPath(command); err == nil && exists(bashPath) {
-			return bashPath, nil
-		}
+	if detected := detectWindowsGitBashPath(env, lookPath, exists); detected != "" {
+		return detected, nil
 	}
 
+	return "", fmt.Errorf("Claude Code CLI requires git-bash on Windows. Install Git for Windows (https://git-scm.com/downloads/win); if Git is already installed but not on PATH, set CLAUDE_CODE_GIT_BASH_PATH to bash.exe, for example C:\\Program Files\\Git\\bin\\bash.exe")
+}
+
+func detectWindowsGitBashPath(env []string, lookPath func(string) (string, error), exists func(string) bool) string {
 	if gitPath, err := lookPath("git.exe"); err == nil {
 		gitDir := parentWindowsPath(gitPath)
 		for _, candidate := range []string{
@@ -750,18 +755,33 @@ func resolveClaudeCodeGitBashPath(env []string, goos string, lookPath func(strin
 			joinWindowsPath(gitDir, "bash.exe"),
 		} {
 			if candidate != "" && exists(candidate) {
-				return candidate, nil
+				return candidate
 			}
 		}
 	}
 
 	for _, candidate := range windowsGitBashCandidates(env) {
 		if exists(candidate) {
-			return candidate, nil
+			return candidate
 		}
 	}
 
-	return "", fmt.Errorf("Claude Code CLI requires git-bash on Windows. Install Git for Windows (https://git-scm.com/downloads/win); if Git is already installed but not on PATH, set CLAUDE_CODE_GIT_BASH_PATH to bash.exe, for example C:\\Program Files\\Git\\bin\\bash.exe")
+	for _, command := range []string{"bash.exe", "bash"} {
+		if bashPath, err := lookPath(command); err == nil && exists(bashPath) && !isWindowsWSLBashLauncher(bashPath) {
+			return bashPath
+		}
+	}
+	return ""
+}
+
+func isWindowsWSLBashLauncher(path string) bool {
+	normalized := strings.ToLower(strings.Trim(strings.ReplaceAll(strings.TrimSpace(path), "/", `\`), `"`))
+	if !strings.HasSuffix(normalized, `\bash.exe`) && !strings.HasSuffix(normalized, `\bash`) {
+		return false
+	}
+	return strings.Contains(normalized, `\windows\system32\`) ||
+		strings.Contains(normalized, `\windows\sysnative\`) ||
+		strings.Contains(normalized, `\microsoft\windowsapps\`)
 }
 
 func windowsGitBashCandidates(env []string) []string {

--- a/internal/ai/provider/claude_cli_test.go
+++ b/internal/ai/provider/claude_cli_test.go
@@ -403,6 +403,59 @@ func TestBuildClaudeCLIEnv_UsesDetectedGitBashOnWindows(t *testing.T) {
 	}
 }
 
+func TestResolveClaudeCodeGitBashPathPrefersGitForWindowsOverWSLLauncher(t *testing.T) {
+	const (
+		wslBash = `C:\Windows\System32\bash.exe`
+		gitExe  = `C:\Program Files\Git\cmd\git.exe`
+		gitBash = `C:\Program Files\Git\bin\bash.exe`
+	)
+
+	got, err := resolveClaudeCodeGitBashPath(nil, "windows", func(name string) (string, error) {
+		switch name {
+		case "bash.exe", "bash":
+			return wslBash, nil
+		case "git.exe":
+			return gitExe, nil
+		default:
+			return "", errors.New("not found")
+		}
+	}, func(path string) bool {
+		return path == wslBash || path == gitExe || path == gitBash
+	})
+	if err != nil {
+		t.Fatalf("resolve Claude Code Git Bash: %v", err)
+	}
+	if got != gitBash {
+		t.Fatalf("expected Git for Windows bash %q, got %q", gitBash, got)
+	}
+}
+
+func TestResolveClaudeCodeGitBashPathRejectsConfiguredWSLLauncher(t *testing.T) {
+	const wslBash = `C:\Windows\System32\bash.exe`
+	_, err := resolveClaudeCodeGitBashPath(
+		[]string{"CLAUDE_CODE_GIT_BASH_PATH=" + wslBash},
+		"windows",
+		func(name string) (string, error) { return "", errors.New("not found") },
+		func(path string) bool { return path == wslBash },
+	)
+	if err == nil || !strings.Contains(err.Error(), "WSL launcher") {
+		t.Fatalf("expected actionable WSL launcher error, got %v", err)
+	}
+}
+
+func TestResolveClaudeCodeGitBashPathIgnoresPATHWSLLauncher(t *testing.T) {
+	const wslBash = `C:\Windows\System32\bash.exe`
+	_, err := resolveClaudeCodeGitBashPath(nil, "windows", func(name string) (string, error) {
+		if name == "bash.exe" || name == "bash" {
+			return wslBash, nil
+		}
+		return "", errors.New("not found")
+	}, func(path string) bool { return path == wslBash })
+	if err == nil || !strings.Contains(err.Error(), "Install Git for Windows") {
+		t.Fatalf("expected PATH WSL launcher to be ignored with an install hint, got %v", err)
+	}
+}
+
 func TestBuildClaudeCLIEnv_ReturnsActionableErrorWhenGitBashMissingOnWindows(t *testing.T) {
 	_, err := buildClaudeCLIEnv(ai.ProviderConfig{}, []string{"ProgramFiles=C:\\Program Files"}, "windows", func(name string) (string, error) {
 		return "", errors.New("not found")

--- a/internal/ai/provider/codebuddy_cli.go
+++ b/internal/ai/provider/codebuddy_cli.go
@@ -98,11 +98,22 @@ func (p *CodeBuddyCLIProvider) ChatWithState(ctx context.Context, state json.Raw
 			requestErr = fmt.Errorf("CodeBuddy CLI timed out (%s); the current login session, Base URL, or API Key may not be returning a valid response", codebuddyCLIRequestTimeout)
 			return nil, nil, requestErr
 		}
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			requestErr = fmt.Errorf("CodeBuddy CLI execution failed: %s", string(exitErr.Stderr))
+		exitErr, exited := err.(*exec.ExitError)
+		if !exited && len(output) == 0 {
+			requestErr = fmt.Errorf("CodeBuddy CLI execution failed: %w", err)
 			return nil, nil, requestErr
 		}
-		requestErr = fmt.Errorf("CodeBuddy CLI execution failed: %w", err)
+		details := make([]string, 0, 3)
+		if exited {
+			if stderr := strings.TrimSpace(string(exitErr.Stderr)); stderr != "" {
+				details = append(details, "stderr: "+stderr)
+			}
+		}
+		if len(output) > 0 {
+			details = append(details, fmt.Sprintf("stdout: %d bytes omitted", len(output)))
+		}
+		details = append(details, "error: "+err.Error())
+		requestErr = fmt.Errorf("CodeBuddy CLI execution failed: %s", strings.Join(details, "; "))
 		return nil, nil, requestErr
 	}
 
@@ -449,33 +460,16 @@ func resolveCodeBuddyGitBashPath(env []string, goos string, lookPath func(string
 
 	if configured := strings.TrimSpace(envValue(env, "CODEBUDDY_CODE_GIT_BASH_PATH")); configured != "" {
 		if exists(configured) {
+			if isWindowsWSLBashLauncher(configured) {
+				return "", fmt.Errorf("Configured CODEBUDDY_CODE_GIT_BASH_PATH points to a WSL launcher instead of Git Bash on Windows: %s", configured)
+			}
 			return configured, nil
 		}
 		return "", fmt.Errorf("Configured CODEBUDDY_CODE_GIT_BASH_PATH does not exist on Windows: %s", configured)
 	}
 
-	for _, command := range []string{"bash.exe", "bash"} {
-		if bashPath, err := lookPath(command); err == nil && exists(bashPath) {
-			return bashPath, nil
-		}
-	}
-
-	if gitPath, err := lookPath("git.exe"); err == nil {
-		gitDir := parentWindowsPath(gitPath)
-		for _, candidate := range []string{
-			joinWindowsPath(parentWindowsPath(gitDir), "bin", "bash.exe"),
-			joinWindowsPath(gitDir, "bash.exe"),
-		} {
-			if candidate != "" && exists(candidate) {
-				return candidate, nil
-			}
-		}
-	}
-
-	for _, candidate := range windowsGitBashCandidates(env) {
-		if exists(candidate) {
-			return candidate, nil
-		}
+	if detected := detectWindowsGitBashPath(env, lookPath, exists); detected != "" {
+		return detected, nil
 	}
 
 	return "", nil

--- a/internal/ai/provider/codebuddy_cli_test.go
+++ b/internal/ai/provider/codebuddy_cli_test.go
@@ -57,6 +57,62 @@ func TestBuildCodeBuddyCLIEnv_AllowsMissingGitBashOnWindows(t *testing.T) {
 	}
 }
 
+func TestResolveCodeBuddyGitBashPathPrefersGitForWindowsOverWSLLauncher(t *testing.T) {
+	const (
+		wslBash = `C:\Windows\System32\bash.exe`
+		gitExe  = `C:\Program Files\Git\cmd\git.exe`
+		gitBash = `C:\Program Files\Git\bin\bash.exe`
+	)
+
+	got, err := resolveCodeBuddyGitBashPath(nil, "windows", func(name string) (string, error) {
+		switch name {
+		case "bash.exe", "bash":
+			return wslBash, nil
+		case "git.exe":
+			return gitExe, nil
+		default:
+			return "", errors.New("not found")
+		}
+	}, func(path string) bool {
+		return path == wslBash || path == gitExe || path == gitBash
+	})
+	if err != nil {
+		t.Fatalf("resolve CodeBuddy Git Bash: %v", err)
+	}
+	if got != gitBash {
+		t.Fatalf("expected Git for Windows bash %q, got %q", gitBash, got)
+	}
+}
+
+func TestResolveCodeBuddyGitBashPathRejectsConfiguredWSLLauncher(t *testing.T) {
+	const wslBash = `C:\Users\tester\AppData\Local\Microsoft\WindowsApps\bash.exe`
+	_, err := resolveCodeBuddyGitBashPath(
+		[]string{"CODEBUDDY_CODE_GIT_BASH_PATH=" + wslBash},
+		"windows",
+		func(name string) (string, error) { return "", errors.New("not found") },
+		func(path string) bool { return path == wslBash },
+	)
+	if err == nil || !strings.Contains(err.Error(), "WSL launcher") {
+		t.Fatalf("expected actionable WSL launcher error, got %v", err)
+	}
+}
+
+func TestResolveCodeBuddyGitBashPathIgnoresPATHWSLLauncher(t *testing.T) {
+	const wslBash = `C:\Windows\System32\bash.exe`
+	got, err := resolveCodeBuddyGitBashPath(nil, "windows", func(name string) (string, error) {
+		if name == "bash.exe" || name == "bash" {
+			return wslBash, nil
+		}
+		return "", errors.New("not found")
+	}, func(path string) bool { return path == wslBash })
+	if err != nil {
+		t.Fatalf("expected missing Git Bash to remain optional for CodeBuddy, got %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected PATH WSL launcher to be ignored, got %q", got)
+	}
+}
+
 func TestCodeBuddyCLIProvider_ChatParsesJSONEventArray(t *testing.T) {
 	fakeCodeBuddy := writeFakeCodeBuddyScript(t, "#!/bin/sh\necho '[{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"hello \"}]}},{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"result\":\"hello world\"}]'\n")
 	restore := overrideCodeBuddyCLIForTest(t, fakeCodeBuddy)
@@ -77,6 +133,32 @@ func TestCodeBuddyCLIProvider_ChatParsesJSONEventArray(t *testing.T) {
 	}
 	if resp.Content != "hello world" {
 		t.Fatalf("expected result content, got %#v", resp)
+	}
+}
+
+func TestCodeBuddyCLIProvider_ChatPreservesExecutionFailureDetails(t *testing.T) {
+	fakeCodeBuddy := writeFakeCodeBuddyScript(t, "#!/bin/sh\necho 'partial output'\necho 'specific failure' >&2\nexit 7\n")
+	restore := overrideCodeBuddyCLIForTest(t, fakeCodeBuddy)
+	defer restore()
+
+	provider, err := NewCodeBuddyCLIProvider(ai.ProviderConfig{APIKey: "cb-test"})
+	if err != nil {
+		t.Fatalf("unexpected provider error: %v", err)
+	}
+
+	_, err = provider.Chat(context.Background(), ai.ChatRequest{
+		Messages: []ai.Message{{Role: "user", Content: "ping"}},
+	})
+	if err == nil {
+		t.Fatal("expected CodeBuddy CLI execution error")
+	}
+	for _, want := range []string{"stderr: specific failure", "stdout: 15 bytes omitted", "error: exit status 7"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected execution error to contain %q, got %q", want, err.Error())
+		}
+	}
+	if strings.Contains(err.Error(), "partial output") {
+		t.Fatalf("expected execution error to omit raw stdout, got %q", err.Error())
 	}
 }
 
@@ -267,7 +349,11 @@ func TestCodeBuddyCLIProviderChatStreamWithState_ResumesExistingSessionWithoutDr
 
 func writeFakeCodeBuddyScript(t *testing.T, content string) string {
 	t.Helper()
-	dir := t.TempDir()
+	tempRoot := t.TempDir()
+	dir := filepath.Join(tempRoot, "包含 空格")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("failed to create fake CodeBuddy directory: %v", err)
+	}
 
 	if runtime.GOOS == "windows" {
 		bashPath, err := resolveClaudeCodeGitBashPath(os.Environ(), runtime.GOOS, exec.LookPath, fileExists)
@@ -280,7 +366,7 @@ func writeFakeCodeBuddyScript(t *testing.T, content string) string {
 			t.Fatalf("failed to write fake codebuddy shell script: %v", err)
 		}
 
-		wrapperPath := filepath.Join(dir, "codebuddy.cmd")
+		wrapperPath := filepath.Join(tempRoot, "codebuddy.cmd")
 		wrapper := "@echo off\r\n\"" + bashPath + "\" \"" + scriptPath + "\" %*\r\n"
 		if err := os.WriteFile(wrapperPath, []byte(wrapper), 0o755); err != nil {
 			t.Fatalf("failed to write fake codebuddy wrapper: %v", err)


### PR DESCRIPTION
## 变更说明

- 在 Windows 上优先通过 `git.exe` 和 Git for Windows 常见安装目录定位 Git Bash
- 排除 `System32`、`Sysnative` 和 `WindowsApps` 下的 WSL `bash.exe` 启动器
- Claude CLI 与 CodeBuddy CLI 共用 Git Bash 检测逻辑，并对显式配置的 WSL 路径返回可定位错误
- 改善 CodeBuddy 非流式执行失败信息：保留 stderr 和退出状态，但不在错误或日志中泄漏完整 stdout

## 问题原因

Windows 的 PATH 可能优先解析到 `C:\Windows\System32\bash.exe`。该文件是 WSL 启动器，无法像 Git for Windows Bash 一样执行 CodeBuddy 创建的 Windows 临时脚本，尤其会影响带空格或中文的路径。

## 验证

- `go test ./internal/ai/... -count=1 -timeout=10m`
- `git diff --check upstream/dev...HEAD`

Closes #893
