### PR TITLE
🐛 fix(data-grid): 支持只读结果单击选中

### DIFF
--- a/frontend/src/components/useDataGridBatchActions.test.tsx
+++ b/frontend/src/components/useDataGridBatchActions.test.tsx
@@ -423,4 +423,15 @@ describe('useDataGridBatchActions clipboard paste', () => {
     expect(editablePreventDefault).not.toHaveBeenCalled();
     expect(editableHook.setModifiedRows).not.toHaveBeenCalled();
   });
+
+  it('selects a single cell in read-only results without enabling mutation actions', () => {
+    const hook = renderHook({ canModifyData: false });
+
+    selectCell(hook.container, 'row-1', 'id');
+
+    expect(hook.selectionStartRef.current).toEqual({ rowKey: 'row-1', colName: 'id', rowIndex: 0, colIndex: 0 });
+    expect(hook.setSelectedCells).toHaveBeenCalledWith(new Set([makeCellKey('row-1', 'id')]));
+    expect(hook.ctx.markCellSelectionDeleteEligible).toHaveBeenCalledWith(false);
+    expect(hook.updateCellSelection).toHaveBeenCalledWith(new Set([makeCellKey('row-1', 'id')]));
+  });
 });

--- a/frontend/src/components/useDataGridBatchActions.ts
+++ b/frontend/src/components/useDataGridBatchActions.ts
@@ -477,7 +477,7 @@ const handleBatchFillCells = useCallback(() => {
       const pendingStart = pendingCellSelectionStartRef.current;
       pendingCellSelectionStartRef.current = null;
       if (!isDraggingRef.current) {
-        if (pendingStart && canModifyData) {
+        if (pendingStart) {
           selectSingleCell(pendingStart);
         }
         return;


### PR DESCRIPTION
Fixes #911

## 背景

关联查询结果属于只读结果，原本可以拖选后复制，但普通单击不会建立单元格选区，导致其交互与可安全编辑的单表结果不一致。

## 变更

- 允许只读结果单击选中单元格，支持定位与复制
- 保持关联查询的只读边界：不启用编辑、粘贴、批量填充或删除
- 保持双击打开只读完整内容查看器的现有行为
- 补充只读结果单击选中、且不获得写入权限的回归测试

## 验证

- `npm test -- src/components/useDataGridBatchActions.test.tsx`
- `npm run build`