### PR TITLE
fix(db): translate vector SQL WHERE filters

### DIFF
--- a/internal/db/chroma_impl.go
+++ b/internal/db/chroma_impl.go
@@ -143,6 +143,9 @@ func (c *ChromaDB) QueryContext(ctx context.Context, query string) ([]map[string
 	}
 
 	if parsed, ok := parseChromaSQL(text); ok {
+		if parsed.WhereError != nil {
+			return nil, nil, fmt.Errorf("Chroma WHERE 解析失败：%w", parsed.WhereError)
+		}
 		if parsed.Count {
 			total, err := c.countCollection(ctx, parsed.Collection, parsed.Where)
 			if err != nil {
@@ -852,6 +855,7 @@ type chromaParsedSQL struct {
 	Where             interface{}
 	Count             bool
 	IncludeEmbeddings bool
+	WhereError        error
 }
 
 var chromaSQLFromRE = regexp.MustCompile(`(?i)\bFROM\s+(?:"([^"]+)"|` + "`" + `([^` + "`" + `]+)` + "`" + `|([a-zA-Z0-9_.\-]+))`)
@@ -875,6 +879,11 @@ func parseChromaSQL(sqlText string) (chromaParsedSQL, bool) {
 	lower := strings.ToLower(text)
 	parsed.Count = strings.Contains(lower, "count(")
 	parsed.IncludeEmbeddings = strings.Contains(lower, "embedding")
+	whereExpr, _, whereErr := parseVectorSQLWhere(text)
+	parsed.WhereError = whereErr
+	if whereErr == nil && whereExpr != nil {
+		parsed.Where = chromaWhereFromExpr(whereExpr)
+	}
 	if m := chromaSQLLimitRE.FindStringSubmatch(text); len(m) > 1 {
 		parsed.Limit, _ = strconv.Atoi(m[1])
 	}

--- a/internal/db/chroma_impl_test.go
+++ b/internal/db/chroma_impl_test.go
@@ -159,6 +159,57 @@ func TestChromaSelectConvertsToGetRows(t *testing.T) {
 	}
 }
 
+func TestChromaSelectPassesWhereToGetAndCount(t *testing.T) {
+	var bodies []map[string]interface{}
+	server := newMockChromaServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v2/heartbeat":
+			writeChromaJSON(w, map[string]interface{}{"ok": true})
+		case strings.HasSuffix(r.URL.Path, "/collections"):
+			writeChromaJSON(w, []chromaCollection{{ID: "col-products", Name: "products"}})
+		case strings.HasSuffix(r.URL.Path, "/collections/col-products/get"):
+			var body map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			bodies = append(bodies, body)
+			writeChromaJSON(w, chromaGetResponse{})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	db := newTestChromaDB(t, server.URL)
+
+	queries := []string{
+		`SELECT * FROM "products" WHERE metadata.category = 'book' AND price >= 10 LIMIT 10 OFFSET 2`,
+		"select count(*) from `products` where active = true OR price < 5",
+	}
+	for _, query := range queries {
+		if _, _, err := db.Query(query); err != nil {
+			t.Fatalf("Query(%q) failed: %v", query, err)
+		}
+	}
+	if len(bodies) != 2 || bodies[0]["where"] == nil || bodies[1]["where"] == nil {
+		t.Fatalf("WHERE was not passed to Chroma: %#v", bodies)
+	}
+	first := bodies[0]["where"].(map[string]interface{})
+	if first["$and"] == nil {
+		t.Fatalf("compound WHERE = %#v, want $and", first)
+	}
+	second := bodies[1]["where"].(map[string]interface{})
+	if second["$or"] == nil {
+		t.Fatalf("COUNT WHERE = %#v, want $or", second)
+	}
+}
+
+func TestChromaSelectRejectsUnsupportedWhereWithoutDataRequest(t *testing.T) {
+	db := &ChromaDB{client: &http.Client{Transport: vectorWhereRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		t.Fatal("unsupported WHERE must not make an HTTP request")
+		return nil, nil
+	})}}
+	if _, _, err := db.Query(`SELECT * FROM products WHERE category LIKE 'book%'`); err == nil || !strings.Contains(err.Error(), "不支持") {
+		t.Fatalf("error = %v, want unsupported syntax error", err)
+	}
+}
+
 func TestChromaJSONQueryFlattensResults(t *testing.T) {
 	server := newMockChromaServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {

--- a/internal/db/qdrant_impl.go
+++ b/internal/db/qdrant_impl.go
@@ -158,14 +158,17 @@ func (q *QdrantDB) QueryContext(ctx context.Context, query string) ([]map[string
 	}
 
 	if parsed, ok := parseQdrantSQL(text); ok {
+		if parsed.WhereError != nil {
+			return nil, nil, fmt.Errorf("Qdrant WHERE 解析失败：%w", parsed.WhereError)
+		}
 		if parsed.Count {
-			total, err := q.countPoints(ctx, parsed.Collection, nil)
+			total, err := q.countPoints(ctx, parsed.Collection, parsed.Filter)
 			if err != nil {
 				return nil, nil, err
 			}
 			return []map[string]interface{}{{"total": total}}, []string{"total"}, nil
 		}
-		return q.scrollPoints(ctx, parsed.Collection, parsed.Limit, parsed.Offset, nil, true, parsed.IncludeVector)
+		return q.scrollPoints(ctx, parsed.Collection, parsed.Limit, parsed.Offset, parsed.Filter, true, parsed.IncludeVector)
 	}
 
 	return nil, nil, fmt.Errorf("Qdrant 查询仅支持 JSON 命令或简单 SELECT 预览")
@@ -818,6 +821,8 @@ type qdrantParsedSQL struct {
 	Offset        interface{}
 	Count         bool
 	IncludeVector bool
+	Filter        interface{}
+	WhereError    error
 }
 
 var qdrantSQLFromRE = regexp.MustCompile(`(?i)\bFROM\s+(?:"([^"]+)"|` + "`" + `([^` + "`" + `]+)` + "`" + `|([a-zA-Z0-9_.\-]+))`)
@@ -841,6 +846,14 @@ func parseQdrantSQL(sqlText string) (qdrantParsedSQL, bool) {
 	lower := strings.ToLower(text)
 	parsed.Count = strings.Contains(lower, "count(")
 	parsed.IncludeVector = strings.Contains(lower, "vector")
+	whereExpr, _, whereErr := parseVectorSQLWhere(text)
+	if whereErr == nil {
+		whereErr = validateQdrantWhereExpr(whereExpr)
+	}
+	parsed.WhereError = whereErr
+	if whereErr == nil && whereExpr != nil {
+		parsed.Filter = qdrantFilterFromExpr(whereExpr)
+	}
 	if m := qdrantSQLLimitRE.FindStringSubmatch(text); len(m) > 1 {
 		parsed.Limit, _ = strconv.Atoi(m[1])
 	}

--- a/internal/db/qdrant_impl_test.go
+++ b/internal/db/qdrant_impl_test.go
@@ -138,6 +138,59 @@ func TestQdrantSelectConvertsToScroll(t *testing.T) {
 	}
 }
 
+func TestQdrantSelectPassesWhereToScrollAndCount(t *testing.T) {
+	var bodies []map[string]interface{}
+	server := newMockQdrantServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/collections":
+			writeQdrantJSON(w, map[string]interface{}{"result": map[string]interface{}{"collections": []interface{}{}}})
+		case r.Method == http.MethodPost && (strings.HasSuffix(r.URL.Path, "/points/scroll") || strings.HasSuffix(r.URL.Path, "/points/count")):
+			var body map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			bodies = append(bodies, body)
+			if strings.HasSuffix(r.URL.Path, "/points/count") {
+				writeQdrantJSON(w, map[string]interface{}{"result": map[string]interface{}{"count": 0}})
+			} else {
+				writeQdrantJSON(w, map[string]interface{}{"result": map[string]interface{}{"points": []interface{}{}}})
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	db := newTestQdrantDB(t, server.URL)
+
+	queries := []string{
+		`SeLeCt * FrOm "products" WhErE payload.category = 'book' AND price >= 10 LIMIT 10 OFFSET point-2`,
+		"select count(*) from `products` where active != false OR price < 5",
+	}
+	for _, query := range queries {
+		if _, _, err := db.Query(query); err != nil {
+			t.Fatalf("Query(%q) failed: %v", query, err)
+		}
+	}
+	if len(bodies) != 2 || bodies[0]["filter"] == nil || bodies[1]["filter"] == nil {
+		t.Fatalf("WHERE was not passed to Qdrant: %#v", bodies)
+	}
+	first := bodies[0]["filter"].(map[string]interface{})
+	if first["must"] == nil {
+		t.Fatalf("compound WHERE = %#v, want must", first)
+	}
+	second := bodies[1]["filter"].(map[string]interface{})
+	if second["should"] == nil {
+		t.Fatalf("COUNT WHERE = %#v, want should", second)
+	}
+}
+
+func TestQdrantSelectRejectsUnsupportedWhereWithoutDataRequest(t *testing.T) {
+	db := &QdrantDB{client: &http.Client{Transport: vectorWhereRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		t.Fatal("unsupported WHERE must not make an HTTP request")
+		return nil, nil
+	})}}
+	if _, _, err := db.Query(`SELECT * FROM products WHERE category LIKE 'book%'`); err == nil || !strings.Contains(err.Error(), "不支持") {
+		t.Fatalf("error = %v, want unsupported syntax error", err)
+	}
+}
+
 func TestQdrantJSONSearchFlattensResults(t *testing.T) {
 	server := newMockQdrantServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {

--- a/internal/db/vector_sql_where.go
+++ b/internal/db/vector_sql_where.go
@@ -1,0 +1,315 @@
+package db
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+type vectorWhereExpr interface{}
+
+type vectorWhereComparison struct {
+	Field string
+	Op    string
+	Value interface{}
+}
+
+type vectorWhereLogical struct {
+	Op          string
+	Left, Right vectorWhereExpr
+}
+
+type vectorWhereParser struct {
+	tokens []string
+	pos    int
+}
+
+func parseVectorSQLWhere(sqlText string) (vectorWhereExpr, bool, error) {
+	whereStart := findSQLKeyword(sqlText, "WHERE", 0)
+	if whereStart < 0 {
+		return nil, false, nil
+	}
+	end := len(sqlText)
+	for _, keyword := range []string{"LIMIT", "OFFSET"} {
+		if index := findSQLKeyword(sqlText, keyword, whereStart+len("WHERE")); index >= 0 && index < end {
+			end = index
+		}
+	}
+	if index := findSQLOrderBy(sqlText, whereStart+len("WHERE")); index >= 0 && index < end {
+		end = index
+	}
+	clause := strings.TrimSpace(sqlText[whereStart+len("WHERE") : end])
+	clause = strings.TrimSuffix(clause, ";")
+	clause = strings.TrimSpace(clause)
+	if clause == "" {
+		return nil, true, fmt.Errorf("WHERE 条件不能为空")
+	}
+	tokens, err := tokenizeVectorWhere(clause)
+	if err != nil {
+		return nil, true, err
+	}
+	parser := vectorWhereParser{tokens: tokens}
+	expr, err := parser.parseOr()
+	if err != nil {
+		return nil, true, err
+	}
+	if parser.pos != len(tokens) {
+		return nil, true, fmt.Errorf("WHERE 包含不支持的语法：%s", tokens[parser.pos])
+	}
+	return expr, true, nil
+}
+
+func findSQLOrderBy(text string, start int) int {
+	for searchFrom := start; searchFrom < len(text); {
+		order := findSQLKeyword(text, "ORDER", searchFrom)
+		if order < 0 {
+			return -1
+		}
+		afterOrder := order + len("ORDER")
+		for afterOrder < len(text) && unicode.IsSpace(rune(text[afterOrder])) {
+			afterOrder++
+		}
+		if afterOrder+len("BY") <= len(text) && strings.EqualFold(text[afterOrder:afterOrder+len("BY")], "BY") &&
+			(afterOrder+len("BY") == len(text) || !isSQLWordByte(text[afterOrder+len("BY")])) {
+			return order
+		}
+		searchFrom = order + len("ORDER")
+	}
+	return -1
+}
+
+func validateQdrantWhereExpr(expr vectorWhereExpr) error {
+	switch value := expr.(type) {
+	case vectorWhereLogical:
+		if err := validateQdrantWhereExpr(value.Left); err != nil {
+			return err
+		}
+		return validateQdrantWhereExpr(value.Right)
+	case vectorWhereComparison:
+		field := strings.TrimPrefix(value.Field, "payload.")
+		if strings.EqualFold(field, "id") && value.Op != "=" && value.Op != "!=" {
+			return fmt.Errorf("Qdrant point ID 仅支持 = 和 != 条件")
+		}
+	}
+	return nil
+}
+
+func findSQLKeyword(text, keyword string, start int) int {
+	quote := rune(0)
+	for i := start; i < len(text); {
+		r := rune(text[i])
+		if quote != 0 {
+			if r == quote {
+				if i+1 < len(text) && rune(text[i+1]) == quote {
+					i += 2
+					continue
+				}
+				quote = 0
+			}
+			i++
+			continue
+		}
+		if r == '\'' || r == '"' || r == '`' {
+			quote = r
+			i++
+			continue
+		}
+		if i+len(keyword) <= len(text) && strings.EqualFold(text[i:i+len(keyword)], keyword) &&
+			(i == 0 || !isSQLWordByte(text[i-1])) && (i+len(keyword) == len(text) || !isSQLWordByte(text[i+len(keyword)])) {
+			return i
+		}
+		i++
+	}
+	return -1
+}
+
+func isSQLWordByte(value byte) bool {
+	return value == '_' || value >= '0' && value <= '9' || value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z'
+}
+
+func tokenizeVectorWhere(text string) ([]string, error) {
+	var tokens []string
+	for i := 0; i < len(text); {
+		if unicode.IsSpace(rune(text[i])) {
+			i++
+			continue
+		}
+		switch text[i] {
+		case '(', ')':
+			tokens = append(tokens, text[i:i+1])
+			i++
+		case '=', '!', '>', '<':
+			start := i
+			i++
+			if i < len(text) && text[i] == '=' {
+				i++
+			}
+			op := text[start:i]
+			if op == "!" {
+				return nil, fmt.Errorf("WHERE 包含不支持的操作符：%s", op)
+			}
+			tokens = append(tokens, op)
+		case '\'', '"', '`':
+			quote, start := text[i], i
+			i++
+			for i < len(text) {
+				if text[i] == quote {
+					if i+1 < len(text) && text[i+1] == quote {
+						i += 2
+						continue
+					}
+					break
+				}
+				if text[i] == '\\' && quote == '\'' && i+1 < len(text) {
+					i += 2
+				} else {
+					i++
+				}
+			}
+			if i == len(text) {
+				return nil, fmt.Errorf("WHERE 包含未闭合的引号")
+			}
+			i++
+			tokens = append(tokens, text[start:i])
+		default:
+			start := i
+			for i < len(text) && !unicode.IsSpace(rune(text[i])) && !strings.ContainsRune("()=!><", rune(text[i])) {
+				i++
+			}
+			tokens = append(tokens, text[start:i])
+		}
+	}
+	return tokens, nil
+}
+
+func (p *vectorWhereParser) parseOr() (vectorWhereExpr, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+	for p.consumeKeyword("OR") {
+		right, err := p.parseAnd()
+		if err != nil {
+			return nil, err
+		}
+		left = vectorWhereLogical{Op: "OR", Left: left, Right: right}
+	}
+	return left, nil
+}
+func (p *vectorWhereParser) parseAnd() (vectorWhereExpr, error) {
+	left, err := p.parsePrimary()
+	if err != nil {
+		return nil, err
+	}
+	for p.consumeKeyword("AND") {
+		right, err := p.parsePrimary()
+		if err != nil {
+			return nil, err
+		}
+		left = vectorWhereLogical{Op: "AND", Left: left, Right: right}
+	}
+	return left, nil
+}
+func (p *vectorWhereParser) parsePrimary() (vectorWhereExpr, error) {
+	if p.consume("(") {
+		expr, err := p.parseOr()
+		if err != nil {
+			return nil, err
+		}
+		if !p.consume(")") {
+			return nil, fmt.Errorf("WHERE 缺少右括号")
+		}
+		return expr, nil
+	}
+	if p.pos+2 >= len(p.tokens) {
+		return nil, fmt.Errorf("WHERE 比较表达式不完整")
+	}
+	field, op, raw := p.tokens[p.pos], p.tokens[p.pos+1], p.tokens[p.pos+2]
+	p.pos += 3
+	if strings.HasPrefix(field, "'") {
+		return nil, fmt.Errorf("WHERE 左侧必须是字段名")
+	}
+	if op != "=" && op != "!=" && op != ">" && op != ">=" && op != "<" && op != "<=" {
+		return nil, fmt.Errorf("WHERE 包含不支持的操作符：%s", op)
+	}
+	value, err := parseVectorWhereValue(raw)
+	if err != nil {
+		return nil, err
+	}
+	return vectorWhereComparison{Field: strings.Trim(field, "\"`"), Op: op, Value: value}, nil
+}
+func (p *vectorWhereParser) consume(token string) bool {
+	if p.pos < len(p.tokens) && p.tokens[p.pos] == token {
+		p.pos++
+		return true
+	}
+	return false
+}
+func (p *vectorWhereParser) consumeKeyword(token string) bool {
+	if p.pos < len(p.tokens) && strings.EqualFold(p.tokens[p.pos], token) {
+		p.pos++
+		return true
+	}
+	return false
+}
+
+func parseVectorWhereValue(raw string) (interface{}, error) {
+	if len(raw) >= 2 && raw[0] == '\'' && raw[len(raw)-1] == '\'' {
+		value := strings.ReplaceAll(raw[1:len(raw)-1], "''", "'")
+		return strings.ReplaceAll(value, "\\'", "'"), nil
+	}
+	if strings.EqualFold(raw, "true") {
+		return true, nil
+	}
+	if strings.EqualFold(raw, "false") {
+		return false, nil
+	}
+	if number, err := strconv.ParseInt(raw, 10, 64); err == nil {
+		return number, nil
+	}
+	if number, err := strconv.ParseFloat(raw, 64); err == nil {
+		return number, nil
+	}
+	return nil, fmt.Errorf("WHERE 值必须是字符串、数字或布尔值：%s", raw)
+}
+
+func chromaWhereFromExpr(expr vectorWhereExpr) interface{} {
+	switch value := expr.(type) {
+	case vectorWhereLogical:
+		return map[string]interface{}{"$" + strings.ToLower(value.Op): []interface{}{chromaWhereFromExpr(value.Left), chromaWhereFromExpr(value.Right)}}
+	case vectorWhereComparison:
+		op := map[string]string{"=": "$eq", "!=": "$ne", ">": "$gt", ">=": "$gte", "<": "$lt", "<=": "$lte"}[value.Op]
+		return map[string]interface{}{strings.TrimPrefix(value.Field, "metadata."): map[string]interface{}{op: value.Value}}
+	}
+	return nil
+}
+
+func qdrantFilterFromExpr(expr vectorWhereExpr) interface{} {
+	switch value := expr.(type) {
+	case vectorWhereLogical:
+		key := "must"
+		if value.Op == "OR" {
+			key = "should"
+		}
+		return map[string]interface{}{key: []interface{}{qdrantFilterFromExpr(value.Left), qdrantFilterFromExpr(value.Right)}}
+	case vectorWhereComparison:
+		field := strings.TrimPrefix(value.Field, "payload.")
+		if strings.EqualFold(field, "id") && (value.Op == "=" || value.Op == "!=") {
+			condition := map[string]interface{}{"has_id": []interface{}{value.Value}}
+			if value.Op == "!=" {
+				return map[string]interface{}{"must_not": []interface{}{condition}}
+			}
+			return condition
+		}
+		if value.Op == "!=" {
+			return map[string]interface{}{"must_not": []interface{}{map[string]interface{}{"key": field, "match": map[string]interface{}{"value": value.Value}}}}
+		}
+		if value.Op == "=" {
+			return map[string]interface{}{"key": field, "match": map[string]interface{}{"value": value.Value}}
+		}
+		op := map[string]string{">": "gt", ">=": "gte", "<": "lt", "<=": "lte"}[value.Op]
+		return map[string]interface{}{"key": field, "range": map[string]interface{}{op: value.Value}}
+	}
+	return nil
+}

--- a/internal/db/vector_sql_where_test.go
+++ b/internal/db/vector_sql_where_test.go
@@ -1,0 +1,110 @@
+package db
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type vectorWhereRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn vectorWhereRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestVectorSQLWhereConversion(t *testing.T) {
+	expr, found, err := parseVectorSQLWhere(`SELECT * FROM products WHERE (category = 'book' OR price < 5) AND active != false LIMIT 10;`)
+	if err != nil || !found {
+		t.Fatalf("parseVectorSQLWhere() = (%#v, %v, %v)", expr, found, err)
+	}
+
+	chromaJSON, _ := json.Marshal(chromaWhereFromExpr(expr))
+	for _, fragment := range []string{`"$and"`, `"$or"`, `"category":{"$eq":"book"}`, `"price":{"$lt":5}`, `"active":{"$ne":false}`} {
+		if !strings.Contains(string(chromaJSON), fragment) {
+			t.Errorf("Chroma filter %s missing %s", chromaJSON, fragment)
+		}
+	}
+
+	qdrantJSON, _ := json.Marshal(qdrantFilterFromExpr(expr))
+	for _, fragment := range []string{`"must"`, `"should"`, `"key":"category"`, `"match":{"value":"book"}`, `"range":{"lt":5}`, `"must_not"`} {
+		if !strings.Contains(string(qdrantJSON), fragment) {
+			t.Errorf("Qdrant filter %s missing %s", qdrantJSON, fragment)
+		}
+	}
+}
+
+func TestVectorSQLWhereRejectsUnsupportedSyntax(t *testing.T) {
+	queries := []string{
+		`SELECT * FROM products WHERE category LIKE 'book%'`,
+		`SELECT * FROM products WHERE price BETWEEN 1 AND 5`,
+		`SELECT * FROM products WHERE id IN (1, 2)`,
+		`SELECT * FROM products WHERE category = NULL`,
+		`SELECT * FROM products WHERE (active = true`,
+	}
+	for _, query := range queries {
+		if _, found, err := parseVectorSQLWhere(query); !found || err == nil {
+			t.Errorf("parseVectorSQLWhere(%q) found=%v err=%v, want explicit error", query, found, err)
+		}
+	}
+}
+
+func TestVectorSQLWhereStopsBeforeOrderBy(t *testing.T) {
+	expr, found, err := parseVectorSQLWhere(`SELECT * FROM products WHERE category = 'book' ORDER BY id LIMIT 10`)
+	if err != nil || !found {
+		t.Fatalf("parseVectorSQLWhere() = (%#v, %v, %v)", expr, found, err)
+	}
+	want := map[string]interface{}{"category": map[string]interface{}{"$eq": "book"}}
+	if got := chromaWhereFromExpr(expr); !reflect.DeepEqual(got, want) {
+		t.Fatalf("where = %#v, want %#v", got, want)
+	}
+}
+
+func TestVectorSQLWhereDoesNotTreatOrderFieldAsOrderBy(t *testing.T) {
+	expr, found, err := parseVectorSQLWhere(`SELECT * FROM products WHERE order = 3 LIMIT 10`)
+	if err != nil || !found {
+		t.Fatalf("parseVectorSQLWhere() = (%#v, %v, %v)", expr, found, err)
+	}
+	want := map[string]interface{}{"order": map[string]interface{}{"$eq": int64(3)}}
+	if got := chromaWhereFromExpr(expr); !reflect.DeepEqual(got, want) {
+		t.Fatalf("where = %#v, want %#v", got, want)
+	}
+}
+
+func TestVectorSQLWhereAcceptsDoubledSingleQuote(t *testing.T) {
+	expr, found, err := parseVectorSQLWhere(`SELECT * FROM products WHERE name = 'O''Reilly'`)
+	if err != nil || !found {
+		t.Fatalf("parseVectorSQLWhere() = (%#v, %v, %v)", expr, found, err)
+	}
+	want := map[string]interface{}{"name": map[string]interface{}{"$eq": "O'Reilly"}}
+	if got := chromaWhereFromExpr(expr); !reflect.DeepEqual(got, want) {
+		t.Fatalf("where = %#v, want %#v", got, want)
+	}
+}
+
+func TestQdrantIDRangePredicateIsRejected(t *testing.T) {
+	parsed, ok := parseQdrantSQL(`SELECT * FROM products WHERE id > 42`)
+	if !ok || parsed.WhereError == nil || !strings.Contains(parsed.WhereError.Error(), "仅支持") {
+		t.Fatalf("parseQdrantSQL() = (%#v, %v), want explicit point ID range error", parsed, ok)
+	}
+}
+
+func TestQdrantIDPredicatesUsePointIDFilter(t *testing.T) {
+	tests := []struct {
+		query string
+		want  interface{}
+	}{
+		{`SELECT * FROM products WHERE id = 42`, map[string]interface{}{"has_id": []interface{}{int64(42)}}},
+		{`SELECT * FROM products WHERE id != 'point-1'`, map[string]interface{}{"must_not": []interface{}{map[string]interface{}{"has_id": []interface{}{"point-1"}}}}},
+	}
+	for _, test := range tests {
+		expr, _, err := parseVectorSQLWhere(test.query)
+		if err != nil {
+			t.Fatalf("parseVectorSQLWhere(%q): %v", test.query, err)
+		}
+		if got := qdrantFilterFromExpr(expr); !reflect.DeepEqual(got, test.want) {
+			t.Errorf("qdrantFilterFromExpr(%q) = %#v, want %#v", test.query, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #927

## 根因
Chroma 和 Qdrant 的简化 SQL 解析器接受包含 `WHERE` 的 `SELECT`，但只提取 `FROM`、`LIMIT` 和 `OFFSET`。执行层随后传递空过滤器，导致条件被静默丢弃并返回未过滤结果。

## 变更内容
- 为向量数据库简化 SQL 增加受限 WHERE 解析器，支持 `=`, `!=`, `>`, `>=`, `<`, `<=`、`AND`、`OR`、括号，以及字符串、数字和布尔字面量。
- 将解析树转换为 Chroma `$eq/$ne/$gt/$gte/$lt/$lte`、`$and/$or` where。
- 将解析树转换为 Qdrant `match`/`range`、`must`/`should`/`must_not` filter。
- SELECT 与 COUNT 传递相同过滤语义；不支持的操作符、子句或残余 token 在 HTTP 数据请求前明确报错。
- 添加端到端请求体测试和解析/转换单元测试。

## 影响范围
仅影响 Chroma 与 Qdrant 的简化 SQL SELECT/COUNT 路径。无 WHERE 的简单预览、JSON 命令以及其他数据库驱动保持不变。字段前缀 `metadata.`（Chroma）与 `payload.`（Qdrant）会在生成服务端过滤器时移除。

## 验证命令和结果
- `go test ./internal/db -run 'Test(VectorSQLWhere|ChromaSelect|QdrantSelect)' -count=1`：通过
- `go test ./internal/db -count=1`：通过
- `go vet ./internal/db`：通过
- `git diff --check`：通过
- 敏感信息正则扫描变更 diff：无匹配

## 未运行检查
- `go test ./...`：根包构建缺少生成产物 `frontend/dist`，`assets_prod.go` embed 模式无法匹配。
- 未运行真实 Chroma/Qdrant live smoke tests；HTTP mock 已验证生成的请求体。

## 风险与回滚方式
风险集中在 SQL 子集到两种服务端过滤 DSL 的映射。解析器采取白名单策略，任何未完全消费的语法均显式失败，避免静默扩大查询范围。若需回滚，可 revert 本 PR 的两个提交；无数据迁移或配置变更。