### PR TITLE
🐛 fix(connection-modal): Redis 密码「清除已保存密码」卡片布局错位

### DIFF
--- a/frontend/src/components/connectionModal/ConnectionModalStep2.tsx
+++ b/frontend/src/components/connectionModal/ConnectionModalStep2.tsx
@@ -1511,41 +1511,43 @@ const ConnectionModalStep2: React.FC<ConnectionModalStep2Props> = (props) => {
             )}
 
             {isRedis && (
-              <div className="gn-conn-f-row">
-                {denseLabel(
-                  t("connection.modal.dense.auth"),
-                  t("connection.modal.field.username.label"),
-                )}
-                <div className="gn-conn-f-ctrl gn-conn-f-inline">
-                  <div className="gn-conn-w gn-conn-w-user">
-                    <Form.Item name="user" style={{ marginBottom: 0 }}>
-                      <Input
-                        {...noAutoCapInputProps}
-                        placeholder={t(
-                          "connection.modal.field.username.optional_placeholder",
-                        )}
-                      />
-                    </Form.Item>
-                  </div>
-                  <div className="gn-conn-w gn-conn-w-pass">
-                    <Form.Item name="password" style={{ marginBottom: 0 }}>
-                      <Input.Password
-                        {...noAutoCapInputProps}
-                        visibilityToggle={{
-                          visible: primaryPasswordVisible,
-                          onVisibleChange: handlePrimaryPasswordVisibleChange,
-                        }}
-                        placeholder={getStoredSecretPlaceholder({
-                          hasStoredSecret: initialValues?.hasPrimaryPassword,
-                          emptyPlaceholder: t(
-                            "connection.modal.field.redisPassword.placeholder",
-                          ),
-                          retainedLabel: t(
-                            "connection.modal.field.redisPassword.retained",
-                          ),
-                        })}
-                      />
-                    </Form.Item>
+              <>
+                <div className="gn-conn-f-row">
+                  {denseLabel(
+                    t("connection.modal.dense.auth"),
+                    t("connection.modal.field.username.label"),
+                  )}
+                  <div className="gn-conn-f-ctrl gn-conn-f-inline">
+                    <div className="gn-conn-w gn-conn-w-user">
+                      <Form.Item name="user" style={{ marginBottom: 0 }}>
+                        <Input
+                          {...noAutoCapInputProps}
+                          placeholder={t(
+                            "connection.modal.field.username.optional_placeholder",
+                          )}
+                        />
+                      </Form.Item>
+                    </div>
+                    <div className="gn-conn-w gn-conn-w-pass">
+                      <Form.Item name="password" style={{ marginBottom: 0 }}>
+                        <Input.Password
+                          {...noAutoCapInputProps}
+                          visibilityToggle={{
+                            visible: primaryPasswordVisible,
+                            onVisibleChange: handlePrimaryPasswordVisibleChange,
+                          }}
+                          placeholder={getStoredSecretPlaceholder({
+                            hasStoredSecret: initialValues?.hasPrimaryPassword,
+                            emptyPlaceholder: t(
+                              "connection.modal.field.redisPassword.placeholder",
+                            ),
+                            retainedLabel: t(
+                              "connection.modal.field.redisPassword.retained",
+                            ),
+                          })}
+                        />
+                      </Form.Item>
+                    </div>
                   </div>
                 </div>
                 {initialValues?.hasPrimaryPassword
@@ -1561,7 +1563,7 @@ const ConnectionModalStep2: React.FC<ConnectionModalStep2Props> = (props) => {
                       ),
                     })
                   : null}
-              </div>
+              </>
             )}
 
             {isRedis && redisTopology === "sentinel" && (


### PR DESCRIPTION
## 背景与问题

编辑已保存密码的 Redis 连接时，「清除已保存密码」卡片被渲染为 `.gn-conn-f-row` 两列 grid（label 列 + 控制区列）的第三个子元素，自动换行落入窄 label 列，视觉上整块被挤压到最左侧。该问题在 Issue #929 验证期间发现；同类区域（MySQL 副本、Mongo 副本、哨兵密码）均为行外渲染，仅 Redis 密码区放错位置。

## 变更点

- 将 Redis 密码区的「清除已保存密码」卡片移出 grid 行，改为与行同级的 fragment 兄弟节点（与哨兵密码区同款结构），卡片恢复整行宽度

## 影响范围

- 仅前端 `ConnectionModalStep2.tsx` 中 Redis 认证区块的 JSX 结构，无逻辑变更
- 其他数据源的密码清除区不变

## 验证方式

- 前端全量测试通过（唯一失败为本改动无关的 Node 24 环境性既有问题）、`tsc --noEmit` 与 `vite build` 通过
- 人工验证：编辑已保存密码的 Redis 连接，清除密码卡片已正常铺满控制区宽度

🤖 Generated with [Claude Code](https://claude.com/claude-code)