### PR TITLE
🐛 fix(installer): 修复 MSI 更新后主程序缺失

### DIFF
--- a/build/windows/installer.wxs
+++ b/build/windows/installer.wxs
@@ -16,6 +16,9 @@
     <Icon Id="GoNaviIcon" SourceFile="$(var.IconPath)" />
     <Property Id="ARPPRODUCTICON" Value="GoNaviIcon" />
     <Property Id="ARPURLINFOABOUT" Value="https://github.com/Syngnat/GoNavi" />
+    <!-- Channel switches and dev builds may install an executable with a lower or equal file version.
+         Always replace installer-owned files instead of leaving a related product's key path in place. -->
+    <Property Id="REINSTALLMODE" Value="amus" />
     <Property Id="INSTALLDESKTOPSHORTCUT" Value="1" Secure="yes" />
     <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLFOLDER]" After="CostFinalize" />
     <WixVariable Id="WixUILicenseRtf" Value="$(var.LicenseRtf)" />

--- a/tools/windows-release-artifacts.test.py
+++ b/tools/windows-release-artifacts.test.py
@@ -127,6 +127,10 @@ class WindowsReleaseArtifactsTest(unittest.TestCase):
         self.assertEqual(major_upgrade.attrib["Schedule"], "afterInstallInitialize")
         self.assertNotIn("AllowSameVersionUpgrades", major_upgrade.attrib)
         self.assertNotIn("DowngradeErrorMessage", major_upgrade.attrib)
+        reinstall_mode = package.find("wix:Property[@Id='REINSTALLMODE']", ns)
+        self.assertIsNotNone(reinstall_mode)
+        assert reinstall_mode is not None
+        self.assertEqual(reinstall_mode.attrib["Value"], "amus")
         self.assertIsNotNone(package.find("wix:MediaTemplate", ns))
         self.assertIsNotNone(package.find("wix:Property[@Id='ARPPRODUCTICON']", ns))
         desktop_property = package.find("wix:Property[@Id='INSTALLDESKTOPSHORTCUT']", ns)


### PR DESCRIPTION
## 背景

Windows MSI 更新时，如果已安装 `GoNavi.exe` 的 FileVersion 高于或等于新包，Windows Installer 默认的 `REINSTALLMODE=omus` 会将 `MainExecutable` 判定为 `Action: Null`。旧产品随后正常卸载并删除主程序，而新产品不再复制 EXE，最终出现 MSI 报告成功但新版未安装的问题。

更新应在连续 dev 构建以及 dev/stable 通道切换时始终替换安装器管理的文件，不能依赖 PE FileVersion 的升降关系。

## 变更点

- 在 Windows MSI 中声明 `REINSTALLMODE=amus`，对已选中的 GoNavi 组件强制执行文件覆盖，同时保留原有事务内旧版本卸载顺序。
- 扩展 Windows 发布产物契约测试，固定强制覆盖属性，防止后续构建配置回退。

## 影响范围

- 影响 Windows MSI 的首次安装、版本升级和更新通道切换；Portable、macOS、Linux 及应用业务数据不受影响。
- 强制覆盖仅作用于 GoNavi 自有 EXE、安装 marker、LICENSE/NOTICE、快捷方式和注册表项，不包含共享系统 DLL。
- `m/u/s` 原本就是 Windows Installer 默认模式，本次仅将文件检测策略从 `o` 调整为 `a`；桌面快捷方式组件的选择条件保持不变。

## 验证

- `python tools/windows-release-artifacts.test.py`：3 项通过。
- `go test ./internal/app -run 'Test(BuildWindowsMSI|ResolveWindowsMSI|ResolveUpdateInstallMode|ExpectedAssetNameForWindowsInstallMode|ValidateUpdatePackageForCurrentInstallMode|InstallUpdateAndRestart)' -count=1`：通过。
- `git diff --check`：通过。
- WiX 6.0.2 使用当前 `installer.wxs` 和 CI 等价参数构建实际 GoNavi MSI：通过，成品属性为 `REINSTALLMODE=amus`、`RemoveExistingProducts=1501`。
- 临时双 MSI 实装升级：旧 KeyPath FileVersion `10.0.26100.8875`、新版 `0.9.3.0` 时，日志为 `Action: Local` 并执行 `FileCopy`；落盘 SHA-256 与新版来源一致，卸载清理通过。
- 用户自测：尚无 CI 生成的修正版 MSI；已授权按逻辑审阅和上述自动实装验证结果提交。
