### PR TITLE
fix(ai): normalize incomplete tool call history

### DIFF
--- a/internal/ai/provider/openai.go
+++ b/internal/ai/provider/openai.go
@@ -122,6 +122,7 @@ type openAIChatMessage struct {
 
 func buildOpenAIMessages(reqMessages []ai.Message, modelName string, baseURL string) []openAIChatMessage {
 	reqMessages = normalizeOpenAISystemMessageOrder(reqMessages)
+	reqMessages = normalizeOpenAIToolCallHistory(reqMessages)
 	messages := make([]openAIChatMessage, len(reqMessages))
 	replayReasoningContent := shouldReplayReasoningContent(modelName, baseURL)
 	for i, m := range reqMessages {
@@ -171,6 +172,60 @@ func buildOpenAIMessages(reqMessages []ai.Message, modelName string, baseURL str
 		}
 	}
 	return messages
+}
+
+// normalizeOpenAIToolCallHistory removes incomplete tool-call groups and orphan
+// tool results. OpenAI-compatible APIs require every assistant tool_call to be
+// answered by a contiguous tool message before another conversation turn.
+func normalizeOpenAIToolCallHistory(messages []ai.Message) []ai.Message {
+	normalized := make([]ai.Message, 0, len(messages))
+	for index := 0; index < len(messages); {
+		message := messages[index]
+		if message.Role == "tool" {
+			index++
+			continue
+		}
+		if message.Role != "assistant" || len(message.ToolCalls) == 0 {
+			normalized = append(normalized, message)
+			index++
+			continue
+		}
+
+		expected := make(map[string]struct{}, len(message.ToolCalls))
+		valid := true
+		for _, call := range message.ToolCalls {
+			if call.ID == "" {
+				valid = false
+				break
+			}
+			if _, duplicate := expected[call.ID]; duplicate {
+				valid = false
+				break
+			}
+			expected[call.ID] = struct{}{}
+		}
+		end := index + 1
+		results := make([]ai.Message, 0, len(expected))
+		seen := make(map[string]struct{}, len(expected))
+		for end < len(messages) && messages[end].Role == "tool" {
+			result := messages[end]
+			if _, ok := expected[result.ToolCallID]; !ok {
+				valid = false
+			} else if _, duplicate := seen[result.ToolCallID]; duplicate {
+				valid = false
+			} else {
+				seen[result.ToolCallID] = struct{}{}
+				results = append(results, result)
+			}
+			end++
+		}
+		if valid && len(seen) == len(expected) {
+			normalized = append(normalized, message)
+			normalized = append(normalized, results...)
+		}
+		index = end
+	}
+	return normalized
 }
 
 // normalizeOpenAISystemMessageOrder keeps strict OpenAI-compatible endpoints

--- a/internal/ai/provider/openai_test.go
+++ b/internal/ai/provider/openai_test.go
@@ -575,14 +575,67 @@ func TestBuildOpenAIMessages_ReplaysDeepSeekReasoningContentForToolCalls(t *test
 	}
 }
 
+func TestBuildOpenAIMessages_DropsIncompleteDeepSeekToolCallGroup(t *testing.T) {
+	firstCall := testOpenAIToolCall()
+	secondCall := firstCall
+	secondCall.ID = "call_query"
+	secondCall.Function.Name = "execute_query"
+
+	got := buildOpenAIMessages([]ai.Message{
+		{Role: "user", Content: "检查并查询订单表"},
+		{Role: "assistant", ToolCalls: []ai.ToolCall{firstCall, secondCall}, ReasoningContent: "先检查表结构"},
+		{Role: "tool", Content: `{"ok":true}`, ToolCallID: firstCall.ID},
+		{Role: "user", Content: "继续"},
+	}, "deepseek-v4-flash", "https://api.deepseek.com/v1")
+
+	if len(got) != 2 || got[0].Role != "user" || got[1].Role != "user" {
+		t.Fatalf("incomplete tool-call group was not removed: %#v", got)
+	}
+	for _, message := range got {
+		if len(message.ToolCalls) > 0 || message.ToolCallID != "" {
+			t.Fatalf("invalid tool history remains in request: %#v", got)
+		}
+	}
+}
+
+func TestBuildOpenAIMessages_PreservesCompleteMultiToolCallGroup(t *testing.T) {
+	firstCall := testOpenAIToolCall()
+	secondCall := firstCall
+	secondCall.ID = "call_query"
+	secondCall.Function.Name = "execute_query"
+
+	got := buildOpenAIMessages([]ai.Message{
+		{Role: "assistant", ToolCalls: []ai.ToolCall{firstCall, secondCall}},
+		{Role: "tool", Content: `{"columns":[]}`, ToolCallID: firstCall.ID},
+		{Role: "tool", Content: `{"rows":[]}`, ToolCallID: secondCall.ID},
+	}, "deepseek-v4-flash", "https://api.deepseek.com/v1")
+
+	if len(got) != 3 || len(got[0].ToolCalls) != 2 || got[1].ToolCallID != firstCall.ID || got[2].ToolCallID != secondCall.ID {
+		t.Fatalf("complete tool-call group changed: %#v", got)
+	}
+}
+
+func TestBuildOpenAIMessages_DropsOrphanToolResult(t *testing.T) {
+	got := buildOpenAIMessages([]ai.Message{
+		{Role: "tool", Content: `{"ok":true}`, ToolCallID: "missing_call"},
+		{Role: "user", Content: "hello"},
+	}, "deepseek-v4-flash", "https://api.deepseek.com/v1")
+
+	if len(got) != 1 || got[0].Role != "user" {
+		t.Fatalf("orphan tool result was not removed: %#v", got)
+	}
+}
+
 func TestBuildOpenAIMessages_OmitsReasoningContentForNonDeepSeekProviders(t *testing.T) {
+	toolCall := testOpenAIToolCall()
 	got := buildOpenAIMessages([]ai.Message{
 		{
 			Role:             "assistant",
 			Content:          "",
-			ToolCalls:        []ai.ToolCall{testOpenAIToolCall()},
+			ToolCalls:        []ai.ToolCall{toolCall},
 			ReasoningContent: "reasoning should stay local",
 		},
+		{Role: "tool", Content: `{"ok":true}`, ToolCallID: toolCall.ID},
 	}, "gpt-4o", "https://api.openai.com/v1")
 
 	if got[0].ReasoningContent != "" {


### PR DESCRIPTION
Fixes #934

## 根因
前端聊天历史可能暂时保存一个包含多个 `tool_calls` 的 assistant 消息，但只写入部分工具结果，或在所有工具结果闭环前出现下一条对话消息。OpenAI provider 构造请求时此前只转换字段，不校验工具调用序列，导致不完整历史原样发送。DeepSeek OpenAI-compatible API 会严格校验每个 `tool_call_id` 都有连续的 tool 响应，因此返回 HTTP 400。

## 变更内容
- 在 OpenAI 请求消息构建阶段规范化工具调用历史。
- 仅保留 assistant tool_calls 后由连续 tool 消息完整且唯一响应所有 ID 的调用组。
- 删除未闭环调用组、孤立 tool 消息、未知/重复结果及缺少/重复 ID 的无效组，不伪造工具执行结果。
- 添加 Issue 复现场景、完整多工具调用和孤立结果回归测试。

## 影响范围
仅影响 OpenAI-compatible provider 发出请求前的历史规范化。完整工具调用链、普通文本、图片和 DeepSeek reasoning_content 重放保持不变。

## 验证命令和结果
- `go test ./internal/ai/provider -run 'TestBuildOpenAIMessages_(DropsIncompleteDeepSeekToolCallGroup|PreservesCompleteMultiToolCallGroup|DropsOrphanToolResult|ReplaysDeepSeek)' -count=1`：通过
- `go test ./internal/ai/provider -count=1`：通过
- `go test ./internal/ai/... -count=1`：通过
- `go vet ./internal/ai/provider`：通过
- `git diff --check`：通过
- 敏感信息扫描：无匹配

## 未运行检查
- 未使用真实 DeepSeek API key 运行 live test；使用与其 HTTP 400 校验规则一致的消息序列单元测试复现并验证。
- 未运行 `go test ./...`；仓库根包需要生成的 `frontend/dist` embed 产物。

## 风险与回滚方式
风险是未闭环工具调用的 assistant 内容会随无效调用组一起从上游请求历史移除；这是有意的安全降级，避免伪造结果或发送协议无效历史。UI 本地历史不会被修改。回滚可 revert 本 PR 单一提交，无数据迁移或配置变更。