### PR TITLE
🐛 fix(connection): Nacos/JVM 连接不再被标记为支持 SQL 查询

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -102,7 +102,7 @@ import {
 import { downloadBrowserTextFile } from './utils/browserFileTransfer';
 import { buildDataSyncWorkbenchTab } from './utils/dataSyncTab';
 import { buildSqlAuditWorkbenchTab } from './utils/sqlAuditTab';
-import { resolveDataSourceType } from './utils/dataSourceCapabilities';
+import { getDataSourceCapabilities, resolveDataSourceType } from './utils/dataSourceCapabilities';
 import { buildContextualNewQueryTemplate } from './utils/objectQueryTemplates';
 import {
   extractCustomThemeAntTokens,
@@ -2749,10 +2749,17 @@ function App() {
 
   const handleNewQuery = useCallback(() => {
       const currentTab = activeTabId ? tabs.find(tab => tab.id === activeTabId) : undefined;
+      // 只继承支持查询编辑器的活动连接；Nacos/JVM 等工作台活动时不预选连接，
+      // 避免新建查询落入必然失败的 SQL 工作流。
+      const validConnectionIds = new Set(
+          connections
+              .filter(connection => getDataSourceCapabilities(connection.config).supportsQueryEditor)
+              .map(connection => connection.id),
+      );
       const targetContext = resolveNewQueryContext({
           sidebarContext: activeContext,
           activeTab: currentTab,
-          validConnectionIds: new Set(connections.map(connection => connection.id)),
+          validConnectionIds,
       });
       const connection = connections.find(c => c.id === targetContext.connectionId);
       const inheritsTableContext = canInheritNewQueryTableContext({

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -148,7 +148,7 @@ import FindInDatabaseModal from './FindInDatabaseModal';
 import { buildRpcConnectionConfig } from '../utils/connectionRpcConfig';
 import { buildSqlAnalysisWorkbenchTab } from '../utils/sqlAnalysisTab';
 import { buildSqlAuditWorkbenchTab } from '../utils/sqlAuditTab';
-import { resolveDataSourceType } from '../utils/dataSourceCapabilities';
+import { getDataSourceCapabilities, resolveDataSourceType } from '../utils/dataSourceCapabilities';
 import { isConnectionStructureEditRestricted } from '../utils/connectionReadOnly';
 import { noAutoCapInputProps } from '../utils/inputAutoCap';
 import {
@@ -868,6 +868,14 @@ const Sidebar: React.FC<{
   const connectionReloadSignaturesRef = useRef<Record<string, string>>({});
   expandedKeysRef.current = expandedKeys;
   const connectionIds = useMemo(() => connections.map((conn) => conn.id), [connections]);
+  const queryCapableConnectionIds = useMemo(
+      () => new Set(
+          connections
+              .filter((conn) => getDataSourceCapabilities(conn.config).supportsQueryEditor)
+              .map((conn) => conn.id),
+      ),
+      [connections],
+  );
   const connectionIdSet = useMemo(() => new Set(connectionIds), [connectionIds]);
   const unmatchedSavedQueries = useMemo(
       () => savedQueries.filter((query) => isSavedQueryUnmatchedForConnectionIds(query, connectionIdSet)),
@@ -3081,6 +3089,7 @@ const Sidebar: React.FC<{
       closeV2CommandSearch,
       commandSearchFlatItems,
       connectionIds,
+      queryCapableConnectionIds,
       findTreeNodeByKeyRef,
       locateObjectInSidebar,
       loadDatabases,

--- a/frontend/src/components/V2TableContextMenu.query-gating.test.tsx
+++ b/frontend/src/components/V2TableContextMenu.query-gating.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { V2ConnectionContextMenuView } from './V2TableContextMenu';
+import { t } from '../i18n';
+
+const renderMenu = (supportsQueryEditor?: boolean): string => renderToStaticMarkup(
+  <V2ConnectionContextMenuView
+    connectionName="dev240"
+    driverLabel="jvm"
+    supportsQueryEditor={supportsQueryEditor}
+  />,
+);
+
+describe('V2ConnectionContextMenuView query entry gating', () => {
+  it('omits new query and run SQL file actions when the connection has no query workflow', () => {
+    const markup = renderMenu(false);
+    expect(markup).not.toContain(t('sidebar.menu.new_query'));
+    expect(markup).not.toContain(t('sidebar.sql_file_exec.title'));
+    expect(markup).toContain(t('connection.sidebar.menu.refresh'));
+    expect(markup).toContain(t('sidebar.menu.edit_connection'));
+  });
+
+  it('keeps new query and run SQL file actions for query-capable connections', () => {
+    const markup = renderMenu(true);
+    expect(markup).toContain(t('sidebar.menu.new_query'));
+    expect(markup).toContain(t('sidebar.sql_file_exec.title'));
+  });
+});

--- a/frontend/src/components/V2TableContextMenu.tsx
+++ b/frontend/src/components/V2TableContextMenu.tsx
@@ -587,6 +587,7 @@ export const V2ConnectionContextMenuView: React.FC<{
   driverLabel?: string;
   isRedis?: boolean;
   supportsCreateDatabase?: boolean;
+  supportsQueryEditor?: boolean;
   tags?: V2ConnectionContextMenuTagItem[];
   onAction?: (action: V2ConnectionContextMenuActionKey) => void;
 }> = ({
@@ -596,6 +597,7 @@ export const V2ConnectionContextMenuView: React.FC<{
   driverLabel,
   isRedis = false,
   supportsCreateDatabase = true,
+  supportsQueryEditor = true,
   tags = [],
   onAction,
 }) => {
@@ -626,8 +628,10 @@ export const V2ConnectionContextMenuView: React.FC<{
         ]) : renderItems([
           ...(supportsCreateDatabase ? [{ action: 'new-db' as const, icon: <DatabaseOutlined />, title: t('connection.sidebar.menu.createDatabase'), kbd: primaryShortcut('N', shortcutPlatform), featured: true }] : []),
           { action: 'refresh', icon: <ReloadOutlined />, title: t('connection.sidebar.menu.refresh'), kbd: primaryShortcut('R', shortcutPlatform) },
-          { action: 'new-query', icon: <ConsoleSqlOutlined />, title: t('sidebar.menu.new_query') },
-          { action: 'open-sql-file', icon: <FileAddOutlined />, title: t('sidebar.sql_file_exec.title') },
+          ...(supportsQueryEditor ? [
+            { action: 'new-query' as const, icon: <ConsoleSqlOutlined />, title: t('sidebar.menu.new_query') },
+            { action: 'open-sql-file' as const, icon: <FileAddOutlined />, title: t('sidebar.sql_file_exec.title') },
+          ] : []),
         ])}
 
         <div className="gn-v2-context-menu-section-title">{t('connection.sidebar.menu.section')}</div>

--- a/frontend/src/components/sidebar/sidebarLegacyNodeMenu.query-capability.test.tsx
+++ b/frontend/src/components/sidebar/sidebarLegacyNodeMenu.query-capability.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { buildSidebarLegacyNodeMenuItems } from './sidebarLegacyNodeMenu';
+
+const buildConnectionRootItems = (connection: any) =>
+  buildSidebarLegacyNodeMenuItems({
+    key: connection.id,
+    type: 'connection',
+    dataRef: connection,
+  }, {
+    addTab: vi.fn(),
+    loadDatabases: vi.fn(),
+    handleRunSQLFile: vi.fn(),
+    buildConnectionRootQueryTabTitle: vi.fn(() => 'query'),
+    connectionTags: [],
+  }) as any[];
+
+const itemKeys = (items: any[]) => items.map((item) => item?.key);
+
+describe('connection root menu query entry gating', () => {
+  it('hides new query and run SQL file for JVM connections', () => {
+    const items = buildConnectionRootItems({
+      id: 'jvm-1',
+      name: 'JVM workbench',
+      config: { type: 'jvm', host: '127.0.0.1', port: 8080 },
+    });
+    expect(itemKeys(items)).not.toContain('new-query');
+    expect(itemKeys(items)).not.toContain('open-sql-file');
+  });
+
+  it('keeps new query and run SQL file for SQL connections', () => {
+    const items = buildConnectionRootItems({
+      id: 'mysql-1',
+      name: 'MySQL dev',
+      config: { type: 'mysql', host: '127.0.0.1', port: 3306 },
+    });
+    expect(itemKeys(items)).toContain('new-query');
+    expect(itemKeys(items)).toContain('open-sql-file');
+  });
+
+  it('keeps new query for currently queryable messaging and vector connections', () => {
+    [
+      { type: 'mqtt', host: '127.0.0.1', port: 1883 },
+      { type: 'rocketmq', host: '127.0.0.1', port: 9876 },
+      { type: 'chroma', host: '127.0.0.1', port: 8000 },
+      { type: 'elasticsearch', host: '127.0.0.1', port: 9200 },
+      { type: 'mongodb', host: '127.0.0.1', port: 27017 },
+    ].forEach((config, index) => {
+      const items = buildConnectionRootItems({
+        id: `query-capable-${index}`,
+        name: `query capable ${index}`,
+        config,
+      });
+      expect(itemKeys(items), JSON.stringify(config)).toContain('new-query');
+      expect(itemKeys(items), JSON.stringify(config)).toContain('open-sql-file');
+    });
+  });
+});

--- a/frontend/src/components/sidebar/sidebarLegacyNodeMenu.tsx
+++ b/frontend/src/components/sidebar/sidebarLegacyNodeMenu.tsx
@@ -791,27 +791,29 @@ export const buildSidebarLegacyNodeMenuItems = (
                 }
             },
             { type: 'divider' },
-             {
-               key: 'new-query',
-               label: t('sidebar.menu.new_query'),
-               icon: <ConsoleSqlOutlined />,
-               onClick: () => {
-                   addTab({
-                       id: `query-${Date.now()}`,
-                       title: buildConnectionRootQueryTabTitle(),
-                       type: 'query',
-                       connectionId: node.key,
-                       dbName: undefined,
-                       query: ''
-                   });
-               }
-             },
-             {
-                 key: 'open-sql-file',
-                 label: t('sidebar.sql_file_exec.title'),
-                 icon: <FileAddOutlined />,
-                 onClick: () => handleRunSQLFile(node)
-             },
+             ...(connectionCapabilities.supportsQueryEditor ? [
+                 {
+                   key: 'new-query',
+                   label: t('sidebar.menu.new_query'),
+                   icon: <ConsoleSqlOutlined />,
+                   onClick: () => {
+                       addTab({
+                           id: `query-${Date.now()}`,
+                           title: buildConnectionRootQueryTabTitle(),
+                           type: 'query',
+                           connectionId: node.key,
+                           dbName: undefined,
+                           query: ''
+                       });
+                   }
+                 },
+                 {
+                     key: 'open-sql-file',
+                     label: t('sidebar.sql_file_exec.title'),
+                     icon: <FileAddOutlined />,
+                     onClick: () => handleRunSQLFile(node)
+                 },
+             ] : []),
              { type: 'divider' },
              {
                  key: 'edit',

--- a/frontend/src/components/sidebar/useSidebarCommandSearchRunner.recent-query.test.ts
+++ b/frontend/src/components/sidebar/useSidebarCommandSearchRunner.recent-query.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveRecentQueryConnectionId } from './useSidebarCommandSearchRunner';
+
+const QUERY_CAPABLE = new Set(['mysql-1', 'mqtt-1']);
+
+describe('resolveRecentQueryConnectionId', () => {
+  it('does not inherit a Nacos/JVM active context or tab when opening recent SQL', () => {
+    expect(resolveRecentQueryConnectionId({
+      activeContextConnectionId: 'nacos-1',
+      activeTabConnectionId: 'nacos-1',
+      queryCapableConnectionIds: QUERY_CAPABLE,
+    })).toBe('');
+    expect(resolveRecentQueryConnectionId({
+      activeContextConnectionId: 'jvm-1',
+      queryCapableConnectionIds: QUERY_CAPABLE,
+    })).toBe('');
+  });
+
+  it('prefers the recent SQL item connection, then the active context, then the active tab', () => {
+    expect(resolveRecentQueryConnectionId({
+      itemConnectionId: 'mysql-1',
+      activeContextConnectionId: 'mqtt-1',
+      queryCapableConnectionIds: QUERY_CAPABLE,
+    })).toBe('mysql-1');
+    expect(resolveRecentQueryConnectionId({
+      activeContextConnectionId: 'mqtt-1',
+      activeTabConnectionId: 'mysql-1',
+      queryCapableConnectionIds: QUERY_CAPABLE,
+    })).toBe('mqtt-1');
+    expect(resolveRecentQueryConnectionId({
+      activeTabConnectionId: 'mysql-1',
+      queryCapableConnectionIds: QUERY_CAPABLE,
+    })).toBe('mysql-1');
+  });
+
+  it('skips unsupported candidates in the priority chain and keeps the first supported one', () => {
+    expect(resolveRecentQueryConnectionId({
+      itemConnectionId: 'nacos-1',
+      activeContextConnectionId: 'mysql-1',
+      activeTabConnectionId: 'mqtt-1',
+      queryCapableConnectionIds: QUERY_CAPABLE,
+    })).toBe('mysql-1');
+    expect(resolveRecentQueryConnectionId({
+      itemConnectionId: 'nacos-1',
+      activeContextConnectionId: 'jvm-1',
+      activeTabConnectionId: 'mqtt-1',
+      queryCapableConnectionIds: QUERY_CAPABLE,
+    })).toBe('mqtt-1');
+  });
+
+  it('returns an empty connection id when every candidate is unsupported or missing', () => {
+    expect(resolveRecentQueryConnectionId({
+      itemConnectionId: 'nacos-1',
+      activeContextConnectionId: '',
+      activeTabConnectionId: 'redis-1',
+      queryCapableConnectionIds: QUERY_CAPABLE,
+    })).toBe('');
+    expect(resolveRecentQueryConnectionId({
+      queryCapableConnectionIds: QUERY_CAPABLE,
+    })).toBe('');
+  });
+});

--- a/frontend/src/components/sidebar/useSidebarCommandSearchRunner.ts
+++ b/frontend/src/components/sidebar/useSidebarCommandSearchRunner.ts
@@ -11,6 +11,7 @@ type UseSidebarCommandSearchRunnerArgs = {
   closeV2CommandSearch: () => void;
   commandSearchFlatItems: V2CommandSearchItem[];
   connectionIds: string[];
+  queryCapableConnectionIds: ReadonlySet<string>;
   findTreeNodeByKeyRef: MutableRefObject<(nodes: TreeNode[], targetKey: React.Key) => TreeNode | null>;
   locateObjectInSidebar: (detail: unknown) => Promise<void>;
   loadDatabases: (node: any) => Promise<void>;
@@ -25,6 +26,27 @@ type UseSidebarCommandSearchRunnerArgs = {
   v2CommandActiveIndex: number;
 };
 
+// 按优先级从最近 SQL 的候选连接中选出第一个支持查询编辑器的连接，
+// 避免把最近 SQL 绑定到 Nacos/JVM 等无查询工作流的活动连接。
+export const resolveRecentQueryConnectionId = ({
+  itemConnectionId,
+  activeContextConnectionId,
+  activeTabConnectionId,
+  queryCapableConnectionIds,
+}: {
+  itemConnectionId?: unknown;
+  activeContextConnectionId?: unknown;
+  activeTabConnectionId?: unknown;
+  queryCapableConnectionIds: ReadonlySet<string>;
+}): string => {
+  const candidate = [
+    itemConnectionId,
+    activeContextConnectionId,
+    activeTabConnectionId,
+  ].find((id): id is string => typeof id === 'string' && id !== '' && queryCapableConnectionIds.has(id));
+  return candidate || '';
+};
+
 export const useSidebarCommandSearchRunner = ({
   activeContext,
   activeTab,
@@ -32,6 +54,7 @@ export const useSidebarCommandSearchRunner = ({
   closeV2CommandSearch,
   commandSearchFlatItems,
   connectionIds,
+  queryCapableConnectionIds,
   findTreeNodeByKeyRef,
   locateObjectInSidebar,
   loadDatabases,
@@ -68,11 +91,19 @@ export const useSidebarCommandSearchRunner = ({
       return;
     }
     if (item.kind === 'recent') {
+      // 只继承支持查询编辑器的连接，避免把最近 SQL 绑定到
+      // Nacos/JVM 等无查询工作流的活动连接。
+      const recentConnectionId = resolveRecentQueryConnectionId({
+        itemConnectionId: item.connectionId,
+        activeContextConnectionId: activeContext?.connectionId,
+        activeTabConnectionId: activeTab?.connectionId,
+        queryCapableConnectionIds,
+      });
       addTab({
         id: `query-${Date.now()}`,
         title: t('sidebar.tab.recent_query'),
         type: 'query',
-        connectionId: item.connectionId || activeContext?.connectionId || activeTab?.connectionId || '',
+        connectionId: recentConnectionId,
         dbName: item.dbName || activeContext?.dbName || activeTab?.dbName || '',
         query: item.sql,
       });

--- a/frontend/src/components/sidebar/useSidebarV2ContextMenu.tsx
+++ b/frontend/src/components/sidebar/useSidebarV2ContextMenu.tsx
@@ -419,6 +419,7 @@ export const useSidebarV2ContextMenu = ({
               driverLabel={resolveConnectionIconType(conn)}
               isRedis={conn?.config?.type === 'redis'}
               supportsCreateDatabase={capabilities.supportsCreateDatabase}
+              supportsQueryEditor={capabilities.supportsQueryEditor}
               tags={connectionTags.map((tag) => ({
                   id: tag.id,
                   name: tag.name,

--- a/frontend/src/utils/dataSourceCapabilities.test.ts
+++ b/frontend/src/utils/dataSourceCapabilities.test.ts
@@ -408,6 +408,45 @@ describe('dataSourceCapabilities', () => {
     });
   });
 
+  it('excludes dedicated-workbench datasources without a query workflow from the query editor', () => {
+    expect(getDataSourceCapabilities({ type: 'nacos' }).supportsQueryEditor).toBe(false);
+    expect(getDataSourceCapabilities({ type: 'jvm' }).supportsQueryEditor).toBe(false);
+    expect(getDataSourceCapabilities({ type: 'redis' }).supportsQueryEditor).toBe(false);
+    // 自定义连接驱动指向这些类型时同样排除，避免绕过白名单
+    expect(getDataSourceCapabilities({ type: 'custom', driver: 'nacos' }).supportsQueryEditor).toBe(false);
+    expect(getDataSourceCapabilities({ type: 'custom', driver: 'jvm' }).supportsQueryEditor).toBe(false);
+    expect(getDataSourceCapabilities({ type: 'custom', driver: 'redis' }).supportsQueryEditor).toBe(false);
+  });
+
+  it('keeps the query editor available for all currently queryable datasource families', () => {
+    [
+      { type: 'mysql' },
+      { type: 'postgres' },
+      { type: 'mongodb' },
+      { type: 'clickhouse' },
+      { type: 'sphinx' },
+      { type: 'duckdb' },
+      { type: 'sqlite' },
+      { type: 'dameng' },
+      { type: 'trino' },
+      { type: 'tdengine' },
+      { type: 'iotdb' },
+      { type: 'rocketmq' },
+      { type: 'mqtt' },
+      { type: 'kafka' },
+      { type: 'rabbitmq' },
+      { type: 'elasticsearch' },
+      { type: 'chroma' },
+      { type: 'qdrant' },
+      { type: 'milvus' },
+      { type: 'custom', driver: 'clickhouse' },
+      // 未识别驱动的通用自定义连接仍保留查询入口
+      { type: 'custom', driver: 'some-jdbc-driver' },
+    ].forEach((config) => {
+      expect(getDataSourceCapabilities(config).supportsQueryEditor, JSON.stringify(config)).toBe(true);
+    });
+  });
+
   it('treats RabbitMQ as a queryable messaging datasource with publish support', () => {
     expect(getDataSourceCapabilities({ type: 'rabbitmq' })).toMatchObject({
       type: 'rabbitmq',

--- a/frontend/src/utils/dataSourceCapabilities.ts
+++ b/frontend/src/utils/dataSourceCapabilities.ts
@@ -171,7 +171,53 @@ const COPY_TABLE_TYPES = new Set([
   'postgres',
 ]);
 
-const QUERY_EDITOR_DISABLED_TYPES = new Set(['redis']);
+// 查询编辑器能力使用显式白名单：只有具备真实查询工作流的类型才允许
+// 进入查询编辑器。Nacos/JVM 等只有专用工作台的数据源不在此列，
+// 否则会进入必然失败的 SQL 工作流（后端仅有通用 unsupported 兜底）。
+const QUERY_EDITOR_SUPPORTED_TYPES = new Set([
+  // 关系型 / SQL 方言
+  'mysql',
+  'goldendb',
+  'mariadb',
+  'oceanbase',
+  'diros',
+  'starrocks',
+  'sphinx',
+  'postgres',
+  'kingbase',
+  'highgo',
+  'vastbase',
+  'opengauss',
+  'gaussdb',
+  'sqlserver',
+  'iris',
+  'sqlite',
+  'duckdb',
+  'oracle',
+  'dameng',
+  'trino',
+  // 时序 / 分析
+  'tdengine',
+  'clickhouse',
+  'iotdb',
+  // 消息
+  'rocketmq',
+  'mqtt',
+  'kafka',
+  'rabbitmq',
+  // 文档 / 搜索 / 向量
+  'mongodb',
+  'elasticsearch',
+  'chroma',
+  'qdrant',
+  'milvus',
+  // 通用自定义连接（driver 未识别时仍保留查询入口）
+  'custom',
+]);
+
+// 自定义连接的未知 driver 走兜底：保持原有“默认可查询”行为，
+// 只有已知且无查询工作流的类型（Nacos/JVM/Redis 等专用工作台）始终排除。
+const CUSTOM_CONNECTION_QUERY_DISABLED_TYPES = new Set(['nacos', 'jvm', 'redis']);
 const EXPLAIN_DIAGNOSIS_TYPES = new Set([
   'mysql',
   'goldendb',
@@ -278,7 +324,9 @@ export const getDataSourceCapabilities = (config: ConnectionLike): DataSourceCap
   const structureEditRestricted = isConnectionStructureEditRestricted(config);
   return {
     type,
-    supportsQueryEditor: !QUERY_EDITOR_DISABLED_TYPES.has(type),
+    supportsQueryEditor:
+      QUERY_EDITOR_SUPPORTED_TYPES.has(type)
+      || (customConnection && !CUSTOM_CONNECTION_QUERY_DISABLED_TYPES.has(type)),
     supportsExplainDiagnosis: EXPLAIN_DIAGNOSIS_TYPES.has(type),
     supportsSqlQueryExport: SQL_QUERY_EXPORT_TYPES.has(type),
     supportsCopyInsert: COPY_INSERT_TYPES.has(type),


### PR DESCRIPTION
## 背景与问题

Issue #928：查询能力门控只禁用 Redis，Nacos/JVM 会进入可查询连接列表；旧版侧栏连接根菜单还无条件提供新建查询与运行 SQL 文件，最终只能在通用数据库后端收到 unsupported。

## 变更点

1. 查询编辑器能力由黑名单改为显式白名单（`dataSourceCapabilities.ts`）：Nacos/JVM/Redis 等只有专用工作台的数据源不再标记为可查询；自定义连接未知 driver 保留原有"默认可查询"兜底
2. 旧版与 V2 侧栏连接根菜单按能力隐藏「新建查询」「运行 SQL 文件」
3. 标题栏新建查询与命令搜索「最近 SQL」不再继承无查询能力的活动连接
4. 查询编辑器连接下拉、Tab 连接切换、SQL 文件绑定等入口复用同一能力判定，自动排除 Nacos/JVM

## 影响范围

- 仅前端：`dataSourceCapabilities.ts` 及侧栏菜单、标题栏、命令搜索相关组件
- Nacos/JVM/Redis 连接不再出现任何 SQL 查询入口；其余数据源（SQL/MQ/向量/文档/搜索/时序、自定义连接）行为不变
- 已持久化的错误绑定 Tab 由查询编辑器运行时兜底（自动回退到可查询连接）

## 验证方式

- 新增/扩展单元测试：能力矩阵、新旧连接根菜单门控、最近 SQL 连接过滤（3 个测试文件，共 4 组新用例）
- 前端全量测试 485/486 套件通过（1 个与本改动无关的 Node 24 环境性失败，独立复现于基线代码）
- `tsc --noEmit` 与 `vite build` 通过
- 人工验证：Nacos/JVM 连接的标题栏新建查询、左右键菜单、查询连接下拉、SQL 文件绑定入口均已确认无查询入口；MySQL 等既有入口无回归

Fixes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)