### PR TITLE
✨ feat(data-grid): 新增活动单元格行列交叉高亮

### DIFF
--- a/frontend/src/components/DataGrid.layout.test.tsx
+++ b/frontend/src/components/DataGrid.layout.test.tsx
@@ -498,7 +498,9 @@ describe('DataGrid layout', () => {
     expect(css).toContain(
       '.hover-grid.data-grid-root .ant-table-tbody .ant-table-row:hover > .ant-table-cell { background-color: transparent !important; }',
     );
-    expect(css).not.toContain('var(--gn-bg-hover');
+    expect(css).not.toContain(
+      '.hover-grid.data-grid-root .ant-table-tbody .ant-table-row:hover > .ant-table-cell { background-color: var(--gn-bg-hover',
+    );
     expect(css).not.toContain('rgba(34, 197, 94, 0.18)');
     expect(css).not.toContain('added-hover');
     expect(css).not.toContain('modified-hover');
@@ -548,6 +550,47 @@ describe('DataGrid layout', () => {
       expect(rule).toContain('background-image: linear-gradient(');
       expect(rule).toContain('var(--gn-bg-selected, rgba(34, 197, 94, 0.14))');
     });
+  });
+
+  it('paints a neutral crosshair for the active cell while preserving selection precedence', () => {
+    const css = buildDataGridCssText({
+      darkMode: false,
+      densityParams: { dataFontSize: 12 },
+      gridId: 'active-cell-grid',
+      bgContent: '#ffffff',
+    });
+    const rowSelector = '.active-cell-grid.data-grid-root .ant-table-tbody-virtual-holder .ant-table-row[data-active-cell-row="true"] > .ant-table-cell';
+    const columnSelector = '.active-cell-grid.data-grid-root .ant-table-tbody-virtual-holder .ant-table-row > .ant-table-cell[data-active-cell-column="true"]';
+    const fixedControlHoverSelector = '.active-cell-grid.data-grid-root .ant-table-tbody-virtual-holder .ant-table-row[data-active-cell-row="true"]:hover > .ant-table-cell:is(.data-grid-row-number-cell, .ant-table-selection-column)';
+    const headerSelector = '.active-cell-grid.data-grid-root .ant-table-header .ant-table-thead > tr > th.ant-table-cell[data-active-cell-column="true"]';
+
+    [rowSelector, columnSelector, fixedControlHoverSelector, headerSelector].forEach((selector) => {
+      expect(css).toContain(selector);
+    });
+    const fixedControlHoverRuleStart = css.indexOf(fixedControlHoverSelector);
+    const fixedControlHoverRuleEnd = css.indexOf('}', fixedControlHoverRuleStart);
+    const fixedControlHoverRule = css.slice(fixedControlHoverRuleStart, fixedControlHoverRuleEnd + 1);
+    expect(fixedControlHoverRule).toContain('background-color: var(--gn-bg-panel, #ffffff) !important;');
+    expect(fixedControlHoverRule).toContain('background-image: linear-gradient(');
+    expect(fixedControlHoverRule).toContain(
+      'var(--gn-bg-hover, rgba(15, 23, 42, 0.045))',
+    );
+    expect(css).toContain('var(--gn-bg-hover, rgba(15, 23, 42, 0.045))');
+    expect(css).toContain('var(--gn-bg-active, rgba(15, 23, 42, 0.075))');
+    expect(css.indexOf('[data-cell-selected="true"]')).toBeGreaterThan(css.indexOf(rowSelector));
+
+    const darkCss = buildDataGridCssText({
+      darkMode: true,
+      densityParams: { dataFontSize: 12 },
+      gridId: 'active-cell-dark-grid',
+      bgContent: '#161a21',
+    });
+    expect(darkCss).toContain('var(--gn-bg-hover, rgba(255, 255, 255, 0.05))');
+    expect(darkCss).toContain('var(--gn-bg-active, rgba(255, 255, 255, 0.08))');
+
+    const source = readDataGridSource();
+    expect(source).toContain("'data-col-name': key");
+    expect(source).toContain('syncDataGridCellSelectionVisuals({');
   });
 
   it('uses the table cell as the only V2 inline edit frame', () => {

--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -191,6 +191,7 @@ import { useDataGridPreviewPanel } from './useDataGridPreviewPanel';
 import { buildTableExportTab } from '../utils/tableExportTab';
 import { createSidebarResizeAwareFrameScheduler } from '../utils/sidebarResizeLifecycle';
 import { buildDataGridCssText } from './dataGridStyles';
+import { syncDataGridCellSelectionVisuals } from './dataGridCellHighlight';
 import { formatMongoEditableValue, normalizeMongoDocumentForEditing, parseMongoEditedValue } from '../utils/mongodb';
 
 // --- Error Boundary ---
@@ -1962,24 +1963,19 @@ const DataGrid: React.FC<DataGridProps> = ({
     return map;
   }, [displayColumnNames]);
 
-  // 直接操作 DOM 更新选中效果，避免 React 重渲染
+  // 直接操作 DOM 同步单元格选区与活动行列，避免拖选时触发 React 重渲染。
   const updateCellSelection = useCallback((newSelection: Set<string>) => {
     const container = containerRef.current;
     if (!container) return;
 
-    // 只同步可见单元格，严格限定 `.ant-table-cell`，避免虚拟列表中内嵌的 EditableCell 被重复获取并打上 selected 样式从而产生白边。
-    const visibleCells = container.querySelectorAll('.ant-table-cell[data-row-key][data-col-name]');
-    visibleCells.forEach((cell) => {
-      const el = cell as HTMLElement;
-      const rowKey = el.getAttribute('data-row-key');
-      const colName = el.getAttribute('data-col-name');
-      if (!rowKey || !colName) return;
-      const key = makeCellKey(rowKey, colName);
-      if (newSelection.has(key)) {
-        if (el.getAttribute('data-cell-selected') !== 'true') el.setAttribute('data-cell-selected', 'true');
-      } else {
-        if (el.hasAttribute('data-cell-selected')) el.removeAttribute('data-cell-selected');
-      }
+    const selectionStart = selectionStartRef.current;
+    syncDataGridCellSelectionVisuals({
+      container,
+      selectedCells: newSelection,
+      activeCell: selectionStart
+        ? { rowKey: selectionStart.rowKey, colName: selectionStart.colName }
+        : null,
+      makeCellKey,
     });
   }, []);
 
@@ -3114,6 +3110,7 @@ const DataGrid: React.FC<DataGridProps> = ({
           },
           onHeaderCell: (column: any) => ({
               id: key,
+              'data-col-name': key,
               columnOrderDragScope: columnOrderDragScopeRef.current,
               width: column.width,
               className: `gonavi-sortable-header-cell${showColumnComment || showColumnType ? '' : ' is-single-line-title'}`,

--- a/frontend/src/components/dataGridCellHighlight.test.ts
+++ b/frontend/src/components/dataGridCellHighlight.test.ts
@@ -1,0 +1,95 @@
+import { expect, it } from 'vitest';
+
+import { syncDataGridCellSelectionVisuals } from './dataGridCellHighlight';
+
+const CELL_KEY_SEPARATOR = '\u0001';
+const makeCellKey = (rowKey: string, colName: string) => `${rowKey}${CELL_KEY_SEPARATOR}${colName}`;
+
+class TestElement {
+  private attributes = new Map<string, string>();
+  row: TestElement | null = null;
+
+  constructor(attributes: Record<string, string> = {}) {
+    Object.entries(attributes).forEach(([name, value]) => this.attributes.set(name, value));
+  }
+
+  getAttribute(name: string) {
+    return this.attributes.get(name) ?? null;
+  }
+
+  setAttribute(name: string, value: string) {
+    this.attributes.set(name, value);
+  }
+
+  hasAttribute(name: string) {
+    return this.attributes.has(name);
+  }
+
+  removeAttribute(name: string) {
+    this.attributes.delete(name);
+  }
+
+  closest(selector: string) {
+    return selector === '.ant-table-row' ? this.row : null;
+  }
+}
+
+it('syncs the active row, column, header and cell without changing the selection set', () => {
+  const idHeader = new TestElement({ 'data-col-name': 'id' });
+  const nameHeader = new TestElement({ 'data-col-name': 'name' });
+  const firstRow = new TestElement();
+  const secondRow = new TestElement();
+  const firstIdCell = new TestElement({ 'data-row-key': 'row-1', 'data-col-name': 'id' });
+  const firstNameCell = new TestElement({ 'data-row-key': 'row-1', 'data-col-name': 'name' });
+  const secondIdCell = new TestElement({ 'data-row-key': 'row-2', 'data-col-name': 'id' });
+  const secondNameCell = new TestElement({ 'data-row-key': 'row-2', 'data-col-name': 'name' });
+  firstIdCell.row = firstRow;
+  firstNameCell.row = firstRow;
+  secondIdCell.row = secondRow;
+  secondNameCell.row = secondRow;
+
+  const bodyCells = [firstIdCell, firstNameCell, secondIdCell, secondNameCell];
+  const rows = [firstRow, secondRow];
+  const headers = [idHeader, nameHeader];
+  const container = {
+    querySelectorAll: (selector: string) => {
+      if (selector === '.ant-table-row[data-active-cell-row="true"]') {
+        return rows.filter((row) => row.getAttribute('data-active-cell-row') === 'true');
+      }
+      if (selector === '.ant-table-thead .ant-table-cell[data-col-name]') return headers;
+      if (selector === '.ant-table-cell[data-row-key][data-col-name]') return bodyCells;
+      return [];
+    },
+  } as unknown as HTMLElement;
+  const selection = new Set([makeCellKey('row-2', 'id')]);
+
+  syncDataGridCellSelectionVisuals({
+    container,
+    selectedCells: selection,
+    activeCell: { rowKey: 'row-2', colName: 'id' },
+    makeCellKey,
+  });
+
+  expect(selection).toEqual(new Set([makeCellKey('row-2', 'id')]));
+  expect(secondRow.getAttribute('data-active-cell-row')).toBe('true');
+  expect(firstRow.getAttribute('data-active-cell-row')).toBeNull();
+  expect(idHeader.getAttribute('data-active-cell-column')).toBe('true');
+  expect(nameHeader.getAttribute('data-active-cell-column')).toBeNull();
+  expect(firstIdCell.getAttribute('data-active-cell-column')).toBe('true');
+  expect(secondIdCell.getAttribute('data-active-cell')).toBe('true');
+  expect(secondIdCell.getAttribute('data-cell-selected')).toBe('true');
+  expect(secondNameCell.getAttribute('data-active-cell-column')).toBeNull();
+
+  syncDataGridCellSelectionVisuals({
+    container,
+    selectedCells: new Set(),
+    activeCell: null,
+    makeCellKey,
+  });
+
+  expect(secondRow.getAttribute('data-active-cell-row')).toBeNull();
+  expect(idHeader.getAttribute('data-active-cell-column')).toBeNull();
+  expect(firstIdCell.getAttribute('data-active-cell-column')).toBeNull();
+  expect(secondIdCell.getAttribute('data-active-cell')).toBeNull();
+  expect(secondIdCell.getAttribute('data-cell-selected')).toBeNull();
+});

--- a/frontend/src/components/dataGridCellHighlight.ts
+++ b/frontend/src/components/dataGridCellHighlight.ts
@@ -1,0 +1,71 @@
+export interface DataGridActiveCell {
+  rowKey: string;
+  colName: string;
+}
+
+interface SyncDataGridCellSelectionVisualsParams {
+  container: HTMLElement;
+  selectedCells: Set<string>;
+  activeCell: DataGridActiveCell | null;
+  makeCellKey: (rowKey: string, colName: string) => string;
+}
+
+const syncBooleanDataAttribute = (
+  element: HTMLElement,
+  name: string,
+  enabled: boolean,
+) => {
+  if (enabled) {
+    if (element.getAttribute(name) !== 'true') element.setAttribute(name, 'true');
+    return;
+  }
+  if (element.hasAttribute(name)) element.removeAttribute(name);
+};
+
+export const syncDataGridCellSelectionVisuals = ({
+  container,
+  selectedCells,
+  activeCell,
+  makeCellKey,
+}: SyncDataGridCellSelectionVisualsParams) => {
+  const activeCellKey = activeCell
+    ? makeCellKey(activeCell.rowKey, activeCell.colName)
+    : null;
+  const hasActiveCell = !!activeCellKey && selectedCells.has(activeCellKey);
+
+  container
+    .querySelectorAll<HTMLElement>('.ant-table-row[data-active-cell-row="true"]')
+    .forEach((row) => row.removeAttribute('data-active-cell-row'));
+
+  container
+    .querySelectorAll<HTMLElement>('.ant-table-thead .ant-table-cell[data-col-name]')
+    .forEach((headerCell) => {
+      syncBooleanDataAttribute(
+        headerCell,
+        'data-active-cell-column',
+        hasActiveCell && headerCell.getAttribute('data-col-name') === activeCell?.colName,
+      );
+    });
+
+  container
+    .querySelectorAll<HTMLElement>('.ant-table-cell[data-row-key][data-col-name]')
+    .forEach((cell) => {
+      const rowKey = cell.getAttribute('data-row-key');
+      const colName = cell.getAttribute('data-col-name');
+      if (!rowKey || !colName) return;
+
+      const cellKey = makeCellKey(rowKey, colName);
+      const isActiveRow = hasActiveCell && rowKey === activeCell?.rowKey;
+      const isActiveColumn = hasActiveCell && colName === activeCell?.colName;
+      const isActiveCell = isActiveRow && isActiveColumn;
+
+      syncBooleanDataAttribute(cell, 'data-cell-selected', selectedCells.has(cellKey));
+      syncBooleanDataAttribute(cell, 'data-active-cell-column', isActiveColumn);
+      syncBooleanDataAttribute(cell, 'data-active-cell', isActiveCell);
+
+      if (isActiveRow) {
+        const row = cell.closest<HTMLElement>('.ant-table-row');
+        if (row) syncBooleanDataAttribute(row, 'data-active-cell-row', true);
+      }
+    });
+};

--- a/frontend/src/components/dataGridStyles.ts
+++ b/frontend/src/components/dataGridStyles.ts
@@ -435,6 +435,42 @@ export const buildDataGridCssText = ({
                     background-image: none !important;
                 }
 
+                /* 当前单元格行列交叉高亮：仅增加中性半透明蒙层，不改变行勾选或单元格选区语义。 */
+                .${gridId}.data-grid-root .ant-table-tbody-virtual-holder .ant-table-row[data-active-cell-row="true"] > .ant-table-cell,
+                .${gridId}.data-grid-root .ant-table-tbody-virtual .ant-table-row[data-active-cell-row="true"] > .ant-table-cell,
+                .${gridId}.data-grid-root .ant-table-tbody-virtual-holder-inner .ant-table-row[data-active-cell-row="true"] > .ant-table-cell,
+                .${gridId}.data-grid-root .ant-table-tbody > tr[data-active-cell-row="true"] > td.ant-table-cell,
+                .${gridId}.data-grid-root .ant-table-tbody-virtual-holder .ant-table-row > .ant-table-cell[data-active-cell-column="true"],
+                .${gridId}.data-grid-root .ant-table-tbody-virtual .ant-table-row > .ant-table-cell[data-active-cell-column="true"],
+                .${gridId}.data-grid-root .ant-table-tbody-virtual-holder-inner .ant-table-row > .ant-table-cell[data-active-cell-column="true"],
+                .${gridId}.data-grid-root .ant-table-tbody > tr > td.ant-table-cell[data-active-cell-column="true"] {
+                    background-image: linear-gradient(
+                        var(--gn-bg-hover, ${darkMode ? 'rgba(255, 255, 255, 0.05)' : 'rgba(15, 23, 42, 0.045)'}),
+                        var(--gn-bg-hover, ${darkMode ? 'rgba(255, 255, 255, 0.05)' : 'rgba(15, 23, 42, 0.045)'})
+                    ) !important;
+                }
+
+                /* 固定的勾选框/序号列在活动行 hover 时继续保留十字高亮蒙层。 */
+                .${gridId}.data-grid-root .ant-table-tbody-virtual-holder .ant-table-row[data-active-cell-row="true"]:hover > .ant-table-cell:is(.data-grid-row-number-cell, .ant-table-selection-column),
+                .${gridId}.data-grid-root .ant-table-tbody-virtual .ant-table-row[data-active-cell-row="true"]:hover > .ant-table-cell:is(.data-grid-row-number-cell, .ant-table-selection-column),
+                .${gridId}.data-grid-root .ant-table-tbody-virtual-holder-inner .ant-table-row[data-active-cell-row="true"]:hover > .ant-table-cell:is(.data-grid-row-number-cell, .ant-table-selection-column),
+                .${gridId}.data-grid-root .ant-table-tbody > tr[data-active-cell-row="true"]:hover > td:is(.data-grid-row-number-cell, .ant-table-selection-column) {
+                    background-color: var(--gn-bg-panel, ${bgContent}) !important;
+                    background-image: linear-gradient(
+                        var(--gn-bg-hover, ${darkMode ? 'rgba(255, 255, 255, 0.05)' : 'rgba(15, 23, 42, 0.045)'}),
+                        var(--gn-bg-hover, ${darkMode ? 'rgba(255, 255, 255, 0.05)' : 'rgba(15, 23, 42, 0.045)'})
+                    ) !important;
+                }
+
+                .${gridId}.data-grid-root .ant-table-header .ant-table-thead > tr > th.ant-table-cell[data-active-cell-column="true"],
+                .${gridId}.data-grid-root .ant-table-thead > tr > th.ant-table-cell[data-active-cell-column="true"] {
+                    background-color: var(--gn-bg-panel, ${bgContent}) !important;
+                    background-image: linear-gradient(
+                        var(--gn-bg-active, ${darkMode ? 'rgba(255, 255, 255, 0.08)' : 'rgba(15, 23, 42, 0.075)'}),
+                        var(--gn-bg-active, ${darkMode ? 'rgba(255, 255, 255, 0.08)' : 'rgba(15, 23, 42, 0.075)'})
+                    ) !important;
+                }
+
                 /*
                  * 行选中：整行统一绿色。
                  * 关键：virtual-holder 下有

--- a/frontend/src/components/useDataGridBatchActions.test.tsx
+++ b/frontend/src/components/useDataGridBatchActions.test.tsx
@@ -90,6 +90,7 @@ describe('useDataGridBatchActions clipboard paste', () => {
       ...containerTarget,
       contains: vi.fn(() => true),
       querySelector: vi.fn(() => null),
+      querySelectorAll: vi.fn(() => []),
     };
     const rows = [
       { key: 'row-1', id: '1', generated: 'A', name: 'alpha' },
@@ -433,5 +434,37 @@ describe('useDataGridBatchActions clipboard paste', () => {
     expect(hook.setSelectedCells).toHaveBeenCalledWith(new Set([makeCellKey('row-1', 'id')]));
     expect(hook.ctx.markCellSelectionDeleteEligible).toHaveBeenCalledWith(false);
     expect(hook.updateCellSelection).toHaveBeenCalledWith(new Set([makeCellKey('row-1', 'id')]));
+  });
+
+  it('moves a single active cell with arrow keys without changing row-selection semantics', () => {
+    const selectedCells = new Set([makeCellKey('row-1', 'id')]);
+    const hook = renderHook({ selectedCells });
+    hook.selectionStartRef.current = { rowKey: 'row-1', colName: 'id', rowIndex: 0, colIndex: 0 };
+    const preventDefault = vi.fn();
+
+    act(() => {
+      (windowTarget.listeners.get('keydown') as any)?.({
+        key: 'ArrowRight',
+        defaultPrevented: false,
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+        target: null,
+        preventDefault,
+      });
+    });
+
+    const expectedSelection = new Set([makeCellKey('row-1', 'name')]);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(hook.selectionStartRef.current).toEqual({
+      rowKey: 'row-1',
+      colName: 'name',
+      rowIndex: 0,
+      colIndex: 2,
+    });
+    expect(hook.setSelectedCells).toHaveBeenCalledWith(expectedSelection);
+    expect(hook.ctx.markCellSelectionDeleteEligible).toHaveBeenCalledWith(false);
+    expect(hook.updateCellSelection).toHaveBeenCalledWith(expectedSelection);
   });
 });

--- a/frontend/src/components/useDataGridBatchActions.ts
+++ b/frontend/src/components/useDataGridBatchActions.ts
@@ -431,6 +431,75 @@ const handleBatchFillCells = useCallback(() => {
       updateCellSelection(nextSelection);
     };
 
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+      if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key)) return;
+
+      const activeElement = document.activeElement as HTMLElement | null;
+      const eventTarget = event.target instanceof HTMLElement ? event.target : null;
+      if (isInteractiveTarget(activeElement) || isInteractiveTarget(eventTarget)) return;
+
+      const activeSelection = currentSelectionRef.current.size > 0
+        ? currentSelectionRef.current
+        : selectedCells;
+      const start = selectionStartRef.current;
+      if (!start || activeSelection.size !== 1) return;
+
+      const currentData = displayDataRef.current;
+      const currentRowIndex = currentData.findIndex((row) => (
+        rowKeyStr(row?.[GONAVI_ROW_KEY]) === start.rowKey
+      ));
+      const currentColumnIndex = columnIndexMap.get(start.colName) ?? -1;
+      if (currentRowIndex === -1 || currentColumnIndex === -1) return;
+
+      let nextRowIndex = currentRowIndex;
+      let nextColumnIndex = currentColumnIndex;
+      if (event.key === 'ArrowUp') nextRowIndex -= 1;
+      if (event.key === 'ArrowDown') nextRowIndex += 1;
+      if (event.key === 'ArrowLeft') nextColumnIndex -= 1;
+      if (event.key === 'ArrowRight') nextColumnIndex += 1;
+
+      if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+        const columnStep = event.key === 'ArrowLeft' ? -1 : 1;
+        while (nextColumnIndex >= 0 && nextColumnIndex < displayColumnNames.length) {
+          const candidateColumn = displayColumnNames[nextColumnIndex];
+          if (canSelectGridCellForClipboard({
+            canModifyData,
+            isDisplayedColumn: true,
+            isWritableColumn: isWritableResultColumn(candidateColumn, effectiveEditLocator),
+          })) break;
+          nextColumnIndex += columnStep;
+        }
+      }
+
+      if (
+        nextRowIndex < 0
+        || nextRowIndex >= currentData.length
+        || nextColumnIndex < 0
+        || nextColumnIndex >= displayColumnNames.length
+      ) {
+        event.preventDefault();
+        return;
+      }
+
+      const nextRow = currentData[nextRowIndex];
+      const nextRowKey = nextRow?.[GONAVI_ROW_KEY];
+      const nextColumnName = displayColumnNames[nextColumnIndex];
+      if (nextRowKey === undefined || nextRowKey === null || !nextColumnName) return;
+
+      event.preventDefault();
+      const nextCellInfo = { rowKey: rowKeyStr(nextRowKey), colName: nextColumnName };
+      selectSingleCell(nextCellInfo);
+
+      const visibleCell = Array.from(
+        container.querySelectorAll<HTMLElement>('.ant-table-cell[data-row-key][data-col-name]'),
+      ).find((cell) => (
+        cell.getAttribute('data-row-key') === nextCellInfo.rowKey
+        && cell.getAttribute('data-col-name') === nextCellInfo.colName
+      ));
+      visibleCell?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
+    };
+
     const onMouseDown = (e: MouseEvent) => {
       if (e.button !== 0) return;
       const target = e.target instanceof HTMLElement ? e.target : null;
@@ -616,6 +685,7 @@ const handleBatchFillCells = useCallback(() => {
     container.addEventListener('click', onClickCapture, true);
     container.addEventListener('scroll', onScroll, true);
     document.addEventListener('mouseup', onMouseUp);
+    window.addEventListener('keydown', onKeyDown);
     window.addEventListener('paste', onPaste);
 
     return () => {
@@ -624,6 +694,7 @@ const handleBatchFillCells = useCallback(() => {
       container.removeEventListener('click', onClickCapture, true);
       container.removeEventListener('scroll', onScroll, true);
       document.removeEventListener('mouseup', onMouseUp);
+      window.removeEventListener('keydown', onKeyDown);
       window.removeEventListener('paste', onPaste);
       if (cellSelectionRafRef.current !== null) {
         cancelAnimationFrame(cellSelectionRafRef.current);
@@ -638,7 +709,7 @@ const handleBatchFillCells = useCallback(() => {
       cellSelectionPointerRef.current = null;
       isDraggingRef.current = false;
     };
-  }, [addedRows, canModifyData, deletedRowKeys, isActive, isTableSurfaceActive, displayColumnNames, columnIndexMap, effectiveEditLocator, isCellValueEqualForDiff, isWritableResultColumn, markCellSelectionDeleteEligible, modifiedRows, rowKeyStr, setAddedRows, setModifiedColumns, setModifiedRows, setSelectedCells, splitCellKey, translateDataGrid, updateCellSelection]);
+  }, [addedRows, canModifyData, deletedRowKeys, isActive, isTableSurfaceActive, displayColumnNames, columnIndexMap, effectiveEditLocator, isCellValueEqualForDiff, isWritableResultColumn, markCellSelectionDeleteEligible, modifiedRows, rowKeyStr, selectedCells, setAddedRows, setModifiedColumns, setModifiedRows, setSelectedCells, splitCellKey, translateDataGrid, updateCellSelection]);
 
   const handleCopySelectedColumnsFromRow = useCallback(() => {
     const activeSelection = currentSelectionRef.current.size > 0 ? currentSelectionRef.current : selectedCells;


### PR DESCRIPTION
- 为活动行、活动列和列标题增加主题自适应高亮
- 支持方向键移动活动单元格并保持复制编辑语义不变
- 修复固定序号和勾选列在行悬停时丢失高亮的问题
- 补充交叉高亮与键盘导航回归测试