### PR TITLE
🐛 fix(query-editor): 恢复 SQL 补全子串模糊匹配（表名/字段中段片段可提示）

### DIFF
--- a/frontend/src/components/QueryEditor.external-sql-save.test.tsx
+++ b/frontend/src/components/QueryEditor.external-sql-save.test.tsx
@@ -3774,7 +3774,7 @@ describe('QueryEditor external SQL save', () => {
     });
   });
 
-  it('matches table names from the beginning in FROM completion', async () => {
+  it('matches table names by prefix and substring in FROM completion', async () => {
     let renderer!: ReactTestRenderer;
     autoFetchState.visible = true;
     storeState.connections[0].config.database = '';
@@ -3787,6 +3787,7 @@ describe('QueryEditor external SQL save', () => {
         { Tables_in_main: 'hrmresource' },
         { Tables_in_main: 'hrm_resource_export_template' },
         { Tables_in_main: 'archive_hrmresource' },
+        { Tables_in_main: 'table_new_1' },
       ],
     });
     backendApp.DBGetAllColumns.mockResolvedValueOnce({
@@ -3795,6 +3796,7 @@ describe('QueryEditor external SQL save', () => {
         { tableName: 'hrmresource', name: 'hrmresult', type: 'varchar(32)' },
         { tableName: 'users', name: 'hrmresult_from_users', type: 'varchar(32)' },
         { tableName: 'users', name: 'SHORT_TITLE', type: 'varchar(255)' },
+        { tableName: 'users', name: 'emp_code', type: 'varchar(32)' },
       ],
     });
 
@@ -3816,8 +3818,10 @@ describe('QueryEditor external SQL save', () => {
     const labels = result.suggestions.map((item: any) => item.label);
 
     expect(labels).toContain('hrmresource');
+    // 子串匹配（#822/#939）：包含 hrmres 的表名候选保留，且排在精确/前缀命中之后
+    expect(labels).toContain('archive_hrmresource');
+    expect(labels.indexOf('archive_hrmresource')).toBeGreaterThan(labels.indexOf('hrmresource'));
     expect(labels).not.toContain('hrm_resource_export_template');
-    expect(labels).not.toContain('archive_hrmresource');
     expect(labels).not.toContain('hrmresult');
 
     editorState.value = 'SELECT * FROM users u, hrmres';
@@ -3828,8 +3832,19 @@ describe('QueryEditor external SQL save', () => {
     );
     const commaLabels = commaResult.suggestions.map((item: any) => item.label);
     expect(commaLabels).toContain('hrmresource');
-    expect(commaLabels).not.toContain('archive_hrmresource');
+    expect(commaLabels).toContain('archive_hrmresource');
+    expect(commaLabels.indexOf('archive_hrmresource')).toBeGreaterThan(commaLabels.indexOf('hrmresource'));
     expect(commaLabels).not.toContain('hrmresult_from_users');
+
+    // #939：输入表名中段片段（new）也能提示 table_new_1
+    editorState.value = 'SELECT * FROM new';
+    editorState.latestOnChange?.(editorState.value);
+    const substringResult = await sqlProvider.provideCompletionItems(
+      editorState.editor.getModel(),
+      { lineNumber: 1, column: editorState.value.length + 1 },
+    );
+    const substringLabels = substringResult.suggestions.map((item: any) => item.label);
+    expect(substringLabels).toContain('table_new_1');
     expect(backendApp.DBGetColumns.mock.calls.map((call: any[]) => call[2])).not.toContain('hrmres');
 
     editorState.value = 'SELECT * FROM A_C';
@@ -3849,6 +3864,16 @@ describe('QueryEditor external SQL save', () => {
     );
     const lowercaseColumn = lowercaseColumnResult.suggestions.find((item: any) => item.label === 'SHORT_TITLE');
     expect(lowercaseColumn?.insertText).toBe('short_title');
+
+    // #939：字段中段片段提示（输入 code 应提示 emp_code）
+    editorState.value = 'SELECT * FROM users WHERE code';
+    editorState.latestOnChange?.(editorState.value);
+    const columnSubstringResult = await sqlProvider.provideCompletionItems(
+      editorState.editor.getModel(),
+      { lineNumber: 1, column: editorState.value.length + 1 },
+    );
+    const columnSubstringLabels = columnSubstringResult.suggestions.map((item: any) => item.label);
+    expect(columnSubstringLabels).toContain('emp_code');
 
     await act(async () => {
       renderer.unmount();

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -6703,7 +6703,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                           getMatchRank: (table, normalizedPrefix) => {
                               if (String(table.dbName || '').toLowerCase() !== qualifierLower) return null;
                               const meta = buildDbQualifiedTableSuggestionMeta(table.dbName || qualifier, table.tableName || '');
-                              return rankQueryEditorCompletionCandidate(normalizedPrefix, [meta.displayName, table.tableName], false);
+                              return rankQueryEditorCompletionCandidate(normalizedPrefix, [meta.displayName, table.tableName]);
                           },
                           getSelectionKey: (table, _prefix, matchRank) => {
                               const meta = buildDbQualifiedTableSuggestionMeta(table.dbName || qualifier, table.tableName || '');
@@ -6764,7 +6764,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                           prefix,
                           getMatchRank: (synonym, normalizedPrefix) => (
                               String(synonym.ownerName || '').trim().toLowerCase() === qualifierLower
-                                  ? rankQueryEditorCompletionCandidate(normalizedPrefix, [synonym.synonymName], false)
+                                  ? rankQueryEditorCompletionCandidate(normalizedPrefix, [synonym.synonymName])
                                   : null
                           ),
                           getSelectionKey: (synonym) => '06' + synonym.synonymName,
@@ -6779,7 +6779,6 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                               return rankQueryEditorCompletionCandidate(
                                   normalizedPrefix,
                                   [meta.displayName, meta.objectName, routine.routineName],
-                                  false,
                               );
                           },
                           getSelectionKey: (routine) => '1' + buildRoutineSuggestionMeta(routine).displayName,
@@ -6818,7 +6817,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                           if (parsed.schema.toLowerCase() !== qualifierLower) return null;
                           hasKnownSchemaQualifier = true;
                           if (!parsed.table) return null;
-                          return rankQueryEditorCompletionCandidate(normalizedPrefix, [parsed.table], false);
+                          return rankQueryEditorCompletionCandidate(normalizedPrefix, [parsed.table]);
                       },
                       getSelectionKey: (table, _prefix, matchRank) => `0${matchRank}${splitSchemaAndTable(table.tableName || '', table.dbName).table}`,
                       buildSuggestion: (table) => {
@@ -6849,7 +6848,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                               if (meta.schemaName.toLowerCase() !== qualifierLower) return null;
                               hasKnownSchemaQualifier = true;
                               if (!meta.objectName) return null;
-                              return rankQueryEditorCompletionCandidate(normalizedPrefix, [meta.objectName], false);
+                              return rankQueryEditorCompletionCandidate(normalizedPrefix, [meta.objectName]);
                           },
                           getSelectionKey: (view, _prefix, matchRank) => `05${matchRank}${buildViewSuggestionMeta(view).objectName}`,
                           buildSuggestion: (view) => {
@@ -6875,7 +6874,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                       getMatchRank: (synonym, normalizedPrefix) => {
                           if (String(synonym.ownerName || '').trim().toLowerCase() !== qualifierLower) return null;
                           hasKnownSchemaQualifier = true;
-                          return rankQueryEditorCompletionCandidate(normalizedPrefix, [synonym.synonymName], false);
+                          return rankQueryEditorCompletionCandidate(normalizedPrefix, [synonym.synonymName]);
                       },
                       getSelectionKey: (synonym) => '06' + synonym.synonymName,
                       buildSuggestion: (synonym) => buildSynonymSuggestion(synonym, '06' + synonym.synonymName),
@@ -6887,7 +6886,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                           const meta = buildRoutineSuggestionMeta(routine);
                           if (meta.schemaName.toLowerCase() !== qualifierLower) return null;
                           hasKnownSchemaQualifier = true;
-                          return rankQueryEditorCompletionCandidate(normalizedPrefix, [meta.objectName], false);
+                          return rankQueryEditorCompletionCandidate(normalizedPrefix, [meta.objectName]);
                       },
                       getSelectionKey: (routine) => '1' + buildRoutineSuggestionMeta(routine).objectName,
                       buildSuggestion: (routine) => {
@@ -7113,10 +7112,9 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                           return rankQueryEditorCompletionCandidate(
                               normalizedPrefix,
                               [meta.dbQualifiedLabel, table.tableName, pureTable],
-                              !expectsTableName,
                           );
                       }
-                      return rankQueryEditorCompletionCandidate(normalizedPrefix, [table.tableName, pureTable], !expectsTableName);
+                      return rankQueryEditorCompletionCandidate(normalizedPrefix, [table.tableName, pureTable]);
                   },
                   getSelectionKey: (table, _prefix, matchRank) => {
                       const isCurrentDb = isCurrentCompletionDatabase(table.dbName || '');
@@ -7186,7 +7184,6 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                           return rankQueryEditorCompletionCandidate(
                               normalizedPrefix,
                               [meta.dbQualifiedLabel, meta.displayName, meta.objectName, view.viewName],
-                              !expectsTableName,
                           );
                       },
                       getSelectionKey: (view, _prefix, matchRank) => {
@@ -7225,7 +7222,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                   candidates: selectUnqualifiedCompletionSynonyms(sharedSynonymsData, oracleLoginOwner),
                   prefix: wordPrefix,
                   getMatchRank: (synonym, normalizedPrefix) => (
-                      rankQueryEditorCompletionCandidate(normalizedPrefix, [synonym.synonymName], !expectsTableName)
+                      rankQueryEditorCompletionCandidate(normalizedPrefix, [synonym.synonymName])
                   ),
                   getSelectionKey: (synonym) => (
                       sortGroups.tableCurrent + '05' + getPrefixMatchRank(synonym.synonymName || '') + synonym.synonymName
@@ -7245,7 +7242,6 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                       return rankQueryEditorCompletionCandidate(
                           normalizedPrefix,
                           [meta.dbQualifiedLabel, meta.displayName, meta.objectName, routine.routineName],
-                          !expectsTableName && !expectsRoutineName,
                       );
                   },
                   getSelectionKey: (routine) => {


### PR DESCRIPTION
## 背景与问题

Issue #939：SQL 编辑时表名/字段不进行模糊匹配 — 表名 `table_new_1` 输入 `new` 无提示；WHERE 条件字段输入中段片段无提示。

根因：PR #831（#822，已合并）实现了子串匹配，但同日 `14033931`「修复表名及别名字段补全异常」在 FROM 上下文中把表名候选改回严格前缀匹配（`rankQueryEditorCompletionCandidate(..., !expectsTableName)` 传入 `includeSubstring=false`），并波及视图、同义词、存储过程及 `db.`/`schema.` 限定分支，导致子串候选在 provider 内被直接剔除，功能整体回退。

## 变更点

1. 恢复 10 处候选匹配的子串能力：全局表/视图/同义词/存储过程批次 + `db.`/`schema.` 限定分支（`QueryEditor.tsx`）
2. 子串命中保持 rank 2，排序仍在精确/前缀命中之后；filterText 沿用 PR #831 的匹配后缀机制，交由 Monaco 二次过滤
3. 关键字、函数名、库名保持严格前缀匹配不变
4. 测试：更新 #810 时代的两处断言（`hrmres` 现在包含 `archive_hrmresource` 且排在 `hrmresource` 之后）；新增 #939 复现用例：`SELECT * FROM new` 提示 `table_new_1`、`WHERE code` 提示 `emp_code`

## 影响范围

- 仅前端 `QueryEditor.tsx` 补全候选排序与过滤、对应测试
- 精确/前缀匹配行为不变；FROM 上下文现在会额外展示子串命中的表名候选（排在后面）— 这是 #822/#939 的预期行为

## 验证方式

- `QueryEditor.external-sql-save.test.tsx` 324 测试通过（含新用例）；queryEditor 相关套件 198 通过
- 前端全量测试 482/483 通过（唯一失败为本改动无关的 Node 24 环境性既有问题）；`tsc --noEmit` 通过
- 人工验证：`SELECT * FROM new` → `table_new_1`；`WHERE code` → `emp_code`；`hrmres` → 前缀在前、子串在后

Fixes #939

🤖 Generated with [Claude Code](https://claude.com/claude-code)