### PR TITLE
🐛 fix(data-grid): 行号点击支持取消行选择 (#910)

### DIFF
--- a/frontend/src/components/DataGrid.ddl.test.tsx
+++ b/frontend/src/components/DataGrid.ddl.test.tsx
@@ -1073,7 +1073,7 @@ describe('DataGrid DDL interactions', () => {
     vi.unstubAllGlobals();
   });
 
-  it('selects one row when its row number cell is clicked', async () => {
+  it('toggles one row when its row number cell is clicked', async () => {
     storeState.appearance.uiVersion = 'v2';
     const rows = [
       { [GONAVI_ROW_KEY]: 'row-1', id: 1 },
@@ -1107,6 +1107,14 @@ describe('DataGrid DDL interactions', () => {
     expect(stopPropagation).toHaveBeenCalledTimes(1);
     expect(testRenderState.latestTableProps.rowHoverable).toBe(false);
     expect(testRenderState.latestTableProps.rowSelection.selectedRowKeys).toEqual(['row-2']);
+
+    await act(async () => {
+      rowNumberColumn.onCell(rows[1], 1).onClick({ stopPropagation });
+    });
+    await waitForEffects();
+
+    expect(stopPropagation).toHaveBeenCalledTimes(2);
+    expect(testRenderState.latestTableProps.rowSelection.selectedRowKeys).toEqual([]);
     renderer!.unmount();
   });
 

--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -3381,7 +3381,9 @@ const DataGrid: React.FC<DataGridProps> = ({
   const handleRowNumberClick = useCallback((record: Item) => {
       const key = record?.[GONAVI_ROW_KEY];
       if (key === undefined || key === null) return;
-      setSelectedRowKeys([key]);
+      setSelectedRowKeys((previousKeys) => (
+          previousKeys.length === 1 && previousKeys[0] === key ? [] : [key]
+      ));
   }, []);
 
   const handleRowNumberDoubleClick = useCallback((index: number) => {


### PR DESCRIPTION
## 背景

表格行号单击后可以选中当前行，但再次单击同一行时仍保持选中，无法通过相同入口取消选择。本次让行号选择行为支持双向切换。

Fixes #910

## 变更点

- 使用函数式状态更新判断当前是否仅选中目标行，再次点击时清空选择。
- 扩展 DataGrid 交互测试，覆盖连续点击同一行号后取消选择。

## 影响范围

- 仅调整表数据和查询结果中行号列的单击选择行为。
- 复选框单选、多选、行号双击文本查看以及数据操作逻辑保持不变。

## 验证

- `npm --prefix frontend test -- src/components/DataGrid.ddl.test.tsx src/components/DataGrid.layout.test.tsx`：125 项测试通过。
- `npm --prefix frontend test`：全量前端测试通过；首次运行有 1 个无关 hydration 用例超时，单独复跑及第二次全量复跑均通过。
- `npm --prefix frontend run build`：TypeScript 检查及 Vite 生产构建通过。
- 用户自测：通过。
