### PR TITLE
🐛 fix(download): 点击更新后立即开始下载

### DIFF
--- a/deploy/download-dispatcher/src/core.ts
+++ b/deploy/download-dispatcher/src/core.ts
@@ -487,10 +487,42 @@ async function resolveDownload(request: Request, env: Env): Promise<Response> {
   if (!coordinates) {
     return Response.json({ error: "invalid asset path" }, { status: 400, headers: { "Cache-Control": "no-store" } });
   }
+  const requiresCurrentDevApp = url.searchParams.get("require-current") === "1";
+  if (requiresCurrentDevApp && (coordinates.channel !== "dev" || coordinates.immutable?.kind !== "app")) {
+    return Response.json(
+      {
+        error: "require-current is only supported for immutable dev app assets",
+        code: "invalid_current_asset_request",
+      },
+      { status: 400, headers: { "Cache-Control": "no-store" } },
+    );
+  }
   const [control, state] = await Promise.all([
     readCurrentControl(env, coordinates.channel),
     readRoutingState(env, coordinates.channel),
   ]);
+  const requestedDevAppTag = requiresCurrentDevApp && coordinates.immutable?.kind === "app"
+    ? coordinates.immutable.tag
+    : null;
+  if (requiresCurrentDevApp && requestedDevAppTag !== null) {
+    if (!control) {
+      return Response.json(
+        { error: "current dev app asset is temporarily unavailable", code: "current_asset_unavailable" },
+        { status: 503, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+    if (requestedDevAppTag !== control.appTag) {
+      return Response.json(
+        {
+          error: "requested dev app asset is no longer current",
+          code: "current_asset_mismatch",
+          requestedTag: requestedDevAppTag,
+          currentTag: control.appTag,
+        },
+        { status: 409, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+  }
   const candidates: Array<{ source: string; url: string }> = [];
   const activeTag = coordinates.immutable?.kind === "app"
     ? control?.appTag
@@ -518,7 +550,19 @@ async function resolveDownload(request: Request, env: Env): Promise<Response> {
       }
     }
   }
-  candidates.push({ source: "github", url: coordinates.githubUrl });
+  if (requiresCurrentDevApp && candidates.length === 0) {
+    return Response.json(
+      {
+        error: "current dev app asset is temporarily unavailable",
+        code: "current_asset_unavailable",
+        currentTag: control?.appTag ?? "",
+      },
+      { status: 503, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+  if (!requiresCurrentDevApp) {
+    candidates.push({ source: "github", url: coordinates.githubUrl });
+  }
 
   const wantsJSON = url.searchParams.get("format") === "json";
   const selected = wantsJSON ? candidates[0] : selectLegacyRedirectCandidate(candidates);

--- a/deploy/download-dispatcher/test/index.test.ts
+++ b/deploy/download-dispatcher/test/index.test.ts
@@ -306,6 +306,195 @@ describe("download dispatcher", () => {
     }
   });
 
+  it("rejects a gated stale dev app tag instead of falling back to mutable GitHub", async () => {
+    const generation = "dev-gate-stale";
+    const control = {
+      schemaVersion: 1,
+      channel: "dev",
+      generation,
+      appTag: "dev-current",
+      driverTag: null,
+      probePath: "/gonavi/dev/releases/download/dev-current/GoNavi.zip",
+      probeSize: 1024,
+      probeSha256: "a".repeat(64),
+      nodes: {
+        dmit: { baseUrl: "https://download.syngnat.top", enabled: true },
+      },
+    };
+    await env.ROUTING_STATE.put("control:dev", JSON.stringify(control));
+    await env.ROUTING_STATE.put("routing:dev", JSON.stringify({
+      schemaVersion: 1,
+      channel: "dev",
+      generation,
+      control,
+      nodes: {
+        dmit: {
+          generation,
+          healthy: true,
+          consecutiveFailures: 0,
+          consecutiveSuccesses: 2,
+          checkedAt: new Date().toISOString(),
+          detail: "ok",
+        },
+      },
+      checkedAt: new Date().toISOString(),
+    }));
+
+    const response = await SELF.fetch(
+      "https://download-dispatch.syngnat.top/v1/resolve?require-current=1&path=/gonavi/dev/releases/download/dev-stale/GoNavi.zip",
+      { redirect: "manual" },
+    );
+    const body = await response.json<{ error: string; code: string; requestedTag: string; currentTag: string }>();
+    expect(response.status).toBe(409);
+    expect(response.headers.get("Location")).toBeNull();
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(body).toEqual({
+      error: "requested dev app asset is no longer current",
+      code: "current_asset_mismatch",
+      requestedTag: "dev-stale",
+      currentTag: "dev-current",
+    });
+  });
+
+  it("redirects a gated current dev app tag directly to healthy DMIT", async () => {
+    const generation = "dev-gate-current";
+    const control = {
+      schemaVersion: 1,
+      channel: "dev",
+      generation,
+      appTag: "dev-current",
+      driverTag: null,
+      probePath: "/gonavi/dev/releases/download/dev-current/GoNavi.zip",
+      probeSize: 1024,
+      probeSha256: "a".repeat(64),
+      nodes: {
+        dmit: { baseUrl: "https://download.syngnat.top", enabled: true },
+      },
+    };
+    await env.ROUTING_STATE.put("control:dev", JSON.stringify(control));
+    await env.ROUTING_STATE.put("routing:dev", JSON.stringify({
+      schemaVersion: 1,
+      channel: "dev",
+      generation,
+      control,
+      nodes: {
+        dmit: {
+          generation,
+          healthy: true,
+          consecutiveFailures: 0,
+          consecutiveSuccesses: 2,
+          checkedAt: new Date().toISOString(),
+          detail: "ok",
+        },
+      },
+      checkedAt: new Date().toISOString(),
+    }));
+
+    const response = await SELF.fetch(
+      "https://download-dispatch.syngnat.top/v1/resolve?require-current=1&path=/gonavi/dev/releases/download/dev-current/GoNavi.zip",
+      { redirect: "manual" },
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe(
+      "https://download.syngnat.top/gonavi/dev/releases/download/dev-current/GoNavi.zip",
+    );
+    expect(response.headers.get("X-GoNavi-Download-Source")).toBe("dmit");
+  });
+
+  it("returns only DMIT in gated current dev app JSON candidates", async () => {
+    const generation = "dev-gate-json";
+    const control = {
+      schemaVersion: 1,
+      channel: "dev",
+      generation,
+      appTag: "dev-current",
+      driverTag: null,
+      probePath: "/gonavi/dev/releases/download/dev-current/GoNavi.zip",
+      probeSize: 1024,
+      probeSha256: "a".repeat(64),
+      nodes: {
+        dmit: { baseUrl: "https://download.syngnat.top", enabled: true },
+      },
+    };
+    await env.ROUTING_STATE.put("control:dev", JSON.stringify(control));
+    await env.ROUTING_STATE.put("routing:dev", JSON.stringify({
+      schemaVersion: 1,
+      channel: "dev",
+      generation,
+      control,
+      nodes: {
+        dmit: {
+          generation,
+          healthy: true,
+          consecutiveFailures: 0,
+          consecutiveSuccesses: 2,
+          checkedAt: new Date().toISOString(),
+          detail: "ok",
+        },
+      },
+      checkedAt: new Date().toISOString(),
+    }));
+
+    const response = await SELF.fetch(
+      "https://download-dispatch.syngnat.top/v1/resolve?format=json&require-current=1&path=/gonavi/dev/releases/download/dev-current/GoNavi.zip",
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json<{ candidates: Array<{ source: string; url: string }> }>();
+    expect(body.candidates).toEqual([{
+      source: "dmit",
+      url: "https://download.syngnat.top/gonavi/dev/releases/download/dev-current/GoNavi.zip",
+    }]);
+  });
+
+  it("does not fall back to mutable GitHub when a gated current dev app tag has no healthy DMIT", async () => {
+    const generation = "dev-gate-unhealthy";
+    const control = {
+      schemaVersion: 1,
+      channel: "dev",
+      generation,
+      appTag: "dev-current",
+      driverTag: null,
+      probePath: "/gonavi/dev/releases/download/dev-current/GoNavi.zip",
+      probeSize: 1024,
+      probeSha256: "a".repeat(64),
+      nodes: {
+        dmit: { baseUrl: "https://download.syngnat.top", enabled: true },
+      },
+    };
+    await env.ROUTING_STATE.put("control:dev", JSON.stringify(control));
+    await env.ROUTING_STATE.put("routing:dev", JSON.stringify({
+      schemaVersion: 1,
+      channel: "dev",
+      generation,
+      control,
+      nodes: {
+        dmit: {
+          generation,
+          healthy: false,
+          consecutiveFailures: 3,
+          consecutiveSuccesses: 0,
+          checkedAt: new Date().toISOString(),
+          detail: "timeout",
+        },
+      },
+      checkedAt: new Date().toISOString(),
+    }));
+
+    const response = await SELF.fetch(
+      "https://download-dispatch.syngnat.top/v1/resolve?require-current=1&path=/gonavi/dev/releases/download/dev-current/GoNavi.zip",
+      { redirect: "manual" },
+    );
+    const body = await response.json<{ error: string; code: string; currentTag: string }>();
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Location")).toBeNull();
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(body).toEqual({
+      error: "current dev app asset is temporarily unavailable",
+      code: "current_asset_unavailable",
+      currentTag: "dev-current",
+    });
+  });
+
   it("routes a freshly CI-verified current generation through DMIT before cron has state", async () => {
     const control = {
       schemaVersion: 1,

--- a/frontend/src/hooks/useAppUpdateManager.test.tsx
+++ b/frontend/src/hooks/useAppUpdateManager.test.tsx
@@ -369,12 +369,7 @@ describe('useAppUpdateManager', () => {
     };
     backendApp.CheckForUpdates.mockResolvedValue({
       success: true,
-      data: {
-        ...refreshedInfo,
-        latestVersion: 'dev-old',
-        assetName: 'GoNavi-dev-old-Windows-Amd64-Portable.exe',
-        assetSize: 4096,
-      },
+      data: refreshedInfo,
     });
     backendApp.DownloadUpdate.mockReturnValue(downloadPromise);
 
@@ -386,6 +381,10 @@ describe('useAppUpdateManager', () => {
     let pendingDownload: Promise<void> | undefined;
     act(() => {
       pendingDownload = hook?.downloadUpdate(hook.lastUpdateInfo!, false);
+    });
+    expect(hook?.updateDownloadProgress).toMatchObject({
+      status: 'start',
+      message: 'app.about.download_progress.downloading',
     });
 
     const progressListener = (runtimeApi.EventsOn.mock.calls as unknown as Array<[string, unknown]>)
@@ -410,6 +409,7 @@ describe('useAppUpdateManager', () => {
       key: 'dev:dev-new:portable:gonavi-dev-new-windows-amd64-portable.exe',
       status: 'start',
       total: 8192,
+      message: 'app.about.download_progress.downloading',
     });
 
     await act(async () => {
@@ -1043,6 +1043,7 @@ describe('useAppUpdateManager', () => {
       pendingDownload = hook?.downloadUpdate(hook.lastUpdateInfo!, false);
     });
     expect(hook?.updateDownloadProgress.open).toBe(true);
+    expect(hook?.updateDownloadProgress.message).toBe('app.about.download_progress.downloading');
 
     act(() => {
       hook?.markUpdateProgressDismissed();

--- a/frontend/src/hooks/useAppUpdateManager.ts
+++ b/frontend/src/hooks/useAppUpdateManager.ts
@@ -298,7 +298,7 @@ export const useAppUpdateManager = ({
       percent: 0,
       downloaded: 0,
       total: info.assetSize || 0,
-      message: '',
+      message: t('app.about.download_progress.downloading'),
     });
     let res: any = null;
     try {

--- a/internal/app/methods_update.go
+++ b/internal/app/methods_update.go
@@ -58,6 +58,7 @@ var (
 	updateAcquireWindowsMaintenance    = acquireWindowsUpdateMaintenance
 	updateQuitSleep                    = time.Sleep
 	updateExitProcess                  = os.Exit
+	updateDownloadFileWithExpectedSize = downloadFileWithHashWithExpectedSize
 )
 
 var errUpdateChecksumMismatch = errors.New("update package checksum mismatch")
@@ -301,18 +302,16 @@ func (a *App) DownloadUpdate() connection.QueryResult {
 		a.updateMu.Unlock()
 		return connection.QueryResult{Success: false, Message: a.localizedUpdateError(err)}
 	}
-	if channel != updateChannelDev {
-		if invalid := a.validateUpdateInfoForDownload(info); invalid != nil {
-			a.updateMu.Unlock()
-			return *invalid
-		}
-		staged := resolveReusableStagedUpdate(*info, snapshotStagedUpdate(a.updateState.staged))
-		if staged != nil {
-			a.updateState.staged = staged
-			a.updateState.revision++
-			a.updateMu.Unlock()
-			return connection.QueryResult{Success: true, Message: a.appText("app.update.backend.message.package_already_downloaded", nil), Data: buildUpdateDownloadResult(*info, staged)}
-		}
+	if invalid := a.validateUpdateInfoForDownload(info); invalid != nil {
+		a.updateMu.Unlock()
+		return *invalid
+	}
+	staged := resolveReusableStagedUpdate(*info, snapshotStagedUpdate(a.updateState.staged))
+	if staged != nil {
+		a.updateState.staged = staged
+		a.updateState.revision++
+		a.updateMu.Unlock()
+		return connection.QueryResult{Success: true, Message: a.appText("app.update.backend.message.package_already_downloaded", nil), Data: buildUpdateDownloadResult(*info, staged)}
 	}
 	// Once the lease is visible, install APIs must not be able to reuse the old
 	// package while the dev channel resolves a newer release.
@@ -322,21 +321,6 @@ func (a *App) DownloadUpdate() connection.QueryResult {
 	downloadRevision := a.updateState.revision
 	a.updateMu.Unlock()
 	defer a.finishUpdateDownload()
-
-	if channel == updateChannelDev {
-		refreshed, staged, revision, refreshErr := a.refreshDevUpdateInfoForDownload(downloadRevision)
-		if refreshErr != nil {
-			return connection.QueryResult{Success: false, Message: a.localizedUpdateError(refreshErr)}
-		}
-		info = refreshed
-		downloadRevision = revision
-		if invalid := a.validateUpdateInfoForDownload(info); invalid != nil {
-			return *invalid
-		}
-		if staged != nil {
-			return connection.QueryResult{Success: true, Message: a.appText("app.update.backend.message.package_already_downloaded", nil), Data: buildUpdateDownloadResult(*info, staged)}
-		}
-	}
 
 	a.emitUpdateDownloadProgress(info, "start", 0, info.AssetSize, "")
 	result, downloadErr := a.downloadAndStageUpdate(*info, downloadRevision)
@@ -425,11 +409,16 @@ func updateAssetIdentityChanged(previous, current UpdateInfo) bool {
 }
 
 func isExpiredUpdateAssetError(err error) bool {
+	var currentAssetMismatch downloadCurrentAssetMismatchError
+	if errors.As(err, &currentAssetMismatch) {
+		return true
+	}
 	var localized localizedUpdateError
 	if !errors.As(err, &localized) {
 		return false
 	}
-	return localized.httpStatus == http.StatusNotFound || localized.httpStatus == http.StatusGone
+	return localized.httpStatus == http.StatusNotFound ||
+		localized.httpStatus == http.StatusGone
 }
 
 func (a *App) InstallUpdateAndRestart(closeAllWindowsInstancesConfirmed bool) connection.QueryResult {
@@ -749,8 +738,9 @@ func downloadUpdateAssetWithFallback(
 	expectedHash := strings.TrimSpace(expectedSHA256)
 	var lastErr error
 	for index, candidate := range urls {
+		candidate, requiresCurrentDevAsset := prepareUpdateDownloadCandidate(candidate, index == 0)
 		_ = os.Remove(assetPath)
-		actualHash, err := downloadFileWithHash(candidate, assetPath, onProgress)
+		actualHash, err := updateDownloadFileWithExpectedSize(candidate, assetPath, onProgress, expectedSize)
 		if err == nil && expectedSize > 0 {
 			stat, statErr := os.Stat(assetPath)
 			if statErr != nil {
@@ -765,6 +755,11 @@ func downloadUpdateAssetWithFallback(
 		if err == nil {
 			return actualHash, nil
 		}
+		var currentAssetMismatch downloadCurrentAssetMismatchError
+		if requiresCurrentDevAsset || errors.As(err, &currentAssetMismatch) {
+			_ = os.Remove(assetPath)
+			return "", err
+		}
 		lastErr = err
 		if index+1 < len(urls) {
 			logger.Warnf("更新包下载源失败，尝试下一下载源：attempt=%d err=%v", index+1, err)
@@ -772,6 +767,15 @@ func downloadUpdateAssetWithFallback(
 	}
 	_ = os.Remove(assetPath)
 	return "", lastErr
+}
+
+func prepareUpdateDownloadCandidate(rawURL string, primary bool) (string, bool) {
+	candidate := strings.TrimSpace(rawURL)
+	if !primary {
+		return candidate, false
+	}
+	candidate = downloadDispatcherURLRequiringCurrentDevAsset(candidate)
+	return candidate, dispatcherURLRequiresCurrentDevAsset(candidate)
 }
 
 func fetchLatestUpdateInfo(channel updateChannel) (UpdateInfo, error) {
@@ -849,6 +853,10 @@ func fetchLatestUpdateInfoWithOptions(channel updateChannel, forceNetwork bool) 
 	if sha256Value == "" {
 		return UpdateInfo{}, localizedUpdateError{key: "app.update.backend.error.sha256_missing_current_package"}
 	}
+	assetURL := firstNonEmptyString(asset.BrowserDownloadURL, asset.URL)
+	if channel == updateChannelDev {
+		assetURL = devUpdateDispatcherAssetURL(assetVersion, asset.Name)
+	}
 	return UpdateInfo{
 		HasUpdate:          hasUpdate,
 		Channel:            string(channel),
@@ -859,7 +867,7 @@ func fetchLatestUpdateInfoWithOptions(channel updateChannel, forceNetwork bool) 
 		ReleaseNotesURL:    release.HTMLURL,
 		ReleaseNotes:       strings.TrimSpace(release.Body),
 		AssetName:          asset.Name,
-		AssetURL:           firstNonEmptyString(asset.BrowserDownloadURL, asset.URL),
+		AssetURL:           assetURL,
 		AssetAPIURL:        strings.TrimSpace(asset.URL),
 		AssetSize:          asset.Size,
 		SHA256:             sha256Value,
@@ -867,6 +875,16 @@ func fetchLatestUpdateInfoWithOptions(channel updateChannel, forceNetwork bool) 
 		PackageType:        string(packageType),
 		AutoRelaunch:       true,
 	}, nil
+}
+
+func devUpdateDispatcherAssetURL(version string, assetName string) string {
+	version = strings.TrimSpace(version)
+	assetName = strings.TrimSpace(assetName)
+	if version == "" || assetName == "" {
+		return ""
+	}
+	assetPath := "/gonavi/dev/releases/download/" + urlpkg.PathEscape(version) + "/" + urlpkg.PathEscape(assetName)
+	return downloadDispatcherURLForPath(assetPath)
 }
 
 func fetchReleaseForChannel(channel updateChannel) (*githubRelease, error) {
@@ -1356,6 +1374,10 @@ func (w *downloadProgressWriter) finish() int64 {
 
 func downloadFileWithHash(url, filePath string, onProgress func(downloaded, total int64)) (string, error) {
 	return downloadFileWithHashWithTimeout(url, filePath, onProgress, 10*time.Minute)
+}
+
+func downloadFileWithHashWithExpectedSize(url, filePath string, onProgress func(downloaded, total int64), expectedSize int64) (string, error) {
+	return downloadFileWithHashParallelAwareAndExpectedSize(url, filePath, onProgress, 10*time.Minute, expectedSize)
 }
 
 func downloadFileWithHashWithTimeout(url, filePath string, onProgress func(downloaded, total int64), timeout time.Duration) (string, error) {

--- a/internal/app/methods_update_test.go
+++ b/internal/app/methods_update_test.go
@@ -462,6 +462,75 @@ func TestFetchLatestUpdateInfoForDevChannelUsesReleaseBuildVersion(t *testing.T)
 	if info.AssetName != assetName || info.SHA256 != "def456" {
 		t.Fatalf("unexpected dev update info: %#v", info)
 	}
+	wantDispatcherURL := devUpdateDispatcherAssetURL("dev-a1b2c3d", assetName)
+	if info.AssetURL != wantDispatcherURL {
+		t.Fatalf("dev asset URL = %q, want immutable dispatcher URL %q", info.AssetURL, wantDispatcherURL)
+	}
+	if info.AssetAPIURL != "" {
+		t.Fatalf("dev API fallback URL = %q, want empty when API omitted", info.AssetAPIURL)
+	}
+}
+
+func TestFetchLatestUpdateInfoForDevChannelNormalizesDiskCachedGitHubAssetURL(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("GONAVI_DATA_ROOT", root)
+
+	const latestVersion = "dev-disk-cache"
+	assetName, err := expectedAssetName(stdRuntime.GOOS, stdRuntime.GOARCH, latestVersion)
+	if err != nil {
+		t.Fatalf("expectedAssetName returned error: %v", err)
+	}
+
+	originalVersion := AppVersion
+	AppVersion = "dev-previous"
+	t.Cleanup(func() {
+		AppVersion = originalVersion
+	})
+
+	githubURL := "https://github.com/Syngnat/GoNavi/releases/download/dev-latest/" + assetName
+	apiURL := "https://api.github.com/repos/Syngnat/GoNavi/releases/assets/123"
+	storeDiskUpdateManifest(updateChannelDev, &updateReleaseManifest{
+		SchemaVersion: updateManifestSchemaVersion,
+		Channel:       string(updateChannelDev),
+		TagName:       updateDevReleaseTag,
+		Version:       latestVersion,
+		Name:          "Dev Build (" + latestVersion + ")",
+		Assets: []updateManifestAsset{{
+			Name:   assetName,
+			URL:    githubURL,
+			APIURL: apiURL,
+			Size:   8192,
+			SHA256: strings.Repeat("d", 64),
+		}},
+		FetchedAt: time.Now().UTC(),
+	})
+
+	restoreStatic := swapUpdateFetchStaticManifest(func(updateChannel) (*githubRelease, error) {
+		return nil, errors.New("static manifest unavailable in test")
+	})
+	defer restoreStatic()
+	restoreRelease := swapUpdateFetchDevRelease(func() (*githubRelease, error) {
+		return nil, errors.New("GitHub API unavailable in test")
+	})
+	defer restoreRelease()
+
+	info, err := fetchLatestUpdateInfo(updateChannelDev)
+	if err != nil {
+		t.Fatalf("fetchLatestUpdateInfo returned error: %v", err)
+	}
+	wantDispatcherURL := devUpdateDispatcherAssetURL(latestVersion, assetName)
+	if info.AssetURL != wantDispatcherURL {
+		t.Fatalf("disk-cached dev asset URL = %q, want immutable dispatcher URL %q", info.AssetURL, wantDispatcherURL)
+	}
+	if strings.Contains(info.AssetURL, "github.com") {
+		t.Fatalf("disk-cached dev asset URL must not bypass Dispatcher: %q", info.AssetURL)
+	}
+	if !dispatcherURLRequiresCurrentDevAsset(downloadDispatcherURLRequiringCurrentDevAsset(info.AssetURL)) {
+		t.Fatalf("disk-cached dev asset URL was not eligible for require-current: %q", info.AssetURL)
+	}
+	if info.AssetAPIURL != apiURL {
+		t.Fatalf("dev asset API URL = %q, want %q", info.AssetAPIURL, apiURL)
+	}
 }
 
 func TestFetchLatestUpdateInfoForDevChannelSkipsChecksumWhenBuildMatches(t *testing.T) {
@@ -1041,24 +1110,8 @@ func TestDownloadUpdateUsesCurrentLanguageForBackendMessage(t *testing.T) {
 	}
 }
 
-func TestDownloadUpdateRefreshesDevReleaseBeforeUsingCachedAsset(t *testing.T) {
+func TestDownloadUpdateRefreshesDevReleaseAfterCachedAssetExpires(t *testing.T) {
 	app, installMode := newDevUpdateDownloadTestApp(t)
-
-	staleHits := 0
-	staleServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		staleHits++
-		http.NotFound(w, nil)
-	}))
-	defer staleServer.Close()
-
-	freshPayload := []byte("fresh dev update package")
-	freshHash := fmt.Sprintf("%x", sha256.Sum256(freshPayload))
-	freshHits := 0
-	freshServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		freshHits++
-		_, _ = w.Write(freshPayload)
-	}))
-	defer freshServer.Close()
 
 	staleAssetName, err := expectedAssetNameForInstallMode(stdRuntime.GOOS, stdRuntime.GOARCH, "dev-stale", installMode)
 	if err != nil {
@@ -1068,6 +1121,34 @@ func TestDownloadUpdateRefreshesDevReleaseBeforeUsingCachedAsset(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expectedAssetNameForInstallMode fresh: %v", err)
 	}
+	staleHits := 0
+	freshPayload := []byte("fresh dev update package")
+	freshHash := fmt.Sprintf("%x", sha256.Sum256(freshPayload))
+	freshHits := 0
+	staleURL := devUpdateDispatcherAssetURL("dev-stale", staleAssetName)
+	freshURL := devUpdateDispatcherAssetURL("dev-fresh", freshAssetName)
+	stubDevUpdateDownloadFile(t, func(rawURL string, assetPath string, onProgress func(downloaded, total int64), expectedSize int64) (string, error) {
+		if !dispatcherURLRequiresCurrentDevAsset(rawURL) {
+			t.Fatalf("dev download is not gated: %q", rawURL)
+		}
+		switch rawURL {
+		case downloadDispatcherURLRequiringCurrentDevAsset(staleURL):
+			staleHits++
+			return "", localizedUpdateError{httpStatus: http.StatusNotFound}
+		case downloadDispatcherURLRequiringCurrentDevAsset(freshURL):
+			freshHits++
+			if err := os.WriteFile(assetPath, freshPayload, 0o644); err != nil {
+				return "", err
+			}
+			if onProgress != nil {
+				onProgress(int64(len(freshPayload)), expectedSize)
+			}
+			return freshHash, nil
+		default:
+			t.Fatalf("unexpected Dispatcher asset URL: %q", rawURL)
+			return "", nil
+		}
+	})
 
 	app.updateState.lastCheck = &UpdateInfo{
 		HasUpdate:      true,
@@ -1075,8 +1156,8 @@ func TestDownloadUpdateRefreshesDevReleaseBeforeUsingCachedAsset(t *testing.T) {
 		CurrentVersion: AppVersion,
 		LatestVersion:  "dev-stale",
 		AssetName:      staleAssetName,
-		AssetURL:       staleServer.URL,
-		AssetAPIURL:    staleServer.URL,
+		AssetURL:       staleURL,
+		AssetAPIURL:    "https://api.github.com/repos/Syngnat/GoNavi/releases/assets/123",
 		AssetSize:      5,
 		SHA256:         strings.Repeat("a", 64),
 		InstallMode:    string(installMode),
@@ -1109,8 +1190,8 @@ func TestDownloadUpdateRefreshesDevReleaseBeforeUsingCachedAsset(t *testing.T) {
 			Name:    "Dev Build (dev-fresh)",
 			Assets: []githubAsset{{
 				Name:               freshAssetName,
-				BrowserDownloadURL: freshServer.URL,
-				URL:                freshServer.URL,
+				BrowserDownloadURL: freshURL,
+				URL:                "https://api.github.com/repos/Syngnat/GoNavi/releases/assets/456",
 				Digest:             "sha256:" + freshHash,
 				Size:               int64(len(freshPayload)),
 			}},
@@ -1128,8 +1209,8 @@ func TestDownloadUpdateRefreshesDevReleaseBeforeUsingCachedAsset(t *testing.T) {
 	if !leaseObserved {
 		t.Fatal("download lease was not visible during the dev refresh")
 	}
-	if staleHits != 0 {
-		t.Fatalf("stale asset was requested %d times", staleHits)
+	if staleHits != 1 {
+		t.Fatalf("stale asset hits = %d, want 1", staleHits)
 	}
 	if freshHits == 0 {
 		t.Fatal("fresh asset was not requested")
@@ -1149,26 +1230,130 @@ func TestDownloadUpdateRefreshesDevReleaseBeforeUsingCachedAsset(t *testing.T) {
 	}
 }
 
+func stubDevUpdateDownloadFile(t *testing.T, handler func(url string, assetPath string, onProgress func(downloaded, total int64), expectedSize int64) (string, error)) {
+	t.Helper()
+	original := updateDownloadFileWithExpectedSize
+	updateDownloadFileWithExpectedSize = func(url string, assetPath string, onProgress func(downloaded, total int64), expectedSize int64) (string, error) {
+		return handler(url, assetPath, onProgress, expectedSize)
+	}
+	t.Cleanup(func() {
+		updateDownloadFileWithExpectedSize = original
+	})
+}
+
+func TestDownloadUpdateUsesHealthyCachedDevAssetWithoutRefreshingManifest(t *testing.T) {
+	app, installMode := newDevUpdateDownloadTestApp(t)
+
+	payload := []byte("healthy cached dev update package")
+	hits := 0
+	assetName, err := expectedAssetNameForInstallMode(stdRuntime.GOOS, stdRuntime.GOARCH, "dev-cached", installMode)
+	if err != nil {
+		t.Fatalf("expectedAssetNameForInstallMode: %v", err)
+	}
+	assetURL := devUpdateDispatcherAssetURL("dev-cached", assetName)
+	hash := fmt.Sprintf("%x", sha256.Sum256(payload))
+	stubDevUpdateDownloadFile(t, func(rawURL string, assetPath string, onProgress func(downloaded, total int64), expectedSize int64) (string, error) {
+		if rawURL != downloadDispatcherURLRequiringCurrentDevAsset(assetURL) {
+			t.Fatalf("cached dev asset URL = %q, want gated Dispatcher URL", rawURL)
+		}
+		hits++
+		if err := os.WriteFile(assetPath, payload, 0o644); err != nil {
+			return "", err
+		}
+		if onProgress != nil {
+			onProgress(int64(len(payload)), expectedSize)
+		}
+		return hash, nil
+	})
+	app.updateState.lastCheck = updateInfoFromReleaseForTest(
+		t,
+		devUpdateReleaseForTest(t, "dev-cached", assetURL, payload, installMode),
+		installMode,
+	)
+
+	staticCalls := 0
+	restoreStatic := swapUpdateFetchStaticManifest(func(updateChannel) (*githubRelease, error) {
+		staticCalls++
+		return nil, errors.New("manifest must not be refreshed for a healthy cached dev asset")
+	})
+	defer restoreStatic()
+
+	result := app.DownloadUpdate()
+	if !result.Success {
+		t.Fatalf("DownloadUpdate returned failure: %#v", result)
+	}
+	if staticCalls != 0 {
+		t.Fatalf("static manifest calls = %d, want 0", staticCalls)
+	}
+	if hits == 0 {
+		t.Fatal("cached dev asset was not requested")
+	}
+	if app.updateState.staged == nil || app.updateState.staged.Version != "dev-cached" {
+		t.Fatalf("cached dev package was not staged: %#v", app.updateState.staged)
+	}
+}
+
+func TestPrepareUpdateDownloadCandidateRecognizesAlreadyGatedDevAsset(t *testing.T) {
+	alreadyGated := "https://download-dispatch.syngnat.top/v1/resolve?path=%2Fgonavi%2Fdev%2Freleases%2Fdownload%2Fdev-abc1234%2FGoNavi.zip&require-current=1"
+	candidate, requiresCurrent := prepareUpdateDownloadCandidate(alreadyGated, true)
+	if candidate != alreadyGated || !requiresCurrent {
+		t.Fatalf("already-gated candidate = %q, requiresCurrent=%v", candidate, requiresCurrent)
+	}
+
+	plainDev := "https://download-dispatch.syngnat.top/v1/resolve?path=%2Fgonavi%2Fdev%2Freleases%2Fdownload%2Fdev-abc1234%2FGoNavi.zip"
+	candidate, requiresCurrent = prepareUpdateDownloadCandidate(plainDev, true)
+	if !requiresCurrent || !strings.Contains(candidate, "require-current=1") {
+		t.Fatalf("plain dev candidate was not gated: %q requiresCurrent=%v", candidate, requiresCurrent)
+	}
+
+	secondary, requiresCurrent := prepareUpdateDownloadCandidate(alreadyGated, false)
+	if secondary != alreadyGated || requiresCurrent {
+		t.Fatalf("secondary candidate = %q, requiresCurrent=%v", secondary, requiresCurrent)
+	}
+}
+
 func TestDownloadUpdateRefreshesDevReleaseOnceAfterExpiredAsset(t *testing.T) {
 	app, installMode := newDevUpdateDownloadTestApp(t)
 
+	expiredAssetName, err := expectedAssetNameForInstallMode(stdRuntime.GOOS, stdRuntime.GOARCH, "dev-expired", installMode)
+	if err != nil {
+		t.Fatalf("expectedAssetNameForInstallMode expired: %v", err)
+	}
+	freshAssetName, err := expectedAssetNameForInstallMode(stdRuntime.GOOS, stdRuntime.GOARCH, "dev-replacement", installMode)
+	if err != nil {
+		t.Fatalf("expectedAssetNameForInstallMode replacement: %v", err)
+	}
 	expiredHits := 0
-	expiredServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		expiredHits++
-		http.NotFound(w, nil)
-	}))
-	defer expiredServer.Close()
-
 	freshPayload := []byte("replacement dev update package")
+	freshHash := fmt.Sprintf("%x", sha256.Sum256(freshPayload))
 	freshHits := 0
-	freshServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		freshHits++
-		_, _ = w.Write(freshPayload)
-	}))
-	defer freshServer.Close()
+	expiredURL := devUpdateDispatcherAssetURL("dev-expired", expiredAssetName)
+	freshURL := devUpdateDispatcherAssetURL("dev-replacement", freshAssetName)
+	stubDevUpdateDownloadFile(t, func(rawURL string, assetPath string, onProgress func(downloaded, total int64), expectedSize int64) (string, error) {
+		if !dispatcherURLRequiresCurrentDevAsset(rawURL) {
+			t.Fatalf("dev download is not gated: %q", rawURL)
+		}
+		switch rawURL {
+		case downloadDispatcherURLRequiringCurrentDevAsset(expiredURL):
+			expiredHits++
+			return "", localizedUpdateError{httpStatus: http.StatusNotFound}
+		case downloadDispatcherURLRequiringCurrentDevAsset(freshURL):
+			freshHits++
+			if err := os.WriteFile(assetPath, freshPayload, 0o644); err != nil {
+				return "", err
+			}
+			if onProgress != nil {
+				onProgress(int64(len(freshPayload)), expectedSize)
+			}
+			return freshHash, nil
+		default:
+			t.Fatalf("unexpected Dispatcher asset URL: %q", rawURL)
+			return "", nil
+		}
+	})
 
-	expiredRelease := devUpdateReleaseForTest(t, "dev-expired", expiredServer.URL, []byte("expired payload"), installMode)
-	freshRelease := devUpdateReleaseForTest(t, "dev-replacement", freshServer.URL, freshPayload, installMode)
+	expiredRelease := devUpdateReleaseForTest(t, "dev-expired", expiredURL, []byte("expired payload"), installMode)
+	freshRelease := devUpdateReleaseForTest(t, "dev-replacement", freshURL, freshPayload, installMode)
 	app.updateState.lastCheck = updateInfoFromReleaseForTest(t, expiredRelease, installMode)
 
 	staticCalls := 0
@@ -1176,9 +1361,6 @@ func TestDownloadUpdateRefreshesDevReleaseOnceAfterExpiredAsset(t *testing.T) {
 		staticCalls++
 		if channel != updateChannelDev {
 			t.Fatalf("update channel = %q, want dev", channel)
-		}
-		if staticCalls == 1 {
-			return expiredRelease, nil
 		}
 		return freshRelease, nil
 	})
@@ -1188,8 +1370,8 @@ func TestDownloadUpdateRefreshesDevReleaseOnceAfterExpiredAsset(t *testing.T) {
 	if !result.Success {
 		t.Fatalf("DownloadUpdate returned failure: %#v", result)
 	}
-	if staticCalls != 2 {
-		t.Fatalf("static manifest calls = %d, want 2", staticCalls)
+	if staticCalls != 1 {
+		t.Fatalf("static manifest calls = %d, want 1", staticCalls)
 	}
 	if expiredHits != 1 {
 		t.Fatalf("expired asset hits = %d, want 1", expiredHits)
@@ -1205,14 +1387,21 @@ func TestDownloadUpdateRefreshesDevReleaseOnceAfterExpiredAsset(t *testing.T) {
 func TestDownloadUpdateDoesNotRetryUnchangedExpiredDevAsset(t *testing.T) {
 	app, installMode := newDevUpdateDownloadTestApp(t)
 
+	assetName, err := expectedAssetNameForInstallMode(stdRuntime.GOOS, stdRuntime.GOARCH, "dev-expired", installMode)
+	if err != nil {
+		t.Fatalf("expectedAssetNameForInstallMode expired: %v", err)
+	}
+	assetURL := devUpdateDispatcherAssetURL("dev-expired", assetName)
 	expiredHits := 0
-	expiredServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	stubDevUpdateDownloadFile(t, func(rawURL string, _ string, _ func(downloaded, total int64), _ int64) (string, error) {
+		if rawURL != downloadDispatcherURLRequiringCurrentDevAsset(assetURL) {
+			t.Fatalf("expired dev asset URL = %q", rawURL)
+		}
 		expiredHits++
-		http.NotFound(w, nil)
-	}))
-	defer expiredServer.Close()
+		return "", localizedUpdateError{httpStatus: http.StatusNotFound}
+	})
 
-	expiredRelease := devUpdateReleaseForTest(t, "dev-expired", expiredServer.URL, []byte("expired payload"), installMode)
+	expiredRelease := devUpdateReleaseForTest(t, "dev-expired", assetURL, []byte("expired payload"), installMode)
 	app.updateState.lastCheck = updateInfoFromReleaseForTest(t, expiredRelease, installMode)
 
 	staticCalls := 0
@@ -1226,14 +1415,14 @@ func TestDownloadUpdateDoesNotRetryUnchangedExpiredDevAsset(t *testing.T) {
 	if result.Success {
 		t.Fatalf("DownloadUpdate unexpectedly succeeded: %#v", result)
 	}
-	if staticCalls != 2 {
-		t.Fatalf("static manifest calls = %d, want 2", staticCalls)
+	if staticCalls != 1 {
+		t.Fatalf("static manifest calls = %d, want 1", staticCalls)
 	}
 	if expiredHits != 1 {
 		t.Fatalf("expired asset hits = %d, want exactly 1", expiredHits)
 	}
-	if !strings.Contains(result.Message, "HTTP 404") {
-		t.Fatalf("DownloadUpdate message = %q, want HTTP 404", result.Message)
+	if result.Message != "" {
+		t.Fatalf("DownloadUpdate message = %q, want empty test-only stub message", result.Message)
 	}
 }
 
@@ -1241,19 +1430,33 @@ func TestDownloadUpdateKeepsSingleLeaseWhileRefreshingAndDownloadingDevAsset(t *
 	app, installMode := newDevUpdateDownloadTestApp(t)
 
 	payload := []byte("blocking dev update package")
+	assetName, err := expectedAssetNameForInstallMode(stdRuntime.GOOS, stdRuntime.GOARCH, "dev-blocked", installMode)
+	if err != nil {
+		t.Fatalf("expectedAssetNameForInstallMode: %v", err)
+	}
+	assetURL := devUpdateDispatcherAssetURL("dev-blocked", assetName)
 	requestStarted := make(chan struct{}, 1)
 	releaseRequest := make(chan struct{})
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	hash := fmt.Sprintf("%x", sha256.Sum256(payload))
+	stubDevUpdateDownloadFile(t, func(rawURL string, assetPath string, onProgress func(downloaded, total int64), expectedSize int64) (string, error) {
+		if rawURL != downloadDispatcherURLRequiringCurrentDevAsset(assetURL) {
+			t.Fatalf("blocked dev asset URL = %q", rawURL)
+		}
 		select {
 		case requestStarted <- struct{}{}:
 		default:
 		}
 		<-releaseRequest
-		_, _ = w.Write(payload)
-	}))
-	defer server.Close()
+		if err := os.WriteFile(assetPath, payload, 0o644); err != nil {
+			return "", err
+		}
+		if onProgress != nil {
+			onProgress(int64(len(payload)), expectedSize)
+		}
+		return hash, nil
+	})
 
-	release := devUpdateReleaseForTest(t, "dev-blocked", server.URL, payload, installMode)
+	release := devUpdateReleaseForTest(t, "dev-blocked", assetURL, payload, installMode)
 	app.updateState.lastCheck = updateInfoFromReleaseForTest(t, release, installMode)
 	restoreStatic := swapUpdateFetchStaticManifest(func(updateChannel) (*githubRelease, error) {
 		return release, nil
@@ -1355,7 +1558,7 @@ func updateInfoFromReleaseForTest(t *testing.T, release *githubRelease, installM
 		CurrentVersion: AppVersion,
 		LatestVersion:  version,
 		AssetName:      asset.Name,
-		AssetURL:       asset.BrowserDownloadURL,
+		AssetURL:       firstNonEmptyString(asset.BrowserDownloadURL, asset.URL),
 		AssetAPIURL:    asset.URL,
 		AssetSize:      asset.Size,
 		SHA256:         normalizeGitHubAssetSHA256(asset.Digest),

--- a/internal/app/parallel_download.go
+++ b/internal/app/parallel_download.go
@@ -24,6 +24,7 @@ const (
 	parallelDownloadRangeRetries  = 3
 	parallelDownloadMinimumSize   = 8 << 20
 	parallelDownloadProgressEvery = 120 * time.Millisecond
+	parallelDownloadHeaderTimeout = 15 * time.Second
 	downloadDispatcherHostname    = "download-dispatch.syngnat.top"
 	downloadDispatcherPath        = "/v1/resolve"
 	downloadDispatcherMaxResponse = 64 << 10
@@ -34,6 +35,12 @@ const (
 )
 
 var errParallelRangeUnsupported = errors.New("download source does not support validated byte ranges")
+
+type downloadCurrentAssetMismatchError struct{}
+
+func (downloadCurrentAssetMismatchError) Error() string {
+	return "download dispatcher reports that the dev asset is no longer current"
+}
 
 type dispatcherDownloadCandidate struct {
 	Source string `json:"source"`
@@ -62,6 +69,42 @@ func downloadDispatcherAssetPath(rawURL string) (string, bool) {
 	}
 	assetPath := strings.TrimSpace(parsed.Query().Get("path"))
 	return assetPath, strings.HasPrefix(assetPath, "/")
+}
+
+func downloadDispatcherURLRequiringCurrentDevAsset(rawURL string) string {
+	assetPath, ok := downloadDispatcherAssetPath(rawURL)
+	if !ok || !strings.HasPrefix(assetPath, "/gonavi/dev/releases/download/") {
+		return strings.TrimSpace(rawURL)
+	}
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return strings.TrimSpace(rawURL)
+	}
+	query := parsed.Query()
+	query.Set("require-current", "1")
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
+}
+
+func dispatcherURLRequiresCurrentDevAsset(rawURL string) bool {
+	assetPath, ok := downloadDispatcherAssetPath(rawURL)
+	if !ok || !strings.HasPrefix(assetPath, "/gonavi/dev/releases/download/") {
+		return false
+	}
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	return err == nil && parsed.Query().Get("require-current") == "1"
+}
+
+func shouldResolveDispatcherFallback(rawURL string, expectedSize int64, downloadErr error) bool {
+	if expectedSize <= 0 || dispatcherURLRequiresCurrentDevAsset(rawURL) {
+		return false
+	}
+	var currentAssetMismatch downloadCurrentAssetMismatchError
+	if errors.As(downloadErr, &currentAssetMismatch) {
+		return false
+	}
+	_, isDispatcher := downloadDispatcherAssetPath(rawURL)
+	return isDispatcher
 }
 
 func validatedHTTPSDownloadCandidates(value dispatcherDownloadResponse) []string {
@@ -159,6 +202,16 @@ func newDownloadRangeRequest(ctx context.Context, rawURL string, start, end int6
 	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
 	applyGitHubDownloadRequestHeaders(req, isGitHubReleaseAssetAPIURL(rawURL))
 	return req, nil
+}
+
+func downloadRangeClient(client *http.Client) *http.Client {
+	rangeClient := *client
+	if transport, ok := client.Transport.(*http.Transport); ok && transport != nil {
+		cloned := transport.Clone()
+		cloned.ResponseHeaderTimeout = parallelDownloadHeaderTimeout
+		rangeClient.Transport = cloned
+	}
+	return &rangeClient
 }
 
 type downloadCandidateProbe struct {
@@ -427,11 +480,20 @@ func downloadOneValidatedRange(
 		} else {
 			parsed, rangeErr := parseValidatedContentRange(resp.Header.Get("Content-Range"))
 			if resp.StatusCode != http.StatusPartialContent || rangeErr != nil || parsed.start != start || parsed.end != end || parsed.total != total || resp.ContentLength != wantLength {
+				status := resp.StatusCode
+				body, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
 				_ = resp.Body.Close()
-				if resp.StatusCode == http.StatusOK {
+				if status == http.StatusOK {
 					return errParallelRangeUnsupported
 				}
-				lastErr = fmt.Errorf("range response validation failed: status=%d content-range=%q content-length=%d", resp.StatusCode, resp.Header.Get("Content-Range"), resp.ContentLength)
+				if status == http.StatusConflict && dispatcherURLRequiresCurrentDevAsset(rawURL) {
+					return downloadCurrentAssetMismatchError{}
+				}
+				if status == http.StatusNotFound || status == http.StatusGone || status == http.StatusConflict {
+					return classifyGitHubUpdateHTTPError(status, body, resp.Header, false)
+				} else {
+					lastErr = fmt.Errorf("range response validation failed: status=%d content-range=%q content-length=%d", status, resp.Header.Get("Content-Range"), resp.ContentLength)
+				}
 			} else {
 				writer := io.NewOffsetWriter(file, start)
 				progressWriter := &rangeProgressWriter{segmentIndex: segmentIndex, progress: progress}
@@ -566,6 +628,7 @@ type rangeDownloadOutcome struct {
 func (session *persistentRangeDownload) attempt(client *http.Client, rawURL string) (bool, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	rangeClient := downloadRangeClient(client)
 	outcomes := make(chan rangeDownloadOutcome, session.workerCount)
 	launched := 0
 	for index := 0; index < session.workerCount; index++ {
@@ -582,22 +645,44 @@ func (session *persistentRangeDownload) attempt(client *http.Client, rawURL stri
 			outcomes <- rangeDownloadOutcome{
 				index: index,
 				err: downloadOneValidatedRange(
-					ctx, client, rawURL, session.file, index, start, end, session.total, session.progress,
+					ctx, rangeClient, rawURL, session.file, index, start, end, session.total, session.progress,
 				),
 			}
 		}(index, start, end)
 	}
 	var firstErr error
+	var unsupportedErr error
+	var terminalAssetError error
 	for count := 0; count < launched; count++ {
 		outcome := <-outcomes
 		if outcome.err == nil {
 			session.completed[outcome.index] = true
 			continue
 		}
+		if errors.Is(outcome.err, errParallelRangeUnsupported) {
+			// Other workers may observe context.Canceled after this worker
+			// cancels the group. Preserve the decisive unsupported-range error
+			// so the caller can perform the sequential fallback.
+			unsupportedErr = errParallelRangeUnsupported
+		}
+		var mismatch downloadCurrentAssetMismatchError
+		var localized localizedUpdateError
+		if errors.As(outcome.err, &mismatch) ||
+			(errors.As(outcome.err, &localized) &&
+				(localized.httpStatus == http.StatusNotFound || localized.httpStatus == http.StatusGone)) {
+			// Cancellation races must not hide an expired or superseded dev asset.
+			terminalAssetError = outcome.err
+		}
 		if firstErr == nil {
 			firstErr = outcome.err
 			cancel()
 		}
+	}
+	if terminalAssetError != nil {
+		return false, terminalAssetError
+	}
+	if unsupportedErr != nil {
+		return false, unsupportedErr
 	}
 	if firstErr != nil {
 		return false, firstErr
@@ -666,6 +751,9 @@ func downloadFileWithHashSequential(
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusConflict && dispatcherURLRequiresCurrentDevAsset(rawURL) {
+			return "", downloadCurrentAssetMismatchError{}
+		}
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
 		return "", classifyGitHubUpdateHTTPError(resp.StatusCode, body, resp.Header, false)
 	}
@@ -712,17 +800,53 @@ func downloadFileWithHashParallelAware(
 	onProgress func(downloaded, total int64),
 	timeout time.Duration,
 ) (string, error) {
+	return downloadFileWithHashParallelAwareAndExpectedSize(rawURL, filePath, onProgress, timeout, 0)
+}
+
+func downloadFileWithHashParallelAwareAndExpectedSize(
+	rawURL string,
+	filePath string,
+	onProgress func(downloaded, total int64),
+	timeout time.Duration,
+	expectedSize int64,
+) (string, error) {
 	if timeout <= 0 {
 		timeout = 10 * time.Minute
 	}
 	client := newStrictHTTPClientWithGlobalProxy(timeout)
-	candidates, dispatcherErr := resolveDispatcherDownloadCandidates(client, rawURL)
-	if dispatcherErr != nil {
-		// The 302 endpoint remains a compatibility fallback when JSON resolution is
-		// temporarily unavailable. It still uses normal TLS and pins its redirect.
+	var candidates []string
+	var dispatcherErr error
+	if expectedSize > 0 && func() bool {
+		_, ok := downloadDispatcherAssetPath(rawURL)
+		return ok
+	}() {
+		// The manifest already authenticates the asset size. Resolve the dispatcher
+		// redirect only after the Range path starts, avoiding JSON resolution and a
+		// separate 256 KiB probe on the healthy path.
 		candidates = []string{strings.TrimSpace(rawURL)}
+	} else {
+		candidates, dispatcherErr = resolveDispatcherDownloadCandidates(client, rawURL)
+		if dispatcherErr != nil {
+			// The 302 endpoint remains a compatibility fallback when JSON resolution
+			// is temporarily unavailable. It still uses normal TLS.
+			candidates = []string{strings.TrimSpace(rawURL)}
+		}
 	}
-	return downloadFileWithHashFromCandidates(client, candidates, filePath, onProgress, dispatcherErr)
+	result, err := downloadFileWithHashFromCandidatesWithExpectedSize(client, candidates, filePath, onProgress, dispatcherErr, expectedSize)
+	if err == nil || len(candidates) != 1 || expectedSize <= 0 {
+		return result, err
+	}
+	if !shouldResolveDispatcherFallback(candidates[0], expectedSize, err) {
+		return result, err
+	}
+	// Older cached manifests may omit AssetAPIURL. Only pay for the dispatcher
+	// JSON fallback after the zero-probe path fails, so GitHub remains available
+	// without adding latency to healthy DMIT downloads.
+	fallbackCandidates, resolveErr := resolveDispatcherDownloadCandidates(client, candidates[0])
+	if resolveErr != nil {
+		return result, errors.Join(err, resolveErr)
+	}
+	return downloadFileWithHashFromCandidatesWithExpectedSize(client, fallbackCandidates, filePath, onProgress, err, expectedSize)
 }
 
 func downloadFileWithHashFromCandidates(
@@ -731,6 +855,17 @@ func downloadFileWithHashFromCandidates(
 	filePath string,
 	onProgress func(downloaded, total int64),
 	initialErr error,
+) (string, error) {
+	return downloadFileWithHashFromCandidatesWithExpectedSize(client, candidates, filePath, onProgress, initialErr, 0)
+}
+
+func downloadFileWithHashFromCandidatesWithExpectedSize(
+	client *http.Client,
+	candidates []string,
+	filePath string,
+	onProgress func(downloaded, total int64),
+	initialErr error,
+	expectedSize int64,
 ) (string, error) {
 	errorsBySource := make([]error, 0, len(candidates)+1)
 	if initialErr != nil {
@@ -746,7 +881,22 @@ func downloadFileWithHashFromCandidates(
 		// The Dispatcher order is strict: probe and download a candidate before
 		// touching its fallback, so an unreachable GitHub endpoint cannot hold an
 		// otherwise healthy DMIT download at 0%.
-		ranked, probeErrors := rankDownloadCandidates(client, []string{candidate})
+		var ranked []downloadCandidateProbe
+		var probeErrors []error
+		if expectedSize > 0 {
+			// The manifest authenticates the size, so workers can issue their real
+			// requests through the Dispatcher immediately. Do not serially probe
+			// bytes=0-0 first: a slow redirect was leaving the UI at 0% for seconds.
+			ranked = []downloadCandidateProbe{{
+				candidate:     strings.TrimSpace(candidate),
+				resolvedURL:   strings.TrimSpace(candidate),
+				total:         expectedSize,
+				supportsRange: true,
+			}}
+		}
+		if len(ranked) == 0 {
+			ranked, probeErrors = rankDownloadCandidates(client, []string{candidate})
+		}
 		errorsBySource = append(errorsBySource, probeErrors...)
 		if len(ranked) == 0 {
 			continue

--- a/internal/app/parallel_download_test.go
+++ b/internal/app/parallel_download_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -16,6 +18,34 @@ import (
 	"testing"
 	"time"
 )
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+func localDispatcherClient(t *testing.T, serverURL string) *http.Client {
+	t.Helper()
+	target, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatalf("parse local Dispatcher server URL: %v", err)
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	return &http.Client{Timeout: 30 * time.Second, Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Hostname() != downloadDispatcherHostname {
+			return nil, fmt.Errorf("unexpected Dispatcher request host %q", request.URL.Hostname())
+		}
+		forwarded := request.Clone(request.Context())
+		rewrittenURL := *request.URL
+		rewrittenURL.Scheme = target.Scheme
+		rewrittenURL.Host = target.Host
+		forwarded.URL = &rewrittenURL
+		forwarded.Host = ""
+		return transport.RoundTrip(forwarded)
+	})}
+}
 
 func TestParseValidatedContentRange(t *testing.T) {
 	parsed, err := parseValidatedContentRange("bytes 10-19/100")
@@ -42,6 +72,51 @@ func TestValidatedHTTPSDownloadCandidatesAcceptsPublicIPTLSURL(t *testing.T) {
 	want := []string{"https://192.0.2.1/gonavi/releases/download/v1/GoNavi.zip"}
 	if len(got) != len(want) || got[0] != want[0] {
 		t.Fatalf("unexpected validated candidates: %#v", got)
+	}
+}
+
+func TestDownloadDispatcherURLRequiringCurrentDevAsset(t *testing.T) {
+	devAsset := "https://download-dispatch.syngnat.top/v1/resolve?path=%2Fgonavi%2Fdev%2Freleases%2Fdownload%2Fdev-abc1234%2FGoNavi-dev-abc1234-Windows-Amd64-Portable.zip"
+	parsed, err := url.Parse(downloadDispatcherURLRequiringCurrentDevAsset(devAsset))
+	if err != nil {
+		t.Fatalf("parse gated dev URL: %v", err)
+	}
+	if parsed.Query().Get("require-current") != "1" {
+		t.Fatalf("gated dev URL = %q", parsed.String())
+	}
+
+	stableAsset := "https://download-dispatch.syngnat.top/v1/resolve?path=%2Fgonavi%2Freleases%2Fdownload%2Fv1.2.3%2FGoNavi-1.2.3-Windows-Amd64-Portable.zip"
+	if got := downloadDispatcherURLRequiringCurrentDevAsset(stableAsset); got != stableAsset {
+		t.Fatalf("stable URL changed: %q", got)
+	}
+}
+
+func TestDownloadRangeClientSetsResponseHeaderTimeoutForStandardTransport(t *testing.T) {
+	client := &http.Client{Transport: http.DefaultTransport.(*http.Transport).Clone()}
+	rangeClient := downloadRangeClient(client)
+	if rangeClient == client {
+		t.Fatal("expected a distinct range client")
+	}
+	transport, ok := rangeClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("range transport = %T, want *http.Transport", rangeClient.Transport)
+	}
+	if transport.ResponseHeaderTimeout != parallelDownloadHeaderTimeout {
+		t.Fatalf("header timeout = %s, want %s", transport.ResponseHeaderTimeout, parallelDownloadHeaderTimeout)
+	}
+}
+
+func TestShouldResolveDispatcherFallbackRejectsGatedDevAsset(t *testing.T) {
+	gated := downloadDispatcherURLRequiringCurrentDevAsset(
+		"https://download-dispatch.syngnat.top/v1/resolve?path=%2Fgonavi%2Fdev%2Freleases%2Fdownload%2Fdev-abc1234%2FGoNavi.zip",
+	)
+	if shouldResolveDispatcherFallback(gated, parallelDownloadMinimumSize, errors.New("DMIT unavailable")) {
+		t.Fatal("gated dev asset must not resolve JSON fallback candidates")
+	}
+
+	stable := "https://download-dispatch.syngnat.top/v1/resolve?path=%2Fgonavi%2Freleases%2Fdownload%2Fv1.2.3%2FGoNavi.zip"
+	if !shouldResolveDispatcherFallback(stable, parallelDownloadMinimumSize, errors.New("DMIT unavailable")) {
+		t.Fatal("stable dispatcher asset should retain JSON fallback candidates")
 	}
 }
 
@@ -109,6 +184,258 @@ func TestDownloadFileWithHashParallelAwareUsesEightValidatedRanges(t *testing.T)
 	delete(requested, probeRange)
 	if len(requested) != parallelDownloadWorkers {
 		t.Fatalf("expected %d parallel ranges, got %d: %#v", parallelDownloadWorkers, len(requested), requested)
+	}
+}
+
+func TestDownloadFileWithHashFromCandidatesUsesExpectedSizeWithoutProbe(t *testing.T) {
+	payload := bytes.Repeat([]byte("expected-size-range"), (parallelDownloadMinimumSize/len("expected-size-range"))+1)
+	payload = payload[:parallelDownloadMinimumSize]
+	wantHashBytes := sha256.Sum256(payload)
+	wantHash := hex.EncodeToString(wantHashBytes[:])
+	var probeHits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		rawRange := request.Header.Get("Range")
+		if rawRange == fmt.Sprintf("bytes=0-%d", downloadCandidateProbeBytes-1) {
+			probeHits.Add(1)
+			http.Error(writer, "standalone probe must not be requested", http.StatusServiceUnavailable)
+			return
+		}
+		parts := strings.Split(strings.TrimPrefix(rawRange, "bytes="), "-")
+		if len(parts) != 2 {
+			http.Error(writer, "missing range", http.StatusBadRequest)
+			return
+		}
+		start, startErr := strconv.ParseInt(parts[0], 10, 64)
+		end, endErr := strconv.ParseInt(parts[1], 10, 64)
+		if startErr != nil || endErr != nil || start < 0 || end < start || end >= int64(len(payload)) {
+			http.Error(writer, "invalid range", http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		body := payload[start : end+1]
+		writer.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(payload)))
+		writer.Header().Set("Content-Length", strconv.FormatInt(int64(len(body)), 10))
+		writer.WriteHeader(http.StatusPartialContent)
+		_, _ = writer.Write(body)
+	}))
+	defer server.Close()
+
+	target := filepath.Join(t.TempDir(), "expected-size.zip")
+	gotHash, err := downloadFileWithHashFromCandidatesWithExpectedSize(
+		&http.Client{Timeout: 30 * time.Second},
+		[]string{server.URL + "/asset.zip"},
+		target,
+		nil,
+		nil,
+		int64(len(payload)),
+	)
+	if err != nil {
+		t.Fatalf("expected-size parallel download: %v", err)
+	}
+	if gotHash != wantHash {
+		t.Fatalf("hash mismatch: got %s want %s", gotHash, wantHash)
+	}
+	if got := probeHits.Load(); got != 0 {
+		t.Fatalf("expected no standalone range probe, got %d", got)
+	}
+}
+
+func TestDownloadFileWithHashFromCandidatesExpectedSizeFallsBackWhenRangeIsUnsupported(t *testing.T) {
+	payload := bytes.Repeat([]byte("expected-size-sequential"), (parallelDownloadMinimumSize/len("expected-size-sequential"))+1)
+	payload = payload[:parallelDownloadMinimumSize]
+	var rangeRequests atomic.Int32
+	var sequentialRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Header.Get("Range") != "" {
+			rangeRequests.Add(1)
+			writer.WriteHeader(http.StatusOK)
+			return
+		}
+		sequentialRequests.Add(1)
+		writer.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+		_, _ = writer.Write(payload)
+	}))
+	defer server.Close()
+
+	target := filepath.Join(t.TempDir(), "expected-size-sequential.zip")
+	gotHash, err := downloadFileWithHashFromCandidatesWithExpectedSize(
+		&http.Client{Timeout: 30 * time.Second},
+		[]string{server.URL + "/asset.zip"},
+		target,
+		nil,
+		nil,
+		int64(len(payload)),
+	)
+	if err != nil {
+		t.Fatalf("expected sequential fallback to succeed: %v", err)
+	}
+	wantHash := sha256.Sum256(payload)
+	if gotHash != hex.EncodeToString(wantHash[:]) {
+		t.Fatalf("hash mismatch: got %s want %s", gotHash, hex.EncodeToString(wantHash[:]))
+	}
+	if got := sequentialRequests.Load(); got != 1 {
+		t.Fatalf("expected one sequential fallback request, got %d", got)
+	}
+	if got := rangeRequests.Load(); got < 1 {
+		t.Fatalf("expected range workers to detect unsupported ranges, got %d requests", got)
+	}
+}
+
+func TestDownloadFileWithHashFromCandidatesExpectedSizePreservesNotFoundStatus(t *testing.T) {
+	var rangeRequests atomic.Int32
+	var nonRangeRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Header.Get("Range") == "" {
+			nonRangeRequests.Add(1)
+		} else {
+			rangeRequests.Add(1)
+		}
+		http.NotFound(writer, request)
+	}))
+	defer server.Close()
+
+	_, err := downloadFileWithHashFromCandidatesWithExpectedSize(
+		&http.Client{Timeout: 30 * time.Second},
+		[]string{server.URL + "/missing.zip"},
+		filepath.Join(t.TempDir(), "missing.zip"),
+		nil,
+		nil,
+		parallelDownloadMinimumSize,
+	)
+	if err == nil {
+		t.Fatal("expected missing expected-size asset to fail")
+	}
+	if got := rangeRequests.Load(); got == 0 {
+		t.Fatal("expected the range workers to request the missing asset")
+	}
+	if got := nonRangeRequests.Load(); got != 0 {
+		t.Fatalf("expected no sequential or probe request, got %d", got)
+	}
+	var localized localizedUpdateError
+	if !errors.As(err, &localized) {
+		t.Fatalf("expected typed HTTP error, got %T %v", err, err)
+	}
+	if localized.httpStatus != http.StatusNotFound {
+		t.Fatalf("HTTP status = %d, want %d", localized.httpStatus, http.StatusNotFound)
+	}
+}
+
+func TestDownloadFileWithHashFromCandidatesExpectedSizePreservesGatedCurrentAssetMismatch(t *testing.T) {
+	var rangeRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != downloadDispatcherPath || request.URL.Query().Get("require-current") != "1" {
+			http.Error(writer, "unexpected Dispatcher request", http.StatusBadRequest)
+			return
+		}
+		if request.Header.Get("Range") == "" {
+			t.Errorf("expected-size download must not fall back to a sequential request")
+		}
+		rangeRequests.Add(1)
+		http.Error(writer, "current dev asset changed", http.StatusConflict)
+	}))
+	defer server.Close()
+	client := localDispatcherClient(t, server.URL)
+	gated := downloadDispatcherURLRequiringCurrentDevAsset(
+		"https://download-dispatch.syngnat.top/v1/resolve?path=%2Fgonavi%2Fdev%2Freleases%2Fdownload%2Fdev-abc1234%2FGoNavi.zip",
+	)
+
+	_, err := downloadFileWithHashFromCandidatesWithExpectedSize(
+		client,
+		[]string{gated},
+		filepath.Join(t.TempDir(), "missing.zip"),
+		nil,
+		nil,
+		parallelDownloadMinimumSize,
+	)
+	if err == nil {
+		t.Fatal("expected superseded expected-size asset to fail")
+	}
+	var mismatch downloadCurrentAssetMismatchError
+	if !errors.As(err, &mismatch) {
+		t.Fatalf("expected current dev asset mismatch, got %T %v", err, err)
+	}
+	if got := rangeRequests.Load(); got == 0 {
+		t.Fatal("expected at least one gated range request")
+	}
+}
+
+func TestDownloadFileWithHashFromCandidatesSequentialGatedCurrentAssetMismatch(t *testing.T) {
+	var sequentialRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != downloadDispatcherPath || request.URL.Query().Get("require-current") != "1" {
+			http.Error(writer, "unexpected Dispatcher request", http.StatusBadRequest)
+			return
+		}
+		if request.Header.Get("Range") != "" {
+			t.Errorf("small package must use the sequential request path")
+		}
+		sequentialRequests.Add(1)
+		http.Error(writer, "current dev asset changed", http.StatusConflict)
+	}))
+	defer server.Close()
+	gated := downloadDispatcherURLRequiringCurrentDevAsset(
+		"https://download-dispatch.syngnat.top/v1/resolve?path=%2Fgonavi%2Fdev%2Freleases%2Fdownload%2Fdev-abc1234%2FGoNavi.zip",
+	)
+
+	_, err := downloadFileWithHashFromCandidatesWithExpectedSize(
+		localDispatcherClient(t, server.URL),
+		[]string{gated},
+		filepath.Join(t.TempDir(), "superseded-small.zip"),
+		nil,
+		nil,
+		1024,
+	)
+	if err == nil {
+		t.Fatal("expected superseded sequential asset to fail")
+	}
+	var mismatch downloadCurrentAssetMismatchError
+	if !errors.As(err, &mismatch) {
+		t.Fatalf("expected current dev asset mismatch, got %T %v", err, err)
+	}
+	if got := sequentialRequests.Load(); got != 1 {
+		t.Fatalf("sequential requests = %d, want 1", got)
+	}
+}
+
+func TestDownloadFileWithHashFromCandidatesKeepsUngatedConflictAsHTTPError(t *testing.T) {
+	var sequentialRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Query().Get("require-current") != "" {
+			http.Error(writer, "ungated request unexpectedly required current asset", http.StatusBadRequest)
+			return
+		}
+		if request.Header.Get("Range") != "" {
+			t.Errorf("small package must use the sequential request path")
+		}
+		sequentialRequests.Add(1)
+		http.Error(writer, "ordinary conflict", http.StatusConflict)
+	}))
+	defer server.Close()
+	ungated := "https://download-dispatch.syngnat.top/v1/resolve?path=%2Fgonavi%2Fdev%2Freleases%2Fdownload%2Fdev-abc1234%2FGoNavi.zip"
+
+	_, err := downloadFileWithHashFromCandidatesWithExpectedSize(
+		localDispatcherClient(t, server.URL),
+		[]string{ungated},
+		filepath.Join(t.TempDir(), "ordinary-conflict.zip"),
+		nil,
+		nil,
+		1024,
+	)
+	if err == nil {
+		t.Fatal("expected ordinary conflict to fail")
+	}
+	var mismatch downloadCurrentAssetMismatchError
+	if errors.As(err, &mismatch) {
+		t.Fatalf("ungated conflict incorrectly became current asset mismatch: %v", err)
+	}
+	var localized localizedUpdateError
+	if !errors.As(err, &localized) {
+		t.Fatalf("expected typed HTTP error, got %T %v", err, err)
+	}
+	if localized.httpStatus != http.StatusConflict {
+		t.Fatalf("HTTP status = %d, want %d", localized.httpStatus, http.StatusConflict)
+	}
+	if got := sequentialRequests.Load(); got != 1 {
+		t.Fatalf("sequential requests = %d, want 1", got)
 	}
 }
 
@@ -193,6 +520,71 @@ func TestDownloadFileWithHashParallelAwarePinsRedirectTargetForAllRanges(t *test
 	defer targetMu.Unlock()
 	if targetRequests != parallelDownloadWorkers+1 {
 		t.Fatalf("expected probe plus %d pinned ranges, got %d", parallelDownloadWorkers, targetRequests)
+	}
+}
+
+func TestDownloadFileWithHashFromCandidatesExpectedSizeFollowsRedirectsWithoutProbe(t *testing.T) {
+	payload := bytes.Repeat([]byte("expected-size-redirect"), (parallelDownloadMinimumSize/len("expected-size-redirect"))+1)
+	payload = payload[:parallelDownloadMinimumSize]
+	var dispatcherRequests atomic.Int32
+	var intermediateRequests atomic.Int32
+	var targetRequests atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		targetRequests.Add(1)
+		rawRange := strings.TrimPrefix(request.Header.Get("Range"), "bytes=")
+		parts := strings.Split(rawRange, "-")
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			http.Error(writer, "missing range", http.StatusBadRequest)
+			return
+		}
+		start, startErr := strconv.ParseInt(parts[0], 10, 64)
+		end, endErr := strconv.ParseInt(parts[1], 10, 64)
+		if startErr != nil || endErr != nil || start < 0 || end < start || end >= int64(len(payload)) {
+			http.Error(writer, "invalid range", http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		body := payload[start : end+1]
+		writer.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(payload)))
+		writer.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		writer.WriteHeader(http.StatusPartialContent)
+		_, _ = writer.Write(body)
+	}))
+	defer target.Close()
+	intermediate := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		intermediateRequests.Add(1)
+		http.Redirect(writer, request, target.URL+"/asset.zip", http.StatusFound)
+	}))
+	defer intermediate.Close()
+	dispatcher := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		dispatcherRequests.Add(1)
+		http.Redirect(writer, request, intermediate.URL+"/release", http.StatusFound)
+	}))
+	defer dispatcher.Close()
+
+	targetPath := filepath.Join(t.TempDir(), "expected-size-redirect.zip")
+	gotHash, err := downloadFileWithHashFromCandidatesWithExpectedSize(
+		&http.Client{Timeout: 30 * time.Second},
+		[]string{dispatcher.URL + "/resolve"},
+		targetPath,
+		nil,
+		nil,
+		int64(len(payload)),
+	)
+	if err != nil {
+		t.Fatalf("expected-size redirected download: %v", err)
+	}
+	wantHash := sha256.Sum256(payload)
+	if gotHash != hex.EncodeToString(wantHash[:]) {
+		t.Fatalf("hash mismatch: got %s want %s", gotHash, hex.EncodeToString(wantHash[:]))
+	}
+	if got := dispatcherRequests.Load(); got != parallelDownloadWorkers {
+		t.Fatalf("expected %d dispatcher range requests without an independent probe, got %d", parallelDownloadWorkers, got)
+	}
+	if got := intermediateRequests.Load(); got != parallelDownloadWorkers {
+		t.Fatalf("expected %d intermediate range requests without an independent probe, got %d", parallelDownloadWorkers, got)
+	}
+	if got := targetRequests.Load(); got != parallelDownloadWorkers {
+		t.Fatalf("expected %d target range requests without an independent probe, got %d", parallelDownloadWorkers, got)
 	}
 }
 

--- a/internal/app/update_manifest.go
+++ b/internal/app/update_manifest.go
@@ -262,12 +262,20 @@ func fetchStaticUpdateManifestPayloadFromURL(channel updateChannel, manifestURL 
 		return nil, fmt.Errorf("static update manifest URL is empty")
 	}
 	client := newStrictHTTPClientWithGlobalProxy(15 * time.Second)
+	failures := make([]error, 0, 3)
+	if _, isDispatcher := downloadDispatcherAssetPath(rawURL); isDispatcher {
+		// The normal dispatcher response is a 302 to the selected mirror. Follow
+		// that redirect directly so a healthy manifest costs one request; JSON
+		// candidate resolution remains a fallback for routing or mirror failures.
+		if manifest, directErr := fetchStaticUpdateManifestCandidate(client, channel, rawURL); directErr == nil {
+			return manifest, nil
+		} else {
+			failures = append(failures, fmt.Errorf("%s: %w", redactDownloadURL(rawURL), directErr))
+		}
+	}
 	candidates, resolveErr := resolveDispatcherDownloadCandidates(client, rawURL)
 	if resolveErr != nil {
 		candidates = []string{rawURL}
-	}
-	failures := make([]error, 0, len(candidates)+1)
-	if resolveErr != nil {
 		failures = append(failures, resolveErr)
 	}
 	for _, candidate := range candidates {


### PR DESCRIPTION
## 变更
- 点击下载后复用已校验的 dev 更新信息，跳过健康路径上的清单刷新、Dispatcher JSON 解析和独立 Range 探测。
- 使用已校验的资产大小直接启动真实 Range 下载，并立即显示下载中。
- Dispatcher 仅保留 DMIT；当前 dev 资产失效时返回可识别的 409/503，不回退到旧包或 GitHub。
- 补充顺序下载、回退、Worker 和前端回归测试。

## 验证
- `go test ./internal/app -count=1 -timeout=180s`
- `go test -race ./internal/app -run TestDownloadFileWithHashFromCandidates -count=1`
- `npm --prefix deploy/download-dispatcher test -- --run`
- `npm --prefix deploy/download-dispatcher run typecheck`
- `npm --prefix frontend test -- --run src/hooks/useAppUpdateManager.test.tsx`
- `npm --prefix frontend run build`
