### PR TITLE
🐛 fix(syncjob): 原子写入运行终态与终态事件

### DIFF
--- a/internal/syncjob/manager.go
+++ b/internal/syncjob/manager.go
@@ -734,7 +734,7 @@ func (m *Manager) dispatchQueued() {
 			continue
 		}
 		if !m.launch(run) {
-			_, _ = m.store.CompleteRunOwned(context.Background(), run.ID, run.OwnerToken, RunStatusInterrupted, ExecutionOutcome{Resumable: true}, "manager stopped before execution", m.nowMillis())
+			m.finish(run, RunStatusInterrupted, ExecutionOutcome{Resumable: true}, "manager stopped before execution")
 			return
 		}
 	}
@@ -898,11 +898,11 @@ func (m *Manager) callExecutor(ctx context.Context, request ExecutionRequest, re
 }
 
 func (m *Manager) finish(run RunRecord, status RunStatus, outcome ExecutionOutcome, message string) bool {
-	completed, err := m.store.CompleteRunOwned(context.Background(), run.ID, run.OwnerToken, status, outcome, message, m.nowMillis())
+	_, event, err := m.store.CompleteRunOwnedWithTerminalEvent(context.Background(), run.ID, run.OwnerToken, status, outcome, message, m.nowMillis())
 	if err != nil {
 		return false
 	}
-	_, _ = m.appendEvent(context.Background(), completed, eventTypeForStatus(status), message, nil)
+	m.notifyRunEvent(event)
 	return true
 }
 
@@ -1056,21 +1056,6 @@ func decodeRunDefinition(run RunRecord) (JobDefinition, error) {
 		return JobDefinition{}, fmt.Errorf("data sync job run snapshot endpoint fingerprints do not match run %s", run.ID)
 	}
 	return definition, nil
-}
-
-func eventTypeForStatus(status RunStatus) RunEventType {
-	switch status {
-	case RunStatusSucceeded:
-		return RunEventSucceeded
-	case RunStatusPartial:
-		return RunEventPartial
-	case RunStatusCanceled:
-		return RunEventCanceled
-	case RunStatusInterrupted:
-		return RunEventInterrupted
-	default:
-		return RunEventFailed
-	}
 }
 
 type managerReporter struct {

--- a/internal/syncjob/manager_test.go
+++ b/internal/syncjob/manager_test.go
@@ -551,6 +551,13 @@ func TestManagerPersistsReporterOutputBeforePublishingHooks(t *testing.T) {
 			if listErr != nil || len(persisted) != 1 || persisted[0].Sequence != event.Sequence {
 				t.Errorf("hook observed event before persistence: event=%#v persisted=%#v err=%v", event, persisted, listErr)
 			}
+			switch event.Type {
+			case RunEventSucceeded, RunEventPartial, RunEventFailed, RunEventCanceled, RunEventInterrupted:
+				run, runErr := store.GetRun(context.Background(), event.RunID)
+				if runErr != nil || run.Status != event.Status || run.OwnerToken != "" {
+					t.Errorf("hook observed terminal event before run completion commit: event=%#v run=%#v err=%v", event, run, runErr)
+				}
+			}
 			hookMu.Lock()
 			hooked = append(hooked, event)
 			hookMu.Unlock()

--- a/internal/syncjob/store.go
+++ b/internal/syncjob/store.go
@@ -681,6 +681,15 @@ type contextExecer interface {
 	ExecContext(context.Context, string, ...any) (sql.Result, error)
 }
 
+type contextQueryRower interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+type contextExecerQueryRower interface {
+	contextExecer
+	contextQueryRower
+}
+
 func insertRun(ctx context.Context, executor contextExecer, run RunRecord, forbidPending bool) error {
 	insertPrefix := `INSERT INTO data_sync_runs(
 		id, job_id, owner_token, job_revision, trigger_kind, status, parent_run_id, attempt, queued_at, started_at, finished_at, heartbeat_at,
@@ -932,18 +941,10 @@ func (s *Store) CompleteRun(ctx context.Context, id string, status RunStatus, ou
 	if err := s.ensureOpen(); err != nil {
 		return RunRecord{}, err
 	}
-	switch status {
-	case RunStatusSucceeded, RunStatusPartial, RunStatusFailed, RunStatusCanceled, RunStatusInterrupted:
-	default:
-		return RunRecord{}, fmt.Errorf("unsupported terminal data sync run status %q", status)
+	message, nowMillis, resumable, err := normalizeTerminalRunCompletion(status, outcome, message, nowMillis)
+	if err != nil {
+		return RunRecord{}, err
 	}
-	if nowMillis <= 0 {
-		nowMillis = time.Now().UnixMilli()
-	}
-	if message == "" {
-		message = outcome.Message
-	}
-	resumable := outcome.Resumable || status == RunStatusInterrupted
 	result, err := s.db.ExecContext(ctx, `UPDATE data_sync_runs SET status = ?, finished_at = ?, heartbeat_at = ?, owner_token = '',
 		rows_inserted = ?, rows_updated = ?, rows_deleted = ?, rows_failed = ?, message = ?, resumable = ?, updated_at = ?
 		WHERE id = ? AND owner_token = '' AND status IN (?, ?)`, status, nowMillis, nowMillis, outcome.RowsInserted, outcome.RowsUpdated,
@@ -965,19 +966,50 @@ func (s *Store) CompleteRunOwned(ctx context.Context, id, ownerToken string, sta
 	if strings.TrimSpace(ownerToken) == "" {
 		return RunRecord{}, ErrRunOwnershipLost
 	}
-	switch status {
-	case RunStatusSucceeded, RunStatusPartial, RunStatusFailed, RunStatusCanceled, RunStatusInterrupted:
-	default:
-		return RunRecord{}, fmt.Errorf("unsupported terminal data sync run status %q", status)
+	message, nowMillis, resumable, err := normalizeTerminalRunCompletion(status, outcome, message, nowMillis)
+	if err != nil {
+		return RunRecord{}, err
 	}
-	if nowMillis <= 0 {
-		nowMillis = time.Now().UnixMilli()
+	return completeRunOwned(ctx, s.db, id, ownerToken, status, outcome, message, nowMillis, resumable)
+}
+
+func (s *Store) CompleteRunOwnedWithTerminalEvent(ctx context.Context, id, ownerToken string, status RunStatus, outcome ExecutionOutcome, message string, nowMillis int64) (RunRecord, RunEvent, error) {
+	if err := s.ensureOpen(); err != nil {
+		return RunRecord{}, RunEvent{}, err
 	}
-	if message == "" {
-		message = outcome.Message
+	if strings.TrimSpace(ownerToken) == "" {
+		return RunRecord{}, RunEvent{}, ErrRunOwnershipLost
 	}
-	resumable := outcome.Resumable || status == RunStatusInterrupted
-	result, err := s.db.ExecContext(ctx, `UPDATE data_sync_runs SET status = ?, finished_at = ?, heartbeat_at = ?, owner_token = '',
+	message, nowMillis, resumable, err := normalizeTerminalRunCompletion(status, outcome, message, nowMillis)
+	if err != nil {
+		return RunRecord{}, RunEvent{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return RunRecord{}, RunEvent{}, fmt.Errorf("begin atomic data sync run completion: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	completed, err := completeRunOwned(ctx, tx, id, ownerToken, status, outcome, message, nowMillis, resumable)
+	if err != nil {
+		return RunRecord{}, RunEvent{}, err
+	}
+	event, err := appendRunEvent(ctx, tx, RunEvent{
+		RunID: completed.ID, JobID: completed.JobID, Type: terminalEventTypeForStatus(status), Status: completed.Status,
+		Current: completed.Current, Total: completed.Total, Table: completed.Table, Stage: completed.Stage,
+		Message: completed.Message, CreatedAt: nowMillis,
+	})
+	if err != nil {
+		return RunRecord{}, RunEvent{}, fmt.Errorf("append terminal data sync run event: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return RunRecord{}, RunEvent{}, fmt.Errorf("commit atomic data sync run completion: %w", err)
+	}
+	return completed, event, nil
+}
+
+func completeRunOwned(ctx context.Context, executor contextExecerQueryRower, id, ownerToken string, status RunStatus, outcome ExecutionOutcome, message string, nowMillis int64, resumable bool) (RunRecord, error) {
+	result, err := executor.ExecContext(ctx, `UPDATE data_sync_runs SET status = ?, finished_at = ?, heartbeat_at = ?, owner_token = '',
 		rows_inserted = ?, rows_updated = ?, rows_deleted = ?, rows_failed = ?, message = ?, resumable = ?, updated_at = ?
 		WHERE id = ? AND owner_token = ? AND status IN (?, ?)`, status, nowMillis, nowMillis, outcome.RowsInserted, outcome.RowsUpdated,
 		outcome.RowsDeleted, outcome.RowsFailed, message, boolInt(resumable), nowMillis, strings.TrimSpace(id), ownerToken,
@@ -988,7 +1020,37 @@ func (s *Store) CompleteRunOwned(ctx context.Context, id, ownerToken string, sta
 	if err := requireOwnedAffected(result); err != nil {
 		return RunRecord{}, err
 	}
-	return s.GetRun(ctx, id)
+	return scanRun(executor.QueryRowContext(ctx, runSelect+` WHERE id = ?`, strings.TrimSpace(id)))
+}
+
+func normalizeTerminalRunCompletion(status RunStatus, outcome ExecutionOutcome, message string, nowMillis int64) (string, int64, bool, error) {
+	switch status {
+	case RunStatusSucceeded, RunStatusPartial, RunStatusFailed, RunStatusCanceled, RunStatusInterrupted:
+	default:
+		return "", 0, false, fmt.Errorf("unsupported terminal data sync run status %q", status)
+	}
+	if nowMillis <= 0 {
+		nowMillis = time.Now().UnixMilli()
+	}
+	if message == "" {
+		message = outcome.Message
+	}
+	return message, nowMillis, outcome.Resumable || status == RunStatusInterrupted, nil
+}
+
+func terminalEventTypeForStatus(status RunStatus) RunEventType {
+	switch status {
+	case RunStatusSucceeded:
+		return RunEventSucceeded
+	case RunStatusPartial:
+		return RunEventPartial
+	case RunStatusCanceled:
+		return RunEventCanceled
+	case RunStatusInterrupted:
+		return RunEventInterrupted
+	default:
+		return RunEventFailed
+	}
 }
 
 func (s *Store) RequestCancelRun(ctx context.Context, id string, nowMillis int64) (RunRecord, error) {
@@ -1627,6 +1689,10 @@ func (s *Store) AppendRunEvent(ctx context.Context, event RunEvent) (RunEvent, e
 	if err := s.ensureOpen(); err != nil {
 		return RunEvent{}, err
 	}
+	return appendRunEvent(ctx, s.db, event)
+}
+
+func appendRunEvent(ctx context.Context, queryer contextQueryRower, event RunEvent) (RunEvent, error) {
 	event.RunID = strings.TrimSpace(event.RunID)
 	if event.RunID == "" || event.Type == "" {
 		return RunEvent{}, errors.New("data sync run event requires runId and type")
@@ -1645,7 +1711,7 @@ func (s *Store) AppendRunEvent(ctx context.Context, event RunEvent) (RunEvent, e
 	FROM data_sync_runs AS run WHERE run.id = ?
 	RETURNING sequence, job_id`
 	for attempt := 0; attempt < 8; attempt++ {
-		err := s.db.QueryRowContext(ctx, insert, event.Type, event.Status, event.Current, event.Total,
+		err := queryer.QueryRowContext(ctx, insert, event.Type, event.Status, event.Current, event.Total,
 			strings.TrimSpace(event.Table), strings.TrimSpace(event.Stage), event.Message, nullableBytes(event.Payload),
 			event.CreatedAt, event.RunID).Scan(&event.Sequence, &event.JobID)
 		switch {

--- a/internal/syncjob/store_test.go
+++ b/internal/syncjob/store_test.go
@@ -93,6 +93,117 @@ func TestStorePersistsConcurrentRunEventsWithContiguousSequences(t *testing.T) {
 	}
 }
 
+func TestStoreCompletesOwnedRunWithTerminalEventForEveryStatus(t *testing.T) {
+	testCases := []struct {
+		status    RunStatus
+		eventType RunEventType
+		resumable bool
+	}{
+		{status: RunStatusSucceeded, eventType: RunEventSucceeded},
+		{status: RunStatusPartial, eventType: RunEventPartial},
+		{status: RunStatusFailed, eventType: RunEventFailed},
+		{status: RunStatusCanceled, eventType: RunEventCanceled},
+		{status: RunStatusInterrupted, eventType: RunEventInterrupted, resumable: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(string(testCase.status), func(t *testing.T) {
+			store := openTestStore(t)
+			definition := putTestJob(t, store, "queue")
+			run := createStoredRun(t, store, definition, RunStatusQueued)
+			if _, err := store.AppendRunEvent(context.Background(), RunEvent{
+				RunID: run.ID, Type: RunEventQueued, Status: RunStatusQueued, Message: "queued",
+			}); err != nil {
+				t.Fatalf("append queued event: %v", err)
+			}
+			claimed, ok, err := store.ClaimRun(context.Background(), run.ID, time.Now().UnixMilli())
+			if err != nil || !ok {
+				t.Fatalf("claim run = %#v, claimed=%v, err=%v", claimed, ok, err)
+			}
+			claimed, err = store.UpdateRunProgressOwned(context.Background(), claimed.ID, claimed.OwnerToken, RunProgress{
+				Current: 2, Total: 3, Table: "orders", Stage: "write",
+			}, claimed.StartedAt+1)
+			if err != nil {
+				t.Fatalf("update owned progress: %v", err)
+			}
+			if _, err := store.AppendRunEvent(context.Background(), RunEvent{
+				RunID: claimed.ID, Type: RunEventStarted, Status: RunStatusRunning, Message: "started",
+			}); err != nil {
+				t.Fatalf("append started event: %v", err)
+			}
+
+			finishedAt := claimed.StartedAt + 2
+			outcome := ExecutionOutcome{RowsInserted: 2, Message: "terminal " + string(testCase.status)}
+			completed, event, err := store.CompleteRunOwnedWithTerminalEvent(
+				context.Background(), claimed.ID, claimed.OwnerToken, testCase.status, outcome, "", finishedAt,
+			)
+			if err != nil {
+				t.Fatalf("complete run with terminal event: %v", err)
+			}
+			if completed.Status != testCase.status || completed.OwnerToken != "" || completed.FinishedAt != finishedAt || completed.Resumable != testCase.resumable {
+				t.Fatalf("completed run = %#v", completed)
+			}
+			if event.Type != testCase.eventType || event.Status != testCase.status || event.Sequence != 3 || event.Message != outcome.Message {
+				t.Fatalf("terminal event = %#v", event)
+			}
+			if event.Current != completed.Current || event.Total != completed.Total || event.Table != completed.Table || event.Stage != completed.Stage {
+				t.Fatalf("terminal event progress = %#v, completed run = %#v", event, completed)
+			}
+			events, err := store.ListRunEvents(context.Background(), run.ID, 0, 10)
+			if err != nil {
+				t.Fatalf("list run events: %v", err)
+			}
+			if len(events) != 3 {
+				t.Fatalf("event count = %d, want 3: %#v", len(events), events)
+			}
+			for index, persisted := range events {
+				if persisted.Sequence != int64(index+1) {
+					t.Fatalf("event sequence at %d = %d, want %d", index, persisted.Sequence, index+1)
+				}
+			}
+		})
+	}
+}
+
+func TestStoreRollsBackOwnedCompletionWhenTerminalEventCannotPersist(t *testing.T) {
+	store := openTestStore(t)
+	definition := putTestJob(t, store, "queue")
+	run := createStoredRun(t, store, definition, RunStatusQueued)
+	claimed, ok, err := store.ClaimRun(context.Background(), run.ID, time.Now().UnixMilli())
+	if err != nil || !ok {
+		t.Fatalf("claim run = %#v, claimed=%v, err=%v", claimed, ok, err)
+	}
+	if _, err := store.AppendRunEvent(context.Background(), RunEvent{
+		RunID: claimed.ID, Type: RunEventStarted, Status: RunStatusRunning, Message: "started",
+	}); err != nil {
+		t.Fatalf("append started event: %v", err)
+	}
+	if _, err := store.db.ExecContext(context.Background(), `CREATE TRIGGER fail_terminal_run_event
+		BEFORE INSERT ON data_sync_run_events WHEN NEW.event_type IN ('succeeded', 'partial', 'failed', 'canceled', 'interrupted')
+		BEGIN SELECT RAISE(ABORT, 'injected terminal event failure'); END`); err != nil {
+		t.Fatalf("create terminal event failure trigger: %v", err)
+	}
+
+	if _, _, err := store.CompleteRunOwnedWithTerminalEvent(context.Background(), claimed.ID, claimed.OwnerToken,
+		RunStatusSucceeded, ExecutionOutcome{RowsInserted: 1}, "completed", claimed.StartedAt+1); err == nil {
+		t.Fatal("completion succeeded despite terminal event failure")
+	}
+	persisted, err := store.GetRun(context.Background(), claimed.ID)
+	if err != nil {
+		t.Fatalf("get run after rollback: %v", err)
+	}
+	if persisted.Status != RunStatusRunning || persisted.OwnerToken != claimed.OwnerToken || persisted.FinishedAt != 0 {
+		t.Fatalf("run completion was not rolled back: %#v", persisted)
+	}
+	events, err := store.ListRunEvents(context.Background(), claimed.ID, 0, 10)
+	if err != nil {
+		t.Fatalf("list events after rollback: %v", err)
+	}
+	if len(events) != 1 || events[0].Type != RunEventStarted || events[0].Sequence != 1 {
+		t.Fatalf("events changed despite rollback: %#v", events)
+	}
+}
+
 func TestStorePersistsIncompleteDraftButManagerWillNotRunIt(t *testing.T) {
 	store := openTestStore(t)
 	draft, err := store.PutJob(context.Background(), JobDefinition{


### PR DESCRIPTION
## 背景与问题

同步任务完成时先提交运行终态，再单独追加终态事件。读取者可能在两次写入之间观察到 `succeeded` 等终态，但事件时间线中只有 `queued`、`started`；事件写入失败时还会永久留下不一致记录。

修复前按 Issue 提供的测试重复运行 100 次，可以稳定观察到多次终态事件缺失。

## 变更点

- 新增 `CompleteRunOwnedWithTerminalEvent`，在同一 SQLite 事务中完成 ownership 校验、运行终态更新、事件序号分配和终态事件插入
- 终态事件插入或事务提交失败时回滚运行状态，不再留下无对应事件的终态
- Manager 的正常结束与启动前中断路径统一使用原子完成方法
- `OnRunEvent` 仅在事务提交成功后触发
- 复用统一事件插入逻辑，保留并发事件序号重试行为

## 测试覆盖

- succeeded、partial、failed、canceled、interrupted 五种终态
- 终态事件与运行进度快照一致
- event sequence 连续
- 注入终态事件写入失败时运行状态和 ownership 回滚
- hook 回调时运行终态与事件均已持久化

## 验证

- 修复前：`go test ./internal/syncjob -run "^TestManagerQueuesRunsForTheSameJobWithoutOverlap$" -count=100 -timeout=10m` 多次失败，终态事件缺失
- 修复后：同一命令 100 次全部通过
- `go test ./internal/syncjob -count=1 -timeout=10m`

Closes #895