### PR TITLE
🐛 fix(connection): 支持查看已保存连接密码

### DIFF
--- a/frontend/src/components/ConnectionModal.i18n.test.tsx
+++ b/frontend/src/components/ConnectionModal.i18n.test.tsx
@@ -50,6 +50,7 @@ const backendApp = {
   SaveConnection: vi.fn(),
   TestConnection: vi.fn(),
   RedisConnect: vi.fn(),
+  RevealSavedConnectionPrimaryPassword: vi.fn(),
   SelectDatabaseFile: vi.fn(),
   SelectCertificateFile: vi.fn(),
   SelectSSHKeyFile: vi.fn(),
@@ -248,9 +249,38 @@ vi.mock("antd", () => {
       {children}
     </input>
   );
-  Input.Password = ({ value, onChange, placeholder, ...rest }: any) => (
-    <input value={value} onChange={onChange} placeholder={placeholder} {...rest} />
-  );
+  Input.Password = ({ value, onChange, placeholder, visibilityToggle, ...rest }: any) => {
+    const visibilityControlled =
+      typeof visibilityToggle === "object" && visibilityToggle.visible !== undefined;
+    const [visible, setVisible] = React.useState(
+      visibilityControlled ? visibilityToggle.visible : false,
+    );
+    React.useEffect(() => {
+      if (visibilityControlled) {
+        setVisible(visibilityToggle.visible);
+      }
+    }, [visibilityControlled, visibilityToggle]);
+    const simulatedVisibilityToggle =
+      typeof visibilityToggle === "object"
+        ? {
+            ...visibilityToggle,
+            onVisibleChange: async (nextVisible: boolean) => {
+              setVisible(nextVisible);
+              return visibilityToggle.onVisibleChange?.(nextVisible);
+            },
+          }
+        : visibilityToggle;
+    return (
+      <input
+        type={visible ? "text" : "password"}
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        visibilityToggle={simulatedVisibilityToggle}
+        {...rest}
+      />
+    );
+  };
   Input.TextArea = ({ value, onChange, placeholder, ...rest }: any) => (
     <textarea value={value} onChange={onChange} placeholder={placeholder} {...rest} />
   );
@@ -437,6 +467,8 @@ describe("ConnectionModal i18n", () => {
     backendApp.DBGetDatabases.mockResolvedValue({ success: true, data: [] });
     backendApp.MongoDiscoverMembers.mockResolvedValue({ success: true, data: { members: [] } });
     backendApp.RedisConnect.mockResolvedValue({ success: true, message: "ok" });
+    backendApp.RevealSavedConnectionPrimaryPassword.mockReset();
+    backendApp.RevealSavedConnectionPrimaryPassword.mockResolvedValue("stored-secret");
     backendApp.TestJVMConnection.mockResolvedValue({ success: true, message: "ok" });
     backendApp.SelectDatabaseFile.mockReset();
     backendApp.SelectCertificateFile.mockReset();
@@ -504,6 +536,348 @@ describe("ConnectionModal i18n", () => {
     );
     expect(onClose).toHaveBeenCalledTimes(1);
   }, 15000);
+
+  it("reveals a saved primary password when the password visibility button is opened", async () => {
+    Object.assign(window, {
+      go: { app: { App: backendApp } },
+    });
+    const { default: ConnectionModal } = await import("./ConnectionModal");
+    const connection = {
+      ...initialConnection("mysql"),
+      hasPrimaryPassword: true,
+    };
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <ConnectionModal open onClose={vi.fn()} initialValues={connection} />,
+      );
+      await flushConnectionTestTick();
+    });
+
+    const passwordInput = findInputByPlaceholder(
+      renderer!,
+      "••••••（留空表示继续沿用已保存密码）",
+    );
+    await act(async () => {
+      await passwordInput.props.visibilityToggle.onVisibleChange(true);
+      await flushConnectionTestTick();
+    });
+
+    expect(backendApp.RevealSavedConnectionPrimaryPassword).toHaveBeenCalledWith(
+      "mysql-conn",
+    );
+    expect(mockFormValues.password).toBe("stored-secret");
+    expect(
+      findInputByPlaceholder(
+        renderer!,
+        "••••••（留空表示继续沿用已保存密码）",
+      ).props.visibilityToggle.visible,
+    ).toBe(true);
+    expect(textContent(renderer!.toJSON())).not.toContain(
+      "已输入新值，保存时会替换当前已保存内容。",
+    );
+  });
+
+  it("returns the password input to hidden mode when revealing fails", async () => {
+    backendApp.RevealSavedConnectionPrimaryPassword.mockRejectedValue(
+      new Error("secret store unavailable"),
+    );
+    Object.assign(window, {
+      go: { app: { App: backendApp } },
+    });
+    const { default: ConnectionModal } = await import("./ConnectionModal");
+    const connection = {
+      ...initialConnection("mysql"),
+      hasPrimaryPassword: true,
+    };
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <ConnectionModal open onClose={vi.fn()} initialValues={connection} />,
+      );
+      await flushConnectionTestTick();
+    });
+
+    const placeholder = "••••••（留空表示继续沿用已保存密码）";
+    await act(async () => {
+      await findInputByPlaceholder(
+        renderer!,
+        placeholder,
+      ).props.visibilityToggle.onVisibleChange(true);
+      await flushConnectionTestTick();
+    });
+
+    expect(findInputByPlaceholder(renderer!, placeholder).props.type).toBe(
+      "password",
+    );
+    expect(antdMessage.error).toHaveBeenCalledWith(
+      expect.stringContaining("系统密文存储当前不可用"),
+    );
+  });
+
+  it("does not let a delayed password reveal overwrite a user replacement", async () => {
+    let resolveReveal: ((value: string) => void) | undefined;
+    backendApp.RevealSavedConnectionPrimaryPassword.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveReveal = resolve;
+        }),
+    );
+    Object.assign(window, {
+      go: { app: { App: backendApp } },
+    });
+    const { default: ConnectionModal } = await import("./ConnectionModal");
+    const connection = {
+      ...initialConnection("mysql"),
+      hasPrimaryPassword: true,
+    };
+
+    let renderer: ReactTestRenderer;
+    let revealRequest: Promise<void>;
+    await act(async () => {
+      renderer = create(
+        <ConnectionModal open onClose={vi.fn()} initialValues={connection} />,
+      );
+      await flushConnectionTestTick();
+      revealRequest = findInputByPlaceholder(
+        renderer,
+        "••••••（留空表示继续沿用已保存密码）",
+      ).props.visibilityToggle.onVisibleChange(true);
+      await Promise.resolve();
+    });
+
+    expect(
+      findInputByPlaceholder(
+        renderer!,
+        "••••••（留空表示继续沿用已保存密码）",
+      ).props.type,
+    ).toBe("password");
+    mockFormValues = { ...mockFormValues, password: "user-replacement" };
+    await act(async () => {
+      resolveReveal?.("stored-secret");
+      await revealRequest!;
+      await flushConnectionTestTick();
+    });
+
+    expect(mockFormValues.password).toBe("user-replacement");
+  });
+
+  it("does not let a delayed password reveal undo an explicit clear", async () => {
+    let resolveReveal: ((value: string) => void) | undefined;
+    backendApp.RevealSavedConnectionPrimaryPassword.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveReveal = resolve;
+        }),
+    );
+    Object.assign(window, {
+      go: { app: { App: backendApp } },
+    });
+    const { default: ConnectionModal } = await import("./ConnectionModal");
+    const connection = {
+      ...initialConnection("mysql"),
+      hasPrimaryPassword: true,
+    };
+
+    let renderer: ReactTestRenderer;
+    let revealRequest: Promise<void>;
+    await act(async () => {
+      renderer = create(
+        <ConnectionModal open onClose={vi.fn()} initialValues={connection} />,
+      );
+      await flushConnectionTestTick();
+      revealRequest = findInputByPlaceholder(
+        renderer,
+        "••••••（留空表示继续沿用已保存密码）",
+      ).props.visibilityToggle.onVisibleChange(true);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      renderer!.root.findAll(
+        (node) =>
+          textContent(node).includes("清除已保存密码") &&
+          typeof node.props.onChange === "function",
+      )[0].props.onChange({ target: { checked: true } });
+    });
+    await act(async () => {
+      resolveReveal?.("stored-secret");
+      await revealRequest!;
+      await flushConnectionTestTick();
+    });
+
+    expect(String(mockFormValues.password ?? "")).toBe("");
+    await act(async () => {
+      findButton(renderer!, "保存").props.onClick();
+      await flushConnectionTestTick();
+    });
+    expect(backendApp.SaveConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ clearPrimaryPassword: true }),
+    );
+  });
+
+  it("clears revealed password state when the modal closes or switches connections", async () => {
+    let resolveReveal: ((value: string) => void) | undefined;
+    backendApp.RevealSavedConnectionPrimaryPassword.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveReveal = resolve;
+        }),
+    );
+    Object.assign(window, {
+      go: { app: { App: backendApp } },
+    });
+    const { default: ConnectionModal } = await import("./ConnectionModal");
+    const firstConnection = {
+      ...initialConnection("mysql"),
+      hasPrimaryPassword: true,
+    };
+    const secondConnection = {
+      ...initialConnection("postgres"),
+      hasPrimaryPassword: true,
+    };
+
+    let renderer: ReactTestRenderer;
+    let revealRequest: Promise<void>;
+    await act(async () => {
+      renderer = create(
+        <ConnectionModal open onClose={vi.fn()} initialValues={firstConnection} />,
+      );
+      await flushConnectionTestTick();
+      revealRequest = findInputByPlaceholder(
+        renderer,
+        "••••••（留空表示继续沿用已保存密码）",
+      ).props.visibilityToggle.onVisibleChange(true);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      renderer!.update(
+        <ConnectionModal
+          open={false}
+          onClose={vi.fn()}
+          initialValues={firstConnection}
+        />,
+      );
+    });
+    expect(String(mockFormValues.password ?? "")).toBe("");
+
+    await act(async () => {
+      renderer!.update(
+        <ConnectionModal open onClose={vi.fn()} initialValues={secondConnection} />,
+      );
+      await flushConnectionTestTick();
+    });
+    expect(
+      findInputByPlaceholder(
+        renderer!,
+        "••••••（留空表示继续沿用已保存密码）",
+      ).props.visibilityToggle.visible,
+    ).toBe(false);
+
+    await act(async () => {
+      resolveReveal?.("first-connection-secret");
+      await revealRequest!;
+      await flushConnectionTestTick();
+    });
+    expect(String(mockFormValues.password ?? "")).toBe("");
+  });
+
+  it("removes an already revealed password as soon as the modal closes", async () => {
+    Object.assign(window, {
+      go: { app: { App: backendApp } },
+    });
+    const { default: ConnectionModal } = await import("./ConnectionModal");
+    const connection = {
+      ...initialConnection("mysql"),
+      hasPrimaryPassword: true,
+    };
+    const onClose = vi.fn();
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <ConnectionModal open onClose={onClose} initialValues={connection} />,
+      );
+      await flushConnectionTestTick();
+      await findInputByPlaceholder(
+        renderer,
+        "••••••（留空表示继续沿用已保存密码）",
+      ).props.visibilityToggle.onVisibleChange(true);
+      await flushConnectionTestTick();
+    });
+    expect(mockFormValues.password).toBe("stored-secret");
+
+    await act(async () => {
+      findButton(renderer!, "取消").props.onClick();
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(String(mockFormValues.password ?? "")).toBe("");
+  });
+
+  it("preserves a revealed password unless the user actually replaces it", async () => {
+    Object.assign(window, {
+      go: { app: { App: backendApp } },
+    });
+    const { default: ConnectionModal } = await import("./ConnectionModal");
+    const connection = {
+      ...initialConnection("mysql"),
+      hasPrimaryPassword: true,
+    };
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <ConnectionModal open onClose={vi.fn()} initialValues={connection} />,
+      );
+      await flushConnectionTestTick();
+      await findInputByPlaceholder(
+        renderer,
+        "••••••（留空表示继续沿用已保存密码）",
+      ).props.visibilityToggle.onVisibleChange(true);
+      await flushConnectionTestTick();
+    });
+    await act(async () => {
+      findButton(renderer!, "保存").props.onClick();
+      await flushConnectionTestTick();
+    });
+    expect(backendApp.SaveConnection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clearPrimaryPassword: false,
+        config: expect.objectContaining({ password: "" }),
+      }),
+    );
+
+    await act(async () => {
+      renderer!.unmount();
+    });
+    backendApp.SaveConnection.mockClear();
+    let replacementRenderer: ReactTestRenderer;
+    await act(async () => {
+      replacementRenderer = create(
+        <ConnectionModal open onClose={vi.fn()} initialValues={connection} />,
+      );
+      await flushConnectionTestTick();
+      await findInputByPlaceholder(
+        replacementRenderer,
+        "••••••（留空表示继续沿用已保存密码）",
+      ).props.visibilityToggle.onVisibleChange(true);
+      await flushConnectionTestTick();
+    });
+    mockFormValues = { ...mockFormValues, password: "user-replacement" };
+    await act(async () => {
+      findButton(replacementRenderer!, "保存").props.onClick();
+      await flushConnectionTestTick();
+    });
+    expect(backendApp.SaveConnection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clearPrimaryPassword: false,
+        config: expect.objectContaining({ password: "user-replacement" }),
+      }),
+    );
+  });
 
   it("updates visible copy when languagePreference changes while the modal stays open", async () => {
     const { default: ConnectionModal } = await import("./ConnectionModal");

--- a/frontend/src/components/ConnectionModal.tsx
+++ b/frontend/src/components/ConnectionModal.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useEffect, useRef, useMemo } from "react";
+import React, {
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useMemo,
+} from "react";
 import Modal from './common/ResizableDraggableModal';
 import {
   Form,
@@ -391,9 +397,13 @@ const ConnectionModal: React.FC<{
     createEmptyConnectionSecretClearState,
   );
   const [primaryPasswordVisible, setPrimaryPasswordVisible] = useState(false);
+  const [, setPrimaryPasswordVisibilityRevision] = useState(0);
   const testInFlightRef = useRef(false);
   const testTimerRef = useRef<number | null>(null);
   const testRunIdRef = useRef(0);
+  const primaryPasswordRevealRequestRef = useRef(0);
+  const revealedPrimaryPasswordRef = useRef("");
+  const clearSecretsRef = useRef(clearSecrets);
   const oracleModeTouchedRef = useRef(false);
   const addConnection = useStore((state) => state.addConnection);
   const updateConnection = useStore((state) => state.updateConnection);
@@ -574,6 +584,27 @@ const ConnectionModal: React.FC<{
     [overlayTheme],
   );
 
+  const resetPrimaryPasswordRevealState = () => {
+    primaryPasswordRevealRequestRef.current += 1;
+    revealedPrimaryPasswordRef.current = "";
+    form.setFieldValue("password", "");
+    setPrimaryPasswordVisible(false);
+  };
+
+  const handleModalClose = () => {
+    resetPrimaryPasswordRevealState();
+    onClose();
+  };
+
+  useLayoutEffect(() => {
+    resetPrimaryPasswordRevealState();
+    return () => {
+      primaryPasswordRevealRequestRef.current += 1;
+      revealedPrimaryPasswordRef.current = "";
+      form.setFieldValue("password", "");
+    };
+  }, [open, initialValues?.id]);
+
   const renderStoredSecretControls = ({
     fieldName,
     clearKey,
@@ -597,10 +628,11 @@ const ConnectionModal: React.FC<{
       >
         {({ getFieldValue }) => {
           const draftValue = getFieldValue(fieldName);
-          const initialSecretValue = resolveInitialSecretFieldValue(
-            initialValues,
-            fieldName,
-          );
+          const initialSecretValue =
+            clearKey === "primaryPassword" &&
+            revealedPrimaryPasswordRef.current !== ""
+              ? revealedPrimaryPasswordRef.current
+              : resolveInitialSecretFieldValue(initialValues, fieldName);
           const normalizedDraftValue = String(draftValue ?? "");
           const matchesInitialSecret =
             initialSecretValue !== "" &&
@@ -644,7 +676,12 @@ const ConnectionModal: React.FC<{
                   if (checked && matchesInitialSecret) {
                     form.setFieldValue(fieldName, "");
                   }
-                  setClearSecrets((prev) => ({ ...prev, [clearKey]: checked }));
+                  const nextClearSecrets = {
+                    ...clearSecretsRef.current,
+                    [clearKey]: checked,
+                  };
+                  clearSecretsRef.current = nextClearSecrets;
+                  setClearSecrets(nextClearSecrets);
                 }}
               >
                 {clearLabel}
@@ -1389,6 +1426,71 @@ const ConnectionModal: React.FC<{
     }
   };
 
+  const handlePrimaryPasswordVisibleChange = async (nextVisible: boolean) => {
+    const requestId = primaryPasswordRevealRequestRef.current + 1;
+    primaryPasswordRevealRequestRef.current = requestId;
+    if (!nextVisible) {
+      setPrimaryPasswordVisible(false);
+      return;
+    }
+
+    const currentPassword = String(form.getFieldValue("password") ?? "");
+    if (currentPassword !== "" || !initialValues?.hasPrimaryPassword) {
+      setPrimaryPasswordVisible(true);
+      return;
+    }
+
+    setPrimaryPasswordVisible(false);
+    setPrimaryPasswordVisibilityRevision((revision) => revision + 1);
+    const connectionId = String(initialValues.id || "").trim();
+    const backendApp = (window as any).go?.app?.App;
+    if (
+      connectionId === "" ||
+      typeof backendApp?.RevealSavedConnectionPrimaryPassword !== "function"
+    ) {
+      setPrimaryPasswordVisible(false);
+      setPrimaryPasswordVisibilityRevision((revision) => revision + 1);
+      message.error(
+        t("connection.modal.secret.reveal_failed", {
+          detail: t("connection.modal.message.save_backend_unavailable"),
+        }),
+      );
+      return;
+    }
+
+    const canApplyRevealResult = () =>
+      primaryPasswordRevealRequestRef.current === requestId &&
+      String(form.getFieldValue("password") ?? "") === "" &&
+      !clearSecretsRef.current.primaryPassword;
+
+    try {
+      const password = await backendApp.RevealSavedConnectionPrimaryPassword(
+        connectionId,
+      );
+      if (!canApplyRevealResult()) {
+        return;
+      }
+      const revealedPassword = String(password ?? "");
+      revealedPrimaryPasswordRef.current = revealedPassword;
+      form.setFieldValue("password", revealedPassword);
+      setPrimaryPasswordVisible(true);
+    } catch (error: any) {
+      if (!canApplyRevealResult()) {
+        return;
+      }
+      setPrimaryPasswordVisible(false);
+      setPrimaryPasswordVisibilityRevision((revision) => revision + 1);
+      message.error(
+        t("connection.modal.secret.reveal_failed", {
+          detail: normalizeConnectionSecretErrorMessage(
+            error?.message || error,
+            t("connection.modal.error.unknown"),
+          ),
+        }),
+      );
+    }
+  };
+
   useEffect(() => {
     testRunIdRef.current += 1;
     if (open) {
@@ -1408,8 +1510,9 @@ const ConnectionModal: React.FC<{
       setUriFeedback(null);
       setCustomIconType(undefined);
       setCustomIconColor(undefined);
-      setClearSecrets(createEmptyConnectionSecretClearState());
-      setPrimaryPasswordVisible(false);
+      const emptyClearSecrets = createEmptyConnectionSecretClearState();
+      clearSecretsRef.current = emptyClearSecrets;
+      setClearSecrets(emptyClearSecrets);
       setTypeSelectWarning(null);
       setDriverStatusLoaded(false);
       void refreshDriverStatus();
@@ -1627,7 +1730,10 @@ const ConnectionModal: React.FC<{
           mongoAuthSource: config.authSource || "",
           mongoReadPreference: config.readPreference || "primary",
           mongoAuthMechanism: config.mongoAuthMechanism || "",
-          savePassword: config.savePassword !== false,
+          savePassword:
+            config.savePassword !== false ||
+            (config.type === "mongodb" &&
+              initialValues.hasPrimaryPassword === true),
           redisDB: Number.isFinite(Number(config.redisDB))
             ? Number(config.redisDB)
             : 0,
@@ -1774,6 +1880,8 @@ const ConnectionModal: React.FC<{
   useEffect(() => {
     return () => {
       testRunIdRef.current += 1;
+      primaryPasswordRevealRequestRef.current += 1;
+      revealedPrimaryPasswordRef.current = "";
       if (testTimerRef.current !== null) {
         window.clearTimeout(testTimerRef.current);
         testTimerRef.current = null;
@@ -1784,7 +1892,16 @@ const ConnectionModal: React.FC<{
   const handleOk = async () => {
     try {
       await form.validateFields();
-      const values = { ...form.getFieldsValue(true), type: dbType };
+      const formValues = { ...form.getFieldsValue(true), type: dbType };
+      const revealedPrimaryPassword = revealedPrimaryPasswordRef.current;
+      const values = {
+        ...formValues,
+        password:
+          revealedPrimaryPassword !== "" &&
+          String(formValues.password ?? "") === revealedPrimaryPassword
+            ? ""
+            : formValues.password,
+      };
       const unavailableReason = await resolveDriverUnavailableReason(
         values.type,
         values.driver,
@@ -1812,7 +1929,7 @@ const ConnectionModal: React.FC<{
         config,
         values,
         initialValues,
-        clearSecrets,
+        clearSecrets: clearSecretsRef.current,
         customIconType,
         customIconColor,
       });
@@ -1848,8 +1965,10 @@ const ConnectionModal: React.FC<{
       setUseHttpTunnel(false);
       setDbType("mysql");
       setStep(1);
-      setClearSecrets(createEmptyConnectionSecretClearState());
-      onClose();
+      const emptyClearSecrets = createEmptyConnectionSecretClearState();
+      clearSecretsRef.current = emptyClearSecrets;
+      setClearSecrets(emptyClearSecrets);
+      handleModalClose();
     } catch (e: any) {
       message.error(
         normalizeConnectionSecretErrorMessage(
@@ -2850,6 +2969,7 @@ const ConnectionModal: React.FC<{
         onOpenDriverManager,
         oracleMode,
         primaryPasswordVisible,
+        handlePrimaryPasswordVisibleChange,
         proxyType,
         redisDbList,
         redisTopology,
@@ -2870,7 +2990,6 @@ const ConnectionModal: React.FC<{
         setCustomIconType,
         setDbType,
         setMongoMembers,
-        setPrimaryPasswordVisible,
         setRedisDbList,
         setTestErrorLogOpen,
         setTestResult,
@@ -2973,7 +3092,11 @@ const ConnectionModal: React.FC<{
           >
             {t("connection.action.test")}
           </Button>
-          <Button key="cancel" className="gn-conn-studio-button" onClick={onClose}>
+          <Button
+            key="cancel"
+            className="gn-conn-studio-button"
+            onClick={handleModalClose}
+          >
             {t("common.action.cancel")}
           </Button>
           <Button
@@ -3055,7 +3178,7 @@ const ConnectionModal: React.FC<{
           className="gn-conn-studio-close"
           aria-label={t("common.action.close")}
           title={t("common.action.close")}
-          onClick={onClose}
+          onClick={handleModalClose}
         >
           <CloseOutlined />
         </button>
@@ -3079,7 +3202,7 @@ const ConnectionModal: React.FC<{
       <Modal
         title={getStudioTitle()}
         open={open}
-        onCancel={onClose}
+        onCancel={handleModalClose}
         footer={getFooter()}
         closable={false}
         centered

--- a/frontend/src/components/connectionModal/ConnectionModalStep2.tsx
+++ b/frontend/src/components/connectionModal/ConnectionModalStep2.tsx
@@ -159,6 +159,7 @@ const ConnectionModalStep2: React.FC<ConnectionModalStep2Props> = (props) => {
     onOpenDriverManager,
     oracleMode,
     primaryPasswordVisible,
+    handlePrimaryPasswordVisibleChange,
     proxyType,
     redisDbList,
     redisTopology,
@@ -179,7 +180,6 @@ const ConnectionModalStep2: React.FC<ConnectionModalStep2Props> = (props) => {
     setCustomIconType,
     setDbType,
     setMongoMembers,
-    setPrimaryPasswordVisible,
     setRedisDbList,
     setTestErrorLogOpen,
     setTestResult,
@@ -1480,7 +1480,7 @@ const ConnectionModalStep2: React.FC<ConnectionModalStep2Props> = (props) => {
                           {...noAutoCapInputProps}
                           visibilityToggle={{
                             visible: primaryPasswordVisible,
-                            onVisibleChange: setPrimaryPasswordVisible,
+                            onVisibleChange: handlePrimaryPasswordVisibleChange,
                           }}
                           placeholder={getStoredSecretPlaceholder({
                             hasStoredSecret: initialValues?.hasPrimaryPassword,
@@ -1533,7 +1533,7 @@ const ConnectionModalStep2: React.FC<ConnectionModalStep2Props> = (props) => {
                         {...noAutoCapInputProps}
                         visibilityToggle={{
                           visible: primaryPasswordVisible,
-                          onVisibleChange: setPrimaryPasswordVisible,
+                          onVisibleChange: handlePrimaryPasswordVisibleChange,
                         }}
                         placeholder={getStoredSecretPlaceholder({
                           hasStoredSecret: initialValues?.hasPrimaryPassword,
@@ -1548,6 +1548,19 @@ const ConnectionModalStep2: React.FC<ConnectionModalStep2Props> = (props) => {
                     </Form.Item>
                   </div>
                 </div>
+                {initialValues?.hasPrimaryPassword
+                  ? renderStoredSecretControls({
+                      fieldName: "password",
+                      clearKey: "primaryPassword",
+                      hasStoredSecret: initialValues?.hasPrimaryPassword,
+                      clearLabel: t(
+                        "connection.modal.secret.clear_saved_password",
+                      ),
+                      description: t(
+                        "connection.modal.secret.saved_redis_password",
+                      ),
+                    })
+                  : null}
               </div>
             )}
 

--- a/frontend/src/components/connectionModal/connectionModalConfig.secret.test.ts
+++ b/frontend/src/components/connectionModal/connectionModalConfig.secret.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import type { ConnectionConfig, SavedConnection } from "../../types";
+import {
+  buildSavedConnectionInput,
+  createEmptyConnectionSecretClearState,
+} from "./connectionModalConfig";
+
+const createConfig = (overrides: Partial<ConnectionConfig> = {}): ConnectionConfig => ({
+  id: "conn-password",
+  type: "mysql",
+  host: "db.local",
+  port: 3306,
+  user: "root",
+  password: "",
+  ...overrides,
+});
+
+const createSavedConnection = (config: ConnectionConfig): SavedConnection => ({
+  id: "conn-password",
+  name: "Saved host",
+  environmentType: "local",
+  config,
+  hasPrimaryPassword: true,
+});
+
+const createValues = (overrides: Record<string, unknown> = {}) => ({
+  type: "mysql",
+  name: "Saved host",
+  environmentType: "local",
+  ...overrides,
+});
+
+describe("connection modal primary password persistence", () => {
+  it("keeps a stored password when an edited connection leaves the field blank", () => {
+    const config = createConfig();
+    const result = buildSavedConnectionInput({
+      config,
+      values: createValues(),
+      initialValues: createSavedConnection(config),
+      clearSecrets: createEmptyConnectionSecretClearState(),
+    });
+
+    expect(result.config.password).toBe("");
+    expect(result.clearPrimaryPassword).toBe(false);
+  });
+
+  it("replaces a stored password when a new value is entered", () => {
+    const config = createConfig({ password: "replacement-secret" });
+    const result = buildSavedConnectionInput({
+      config,
+      values: createValues(),
+      initialValues: createSavedConnection(createConfig()),
+      clearSecrets: createEmptyConnectionSecretClearState(),
+    });
+
+    expect(result.config.password).toBe("replacement-secret");
+    expect(result.clearPrimaryPassword).toBe(false);
+  });
+
+  it("clears a stored password only when clearing is explicitly requested", () => {
+    const config = createConfig();
+    const clearSecrets = createEmptyConnectionSecretClearState();
+    clearSecrets.primaryPassword = true;
+
+    const result = buildSavedConnectionInput({
+      config,
+      values: createValues(),
+      initialValues: createSavedConnection(config),
+      clearSecrets,
+    });
+
+    expect(result.config.password).toBe("");
+    expect(result.clearPrimaryPassword).toBe(true);
+  });
+
+  it("clears a MongoDB password when save password is disabled", () => {
+    const config = createConfig({ type: "mongodb" });
+    const result = buildSavedConnectionInput({
+      config,
+      values: createValues({ type: "mongodb", savePassword: false }),
+      initialValues: createSavedConnection(config),
+      clearSecrets: createEmptyConnectionSecretClearState(),
+    });
+
+    expect(result.config.password).toBe("");
+    expect(result.clearPrimaryPassword).toBe(true);
+  });
+
+});

--- a/frontend/src/components/connectionModal/connectionModalConfig.ts
+++ b/frontend/src/components/connectionModal/connectionModalConfig.ts
@@ -137,10 +137,7 @@ export const buildSavedConnectionInput = ({
   const primaryDraft = resolveConnectionSecretDraft({
     hasSecret: initialValues?.hasPrimaryPassword,
     valueInput: config.password,
-    clearSecret:
-      clearSecrets.primaryPassword ||
-      (initialValues?.hasPrimaryPassword === true &&
-        String(config.password || "") === ""),
+    clearSecret: clearSecrets.primaryPassword,
     forceClear: values.type === "mongodb" && values.savePassword === false,
   });
   const sshDraft = resolveConnectionSecretDraft({

--- a/frontend/src/main.browserMock.test.ts
+++ b/frontend/src/main.browserMock.test.ts
@@ -82,6 +82,11 @@ const importMain = async () => {
             CheckForUpdates: () => Promise<{ success: boolean; data?: Record<string, unknown> }>;
             CheckForUpdatesSilently: () => Promise<{ success: boolean; data?: Record<string, unknown> }>;
             SetUpdateChannel: (channel: string) => Promise<{ success: boolean; data?: { channel?: string } }>;
+            SaveConnection: (input: Record<string, unknown>) => Promise<any>;
+            GetEditableSavedConnection: (id: string) => Promise<any>;
+            RevealSavedConnectionPrimaryPassword: (id: string) => Promise<string>;
+            DeleteConnection: (id: string) => Promise<null>;
+            DuplicateConnection: (id: string) => Promise<any>;
           };
         };
       };
@@ -166,6 +171,60 @@ describe('main browser mock', () => {
       t('app.browser_mock.import_connection_package_unsupported'),
     );
   });
+
+  it('reveals saved host passwords on demand without exposing them in editable connection metadata', async () => {
+    const app = await importMain();
+    const saved = await app!.SaveConnection({
+      id: 'browser-mock-password',
+      name: 'Password host',
+      config: {
+        id: 'browser-mock-password',
+        type: 'mysql',
+        host: 'db.local',
+        port: 3306,
+        user: 'root',
+        password: 'primary-secret',
+      },
+    });
+
+    await expect(app!.GetEditableSavedConnection(saved.id)).resolves.toMatchObject({
+      config: { password: '' },
+      hasPrimaryPassword: true,
+    });
+    await expect(app!.RevealSavedConnectionPrimaryPassword(saved.id)).resolves.toBe('primary-secret');
+
+    const duplicated = await app!.DuplicateConnection(saved.id);
+    await expect(app!.RevealSavedConnectionPrimaryPassword(duplicated.id)).resolves.toBe('primary-secret');
+
+    await app!.SaveConnection({
+      ...saved,
+      name: 'Renamed host',
+      config: { ...saved.config, password: '' },
+    });
+    await expect(app!.RevealSavedConnectionPrimaryPassword(saved.id)).resolves.toBe('primary-secret');
+
+    await app!.SaveConnection({
+      ...saved,
+      config: { ...saved.config, password: '' },
+      clearPrimaryPassword: true,
+    });
+    await expect(app!.RevealSavedConnectionPrimaryPassword(saved.id)).rejects.toThrow('no stored primary password');
+
+    await app!.SaveConnection({
+      ...saved,
+      config: { ...saved.config, password: 'must-not-survive-delete' },
+    });
+    await app!.DeleteConnection(saved.id);
+    await expect(app!.RevealSavedConnectionPrimaryPassword(saved.id)).rejects.toThrow('saved connection not found');
+
+    const recreated = await app!.SaveConnection({
+      id: saved.id,
+      name: 'Recreated without password',
+      config: { ...saved.config, password: '' },
+    });
+    expect(recreated.hasPrimaryPassword).toBe(false);
+    await expect(app!.RevealSavedConnectionPrimaryPassword(saved.id)).rejects.toThrow('no stored primary password');
+  }, 30000);
 
   it('localizes generated browser mock saved query names', async () => {
     vi.stubGlobal('navigator', {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -167,39 +167,51 @@ if (
         mockConnections.push(view);
     };
 
+    const retainMockConnectionSecret = (value: unknown, existingValue: unknown): string => {
+        const nextValue = String(value ?? '');
+        return nextValue !== '' ? nextValue : String(existingValue ?? '');
+    };
+
     const saveMockConnection = (input: any) => {
         const existing = mockConnections.find((item) => item.id === input?.id);
         const hasIncludeDatabases = Object.prototype.hasOwnProperty.call(input || {}, 'includeDatabases');
         const hasIncludeDatabasePatterns = Object.prototype.hasOwnProperty.call(input || {}, 'includeDatabasePatterns');
         const hasExcludeDatabasePatterns = Object.prototype.hasOwnProperty.call(input || {}, 'excludeDatabasePatterns');
         const hasSchemaVisibilityByDatabase = Object.prototype.hasOwnProperty.call(input || {}, 'schemaVisibilityByDatabase');
-        const existingSecrets = mockConnectionSecrets.get(existing?.id || input?.id || '') || {};
+        const existingSecrets = existing ? (mockConnectionSecrets.get(existing.id) || {}) : {};
         const config = (input?.config && typeof input.config === 'object') ? input.config : {};
         const ssh = (config.ssh && typeof config.ssh === 'object') ? config.ssh : {};
         const proxy = (config.proxy && typeof config.proxy === 'object') ? config.proxy : {};
         const httpTunnel = (config.httpTunnel && typeof config.httpTunnel === 'object') ? config.httpTunnel : {};
         const nextId = String(input?.id || existing?.id || `mock-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
-        const nextSecrets = {
-            password: String(config.password ?? existingSecrets.password ?? ''),
-            sshPassword: String(ssh.password ?? existingSecrets.sshPassword ?? ''),
-            proxyPassword: String(proxy.password ?? existingSecrets.proxyPassword ?? ''),
-            httpTunnelPassword: String(httpTunnel.password ?? existingSecrets.httpTunnelPassword ?? ''),
-            mysqlReplicaPassword: String(config.mysqlReplicaPassword ?? existingSecrets.mysqlReplicaPassword ?? ''),
-            mongoReplicaPassword: String(config.mongoReplicaPassword ?? existingSecrets.mongoReplicaPassword ?? ''),
-            redisSentinelPassword: String(config.redisSentinelPassword ?? existingSecrets.redisSentinelPassword ?? ''),
-            uri: String(config.uri ?? existingSecrets.uri ?? ''),
-            dsn: String(config.dsn ?? existingSecrets.dsn ?? ''),
+        const nextSecrets: Record<string, string> = {
+            password: retainMockConnectionSecret(config.password, existingSecrets.password),
+            sshPassword: retainMockConnectionSecret(ssh.password, existingSecrets.sshPassword),
+            proxyPassword: retainMockConnectionSecret(proxy.password, existingSecrets.proxyPassword),
+            httpTunnelPassword: retainMockConnectionSecret(httpTunnel.password, existingSecrets.httpTunnelPassword),
+            mysqlReplicaPassword: retainMockConnectionSecret(config.mysqlReplicaPassword, existingSecrets.mysqlReplicaPassword),
+            mongoReplicaPassword: retainMockConnectionSecret(config.mongoReplicaPassword, existingSecrets.mongoReplicaPassword),
+            redisSentinelPassword: retainMockConnectionSecret(config.redisSentinelPassword, existingSecrets.redisSentinelPassword),
+            uri: retainMockConnectionSecret(config.uri, existingSecrets.uri),
+            dsn: retainMockConnectionSecret(config.dsn, existingSecrets.dsn),
         };
-        if (input?.clearPrimaryPassword) nextSecrets.password = '';
-        if (input?.clearSSHPassword) nextSecrets.sshPassword = '';
-        if (input?.clearProxyPassword) nextSecrets.proxyPassword = '';
-        if (input?.clearHttpTunnelPassword) nextSecrets.httpTunnelPassword = '';
-        if (input?.clearMySQLReplicaPassword) nextSecrets.mysqlReplicaPassword = '';
-        if (input?.clearMongoReplicaPassword) nextSecrets.mongoReplicaPassword = '';
-        if (input?.clearRedisSentinelPassword) nextSecrets.redisSentinelPassword = '';
-        if (input?.clearOpaqueURI) nextSecrets.uri = '';
-        if (input?.clearOpaqueDSN) nextSecrets.dsn = '';
-        mockConnectionSecrets.set(nextId, nextSecrets);
+        if (input?.clearPrimaryPassword) delete nextSecrets.password;
+        if (input?.clearSSHPassword) delete nextSecrets.sshPassword;
+        if (input?.clearProxyPassword) delete nextSecrets.proxyPassword;
+        if (input?.clearHttpTunnelPassword) delete nextSecrets.httpTunnelPassword;
+        if (input?.clearMySQLReplicaPassword) delete nextSecrets.mysqlReplicaPassword;
+        if (input?.clearMongoReplicaPassword) delete nextSecrets.mongoReplicaPassword;
+        if (input?.clearRedisSentinelPassword) delete nextSecrets.redisSentinelPassword;
+        if (input?.clearOpaqueURI) delete nextSecrets.uri;
+        if (input?.clearOpaqueDSN) delete nextSecrets.dsn;
+        Object.entries(nextSecrets).forEach(([key, value]) => {
+            if (value === '') delete nextSecrets[key];
+        });
+        if (Object.keys(nextSecrets).length > 0) {
+            mockConnectionSecrets.set(nextId, nextSecrets);
+        } else {
+            mockConnectionSecrets.delete(nextId);
+        }
         const view = {
             id: nextId,
             name: String(input?.name || existing?.name || t('connection.unnamed')),
@@ -387,22 +399,18 @@ if (
                     if (!existing) {
                         throw new Error(`saved connection not found: ${id}`);
                     }
-                    const secrets = mockConnectionSecrets.get(id) || {};
-                    return cloneBrowserMockValue({
-                        ...existing,
-                        config: {
-                            ...existing.config,
-                            password: secrets.password || '',
-                            ssh: { ...(existing.config?.ssh || {}), password: secrets.sshPassword || '' },
-                            proxy: { ...(existing.config?.proxy || {}), password: secrets.proxyPassword || '' },
-                            httpTunnel: { ...(existing.config?.httpTunnel || {}), password: secrets.httpTunnelPassword || '' },
-                            mysqlReplicaPassword: secrets.mysqlReplicaPassword || '',
-                            mongoReplicaPassword: secrets.mongoReplicaPassword || '',
-                            redisSentinelPassword: secrets.redisSentinelPassword || '',
-                            uri: secrets.uri || '',
-                            dsn: secrets.dsn || '',
-                        },
-                    });
+                    return cloneBrowserMockValue(existing);
+                },
+                RevealSavedConnectionPrimaryPassword: async (id: string) => {
+                    const existing = mockConnections.find((item) => item.id === id);
+                    if (!existing) {
+                        throw new Error(`saved connection not found: ${id}`);
+                    }
+                    const password = String(mockConnectionSecrets.get(id)?.password || '');
+                    if (!existing.hasPrimaryPassword || password === '') {
+                        throw new Error(`saved connection has no stored primary password: ${id}`);
+                    }
+                    return password;
                 },
                 ListInstalledFontFamilies: async () => ({ success: true, data: [] }),
                 SaveConnection: async (input: any) => saveMockConnection(input),
@@ -411,6 +419,7 @@ if (
                     if (index >= 0) {
                         mockConnections.splice(index, 1);
                     }
+                    mockConnectionSecrets.delete(id);
                     return null;
                 },
                 DuplicateConnection: async (id: string) => {
@@ -422,6 +431,13 @@ if (
                         nextId: `mock-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
                     });
                     mockConnections.push(duplicated);
+                    const existingSecrets = mockConnectionSecrets.get(id);
+                    if (existingSecrets) {
+                        mockConnectionSecrets.set(
+                            duplicated.id,
+                            cloneBrowserMockValue(existingSecrets),
+                        );
+                    }
                     return cloneBrowserMockValue(duplicated);
                 },
                 ImportLegacyConnections: async (items: any[]) => items.map((item) => saveMockConnection(item)),

--- a/internal/app/methods_saved_connections.go
+++ b/internal/app/methods_saved_connections.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"strings"
 
 	"GoNavi-Wails/internal/connection"
@@ -26,6 +27,17 @@ func (a *App) GetEditableSavedConnection(id string) (connection.SavedConnectionV
 	// Editing relies on the Has* flags and explicit clear fields. Returning the
 	// resolved bundle would expose every saved credential to the WebView.
 	return sanitizeSavedConnectionView(view), nil
+}
+
+func (a *App) RevealSavedConnectionPrimaryPassword(id string) (string, error) {
+	view, bundle, err := a.savedConnectionRepository().loadConnectionSnapshot(id)
+	if err != nil {
+		return "", err
+	}
+	if !view.HasPrimaryPassword || strings.TrimSpace(bundle.Password) == "" {
+		return "", fmt.Errorf("saved connection has no stored primary password: %s", strings.TrimSpace(id))
+	}
+	return bundle.Password, nil
 }
 
 func (a *App) SaveConnection(input connection.SavedConnectionInput) (connection.SavedConnectionView, error) {

--- a/internal/app/methods_saved_connections_test.go
+++ b/internal/app/methods_saved_connections_test.go
@@ -280,6 +280,123 @@ func TestGetEditableSavedConnectionReturnsSecretlessViewForEdit(t *testing.T) {
 	}
 }
 
+func TestRevealSavedConnectionPrimaryPasswordReturnsOnlyPrimarySecret(t *testing.T) {
+	app := NewAppWithSecretStore(newFakeAppSecretStore())
+	app.configDir = t.TempDir()
+
+	if _, err := app.SaveConnection(connection.SavedConnectionInput{
+		ID:   "conn-reveal-password",
+		Name: "Reveal password",
+		Config: connection.ConnectionConfig{
+			ID:       "conn-reveal-password",
+			Type:     "mysql",
+			Host:     "db.local",
+			Port:     3306,
+			User:     "root",
+			Password: "primary-secret",
+			UseSSH:   true,
+			SSH: connection.SSHConfig{
+				Host:     "jump.local",
+				Port:     22,
+				User:     "ops",
+				Password: "ssh-secret",
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	password, err := app.RevealSavedConnectionPrimaryPassword("conn-reveal-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if password != "primary-secret" {
+		t.Fatalf("expected primary password, got %q", password)
+	}
+
+	editable, err := app.GetEditableSavedConnection("conn-reveal-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if editable.Config.Password != "" || editable.Config.SSH.Password != "" {
+		t.Fatalf("editable view must remain secretless: %#v", editable.Config)
+	}
+}
+
+func TestRevealSavedConnectionPrimaryPasswordFailsClosedWithoutSavedPrimarySecret(t *testing.T) {
+	app := NewAppWithSecretStore(newFakeAppSecretStore())
+	app.configDir = t.TempDir()
+
+	withoutPassword, err := app.SaveConnection(connection.SavedConnectionInput{
+		ID:   "conn-without-password",
+		Name: "No password",
+		Config: connection.ConnectionConfig{
+			ID:   "conn-without-password",
+			Type: "mysql",
+			Host: "db.local",
+			Port: 3306,
+			User: "root",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withoutPassword.HasPrimaryPassword {
+		t.Fatal("connection without a password must not advertise a saved primary password")
+	}
+
+	password, err := app.RevealSavedConnectionPrimaryPassword(withoutPassword.ID)
+	if err == nil || !strings.Contains(err.Error(), "no stored primary password") {
+		t.Fatalf("expected an explicit no-password error, got password=%q err=%v", password, err)
+	}
+	if password != "" {
+		t.Fatalf("no-password error must not return secret material, got %q", password)
+	}
+
+	staleView, err := app.SaveConnection(connection.SavedConnectionInput{
+		ID:   "conn-stale-password",
+		Name: "Stale password",
+		Config: connection.ConnectionConfig{
+			ID:       "conn-stale-password",
+			Type:     "mysql",
+			Host:     "db.local",
+			Port:     3306,
+			User:     "root",
+			Password: "must-not-leak",
+			UseSSH:   true,
+			SSH: connection.SSHConfig{
+				Host:     "jump.local",
+				Port:     22,
+				User:     "ops",
+				Password: "ssh-secret",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleView.HasPrimaryPassword = false
+	if err := app.savedConnectionRepository().saveAll([]connection.SavedConnectionView{withoutPassword, staleView}); err != nil {
+		t.Fatal(err)
+	}
+
+	password, err = app.RevealSavedConnectionPrimaryPassword(staleView.ID)
+	if err == nil || !strings.Contains(err.Error(), "no stored primary password") {
+		t.Fatalf("expected stale primary secret to be rejected, got password=%q err=%v", password, err)
+	}
+	if password != "" {
+		t.Fatalf("stale primary secret must not be returned, got %q", password)
+	}
+
+	password, err = app.RevealSavedConnectionPrimaryPassword("missing-connection")
+	if err == nil || !strings.Contains(err.Error(), "saved connection not found") {
+		t.Fatalf("expected missing connection error, got password=%q err=%v", password, err)
+	}
+	if password != "" {
+		t.Fatalf("missing connection must not return secret material, got %q", password)
+	}
+}
+
 func TestSaveConnectionOnDarwinPersistsSecretsInlineButReturnsSecretlessView(t *testing.T) {
 	app := NewAppWithSecretStore(failOnUseSecretStore{})
 	app.configDir = t.TempDir()

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -102,6 +102,10 @@ var desktopOnlyAppMethods = map[string]struct{}{
 	"ExportSQLAuditFile":            {},
 }
 
+var desktopOnlyCredentialAppMethods = map[string]struct{}{
+	"RevealSavedConnectionPrimaryPassword": {},
+}
+
 type Options struct {
 	Addr string
 }
@@ -435,7 +439,11 @@ func (i *methodInvoker) Invoke(req invokeRequest) (any, error) {
 }
 
 func isDesktopOnlyAppMethod(methodName string) bool {
-	_, denied := desktopOnlyAppMethods[strings.TrimSpace(methodName)]
+	methodName = strings.TrimSpace(methodName)
+	if _, denied := desktopOnlyAppMethods[methodName]; denied {
+		return true
+	}
+	_, denied := desktopOnlyCredentialAppMethods[methodName]
 	return denied
 }
 

--- a/internal/webserver/server_test.go
+++ b/internal/webserver/server_test.go
@@ -32,6 +32,10 @@ func (webserverTestReceiver) OpenSQLFile() string {
 	return "desktop-method-reached"
 }
 
+func (webserverTestReceiver) RevealSavedConnectionPrimaryPassword(id string) (string, error) {
+	return "secret-for-" + id, nil
+}
+
 func TestInjectRuntimeBridgeAddsScriptOnce(t *testing.T) {
 	indexHTML := "<html><head><title>GoNavi</title></head><body></body></html>"
 
@@ -109,7 +113,7 @@ func TestMethodInvokerRejectsDesktopOnlyAppMethodsBeforeReflection(t *testing.T)
 		"ExportDatabaseSQLWithOptions", "ExportSchemaSQLWithOptions",
 		"ApplyDataRootDirectory", "OpenDataRootDirectory", "SelectLogDirectory", "ApplyLogDirectory", "OpenLogDirectory",
 		"SelectSavedQueryDirectory", "ApplySavedQueryDirectory", "OpenSavedQueryDirectory", "RevealSavedQueryInFolder", "SetApplicationBrandIcon",
-		"RefreshWebViewBounds",
+		"RefreshWebViewBounds", "RevealSavedConnectionPrimaryPassword",
 	} {
 		_, err := invoker.Invoke(invokeRequest{Namespace: "app", Receiver: "app", Method: method})
 		if err == nil || !strings.Contains(err.Error(), "unavailable in web runtime") {
@@ -131,6 +135,28 @@ func TestSharedMethodInvokerAllowsDesktopMethods(t *testing.T) {
 	}
 	if result != "desktop-method-reached" {
 		t.Fatalf("unexpected shared desktop result: %#v", result)
+	}
+}
+
+func TestSharedMethodInvokerAllowsSavedPasswordReveal(t *testing.T) {
+	invoker := &methodInvoker{
+		targets: map[string]reflect.Value{
+			"app.app": reflect.ValueOf(webserverTestReceiver{}),
+		},
+		allowDesktopMethods: true,
+	}
+	rawID, _ := json.Marshal("conn-1")
+	result, err := invoker.Invoke(invokeRequest{
+		Namespace: "app",
+		Receiver:  "app",
+		Method:    "RevealSavedConnectionPrimaryPassword",
+		Args:      []json.RawMessage{rawID},
+	})
+	if err != nil {
+		t.Fatalf("shared desktop password reveal was rejected: %v", err)
+	}
+	if result != "secret-for-conn-1" {
+		t.Fatalf("unexpected revealed password: %#v", result)
 	}
 }
 

--- a/shared/i18n/de-DE.json
+++ b/shared/i18n/de-DE.json
@@ -3758,6 +3758,7 @@
   "connection_modal.secret.error.saved_connection_missing": "Das gespeicherte Secret für die aktuelle Verbindung wurde nicht gefunden. Geben Sie das Passwort erneut ein, speichern Sie und versuchen Sie es noch einmal.",
   "connection_modal.secret.error.store_unavailable": "Der sichere Secret-Speicher ist derzeit nicht verfügbar. Prüfen Sie den System-Schlüsselbund oder die Anmeldeinformationsverwaltung und versuchen Sie es erneut.",
   "connection_modal.secret.new_value_replaces_saved": "Der neu eingegebene Wert ersetzt beim Speichern den aktuell gesicherten Wert.",
+  "connection_modal.secret.reveal_failed": "Das gespeicherte Passwort konnte nicht angezeigt werden: {{detail}}",
   "connection_modal.secret.saved_dsn_description": "Eine DSN ist bereits sicher gespeichert. Lassen Sie das Feld leer, um sie weiter zu verwenden.",
   "connection_modal.secret.saved_mongo_replica_password": "Gespeichertes MongoDB-Replica-Passwort",
   "connection_modal.secret.saved_mongo_replica_password_description": "Ein MongoDB-Replica-Passwort ist bereits im sicheren Speicher vorhanden. Leer lassen, um es beizubehalten.",

--- a/shared/i18n/en-US.json
+++ b/shared/i18n/en-US.json
@@ -3758,6 +3758,7 @@
   "connection_modal.secret.error.saved_connection_missing": "The saved secret for the current connection was not found. Re-enter the password, save, and try again.",
   "connection_modal.secret.error.store_unavailable": "Secure secret storage is currently unavailable. Check the system keychain or credential manager, then try again.",
   "connection_modal.secret.new_value_replaces_saved": "New value will replace the saved secret.",
+  "connection_modal.secret.reveal_failed": "Failed to show the saved password: {{detail}}",
   "connection_modal.secret.saved_dsn_description": "A DSN is already stored securely. Leave this empty to keep using it.",
   "connection_modal.secret.saved_mongo_replica_password": "Saved MongoDB replica password",
   "connection_modal.secret.saved_mongo_replica_password_description": "A MongoDB replica password is already saved in secure storage. Leave this field empty to keep it.",

--- a/shared/i18n/ja-JP.json
+++ b/shared/i18n/ja-JP.json
@@ -3758,6 +3758,7 @@
   "connection_modal.secret.error.saved_connection_missing": "現在の接続に対応する保存済みシークレットが見つかりません。パスワードを入力し直して保存してから再試行してください。",
   "connection_modal.secret.error.store_unavailable": "システムのシークレットストレージは現在利用できません。システムのキーチェーンまたは資格情報マネージャーを確認してから再試行してください。",
   "connection_modal.secret.new_value_replaces_saved": "新しい値が入力されています。保存時に保存済みの値を置き換えます。",
+  "connection_modal.secret.reveal_failed": "保存済みパスワードを表示できませんでした: {{detail}}",
   "connection_modal.secret.saved_dsn_description": "DSN は安全に保存されています。空のままにするとその DSN を使い続けます。",
   "connection_modal.secret.saved_mongo_replica_password": "保存済み MongoDB レプリカパスワード",
   "connection_modal.secret.saved_mongo_replica_password_description": "セキュアストレージに MongoDB レプリカパスワードが保存されています。保持する場合は空にします。",

--- a/shared/i18n/ru-RU.json
+++ b/shared/i18n/ru-RU.json
@@ -3758,6 +3758,7 @@
   "connection_modal.secret.error.saved_connection_missing": "Сохраненный секрет для текущего подключения не найден. Повторно введите пароль, сохраните и попробуйте снова.",
   "connection_modal.secret.error.store_unavailable": "Безопасное хранилище секретов сейчас недоступно. Проверьте системную связку ключей или диспетчер учетных данных и попробуйте снова.",
   "connection_modal.secret.new_value_replaces_saved": "Введено новое значение. При сохранении оно заменит текущие сохраненные данные.",
+  "connection_modal.secret.reveal_failed": "Не удалось показать сохраненный пароль: {{detail}}",
   "connection_modal.secret.saved_dsn_description": "DSN уже сохранен в защищенном хранилище. Оставьте поле пустым, чтобы сохранить его.",
   "connection_modal.secret.saved_mongo_replica_password": "Сохраненный пароль реплики MongoDB",
   "connection_modal.secret.saved_mongo_replica_password_description": "Пароль реплики MongoDB уже сохранен в защищенном хранилище. Оставьте поле пустым, чтобы сохранить его.",

--- a/shared/i18n/zh-CN.json
+++ b/shared/i18n/zh-CN.json
@@ -3758,6 +3758,7 @@
   "connection_modal.secret.error.saved_connection_missing": "未找到当前连接对应的已保存密文，请重新填写密码并保存后再试",
   "connection_modal.secret.error.store_unavailable": "系统密文存储当前不可用，请检查系统钥匙串或凭据管理器后再试",
   "connection_modal.secret.new_value_replaces_saved": "已输入新值，保存时会替换当前已保存内容。",
+  "connection_modal.secret.reveal_failed": "显示已保存密码失败：{{detail}}",
   "connection_modal.secret.saved_dsn_description": "安全存储中已有 DSN。留空将继续使用该 DSN。",
   "connection_modal.secret.saved_mongo_replica_password": "已保存 MongoDB 副本密码",
   "connection_modal.secret.saved_mongo_replica_password_description": "安全存储中已有 MongoDB 副本密码。留空将继续使用该密码。",

--- a/shared/i18n/zh-TW.json
+++ b/shared/i18n/zh-TW.json
@@ -3758,6 +3758,7 @@
   "connection_modal.secret.error.saved_connection_missing": "找不到目前連線對應的已儲存密文，請重新填寫密碼並儲存後再試",
   "connection_modal.secret.error.store_unavailable": "系統密文儲存目前無法使用，請檢查系統鑰匙圈或認證管理員後再試",
   "connection_modal.secret.new_value_replaces_saved": "已輸入新值，儲存時會取代目前已儲存內容。",
+  "connection_modal.secret.reveal_failed": "顯示已儲存密碼失敗：{{detail}}",
   "connection_modal.secret.saved_dsn_description": "安全儲存中已有 DSN。留空將繼續使用該 DSN。",
   "connection_modal.secret.saved_mongo_replica_password": "已儲存 MongoDB 複本密碼",
   "connection_modal.secret.saved_mongo_replica_password_description": "安全儲存中已有 MongoDB 複本密碼。留空將繼續使用該密碼。",


### PR DESCRIPTION
## 背景

编辑已保存的 Host 连接时，密码字段会保持脱敏，用户点击小眼睛后无法查看已保存密码；同时必须避免保存时误覆盖或误清除原密码。

## 变更点

- 新增桌面端按需读取已保存主密码的接口，并保持其他密文字段不暴露。
- 连接编辑弹窗支持点击小眼睛显示已保存密码，处理关闭弹窗、切换连接、清除密码和慢响应的状态竞争。
- 调整保存语义：仅查看密码不会覆盖原密码，明确清除才会删除；补充浏览器 mock、翻译及回归测试。
- Web Server 明确拒绝该明文密码读取接口。

## 影响范围

- 影响已保存连接的编辑密码交互与密码保留语义。
- 桌面端可按需显示主密码；Web 端不会获得明文密码。
- 查询、连接建立、驱动、同步及其他设置逻辑未改动。

## 验证

- `npm test -- --run src/components/ConnectionModal.i18n.test.tsx src/main.browserMock.test.ts src/components/connectionModal/connectionModalConfig.secret.test.ts`：62/62 通过。
- `npx tsc --noEmit`：通过。
- `GOMAXPROCS=1 go test -p 1 ./internal/app -run 'Test(RevealSavedConnectionPrimaryPassword|GetEditableSavedConnection|SaveConnection)' -count=1`：通过。
- `GOMAXPROCS=1 go test -p 1 ./internal/webserver -run 'Test(MethodInvokerRejectsDesktopOnlyAppMethodsBeforeReflection|SharedMethodInvokerAllowsSavedPasswordReveal)' -count=1`：通过。
- 用户自测：通过。
- 全量前端测试和完整 Vite 构建因本机资源占用导致超时，未发现密码功能相关失败。