### PR TITLE
✨ feat(ui): 统一查询工作台菜单与编辑器右键交互

### DIFF
--- a/frontend/src/components/QueryEditor.results-and-drop.test.tsx
+++ b/frontend/src/components/QueryEditor.results-and-drop.test.tsx
@@ -25,6 +25,7 @@ import QueryEditorResultsPanel, {
   resolveEffectiveActiveResultKey,
   shouldActivateResultTabDetachPointer,
 } from './QueryEditorResultsPanel';
+import QueryEditorToolbar from './QueryEditorToolbar';
 
 const mountedRenderers = new Set<ReactTestRenderer>();
 const create = (...args: Parameters<typeof createRenderer>): ReactTestRenderer => {
@@ -78,7 +79,7 @@ const storeState = vi.hoisted(() => ({
     sqlEditorFontSize: null as number | null,
     sqlEditorFontSizeFollowGlobal: true,
   },
-  sqlFormatOptions: { keywordCase: 'upper' as const },
+  sqlFormatOptions: { keywordCase: 'upper' as 'upper' | 'lower' },
   setSqlFormatOptions: vi.fn(),
   queryOptions: {
     maxRows: 5000,
@@ -432,19 +433,30 @@ vi.mock('@ant-design/icons', () => {
   const Icon = () => <span />;
   return {
     BugOutlined: Icon,
+    ArrowDownOutlined: Icon,
+    ArrowUpOutlined: Icon,
+    BulbOutlined: Icon,
+    CheckOutlined: Icon,
     ClearOutlined: Icon,
+    CodeOutlined: Icon,
     CopyOutlined: Icon,
     DiffOutlined: Icon,
+    EditOutlined: Icon,
     ExportOutlined: Icon,
+    FileTextOutlined: Icon,
+    HistoryOutlined: Icon,
+    KeyOutlined: Icon,
     TableOutlined: Icon,
     ArrowLeftOutlined: Icon,
     ArrowRightOutlined: Icon,
     PlayCircleOutlined: Icon,
     SaveOutlined: Icon,
+    UndoOutlined: Icon,
     FormatPainterOutlined: Icon,
     SettingOutlined: Icon,
     CloseOutlined: Icon,
     StopOutlined: Icon,
+    ThunderboltOutlined: Icon,
     DownOutlined: Icon,
     RobotOutlined: Icon,
     SearchOutlined: Icon,
@@ -731,6 +743,100 @@ describe('QueryEditor external SQL save', () => {
     });
   });
 
+  it('closes non-log result tabs with the middle mouse button and leaves the log tab unchanged', async () => {
+    vi.stubGlobal('window', {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    const onCloseResult = vi.fn();
+    let renderer!: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        <QueryEditorResultsPanel
+          resultSets={[{
+            key: 'result-1',
+            sql: 'select 1',
+            rows: [{ value: 1 }],
+            columns: ['value'],
+            pkColumns: [],
+            readOnly: true,
+          }]}
+          activeResultKey="result-1"
+          isActive
+          loading={false}
+          executionError=""
+          sqlLogCount={1}
+          darkMode={false}
+          isV2Ui
+          currentDb="main"
+          currentConnectionId="conn-1"
+          toggleShortcutLabel=""
+          onActiveResultKeyChange={vi.fn()}
+          onHide={vi.fn()}
+          onCloseResult={onCloseResult}
+          onCloseOtherResultTabs={vi.fn()}
+          onCloseResultTabsToLeft={vi.fn()}
+          onCloseResultTabsToRight={vi.fn()}
+          onCloseAllResultTabs={vi.fn()}
+          onResultPinnedChange={vi.fn()}
+          onReloadResult={vi.fn()}
+          onResultPageChange={vi.fn()}
+          onResultSort={vi.fn()}
+          onDiagnoseExecutionError={vi.fn()}
+        />,
+      );
+    });
+
+    const resultTabLabel = renderer.root.findAll((node) =>
+      typeof node.props?.onPointerDown === 'function'
+      && String(node.props?.className || '').split(/\s+/).includes('query-result-tab-label'),
+    )[0];
+    const logTabLabel = renderer.root.findAll((node) =>
+      typeof node.props?.onPointerDown !== 'function'
+      && String(node.props?.className || '').split(/\s+/).includes('query-result-tab-label'),
+    )[0];
+    expect(resultTabLabel.props.onMouseDown).toEqual(expect.any(Function));
+    expect(resultTabLabel.props.onAuxClick).toEqual(expect.any(Function));
+    expect(logTabLabel.props.onMouseDown).toBeUndefined();
+    expect(logTabLabel.props.onAuxClick).toBeUndefined();
+
+    const mouseDownEvent = { button: 1, preventDefault: vi.fn(), stopPropagation: vi.fn() };
+    resultTabLabel.props.onMouseDown(mouseDownEvent);
+    expect(mouseDownEvent.preventDefault).toHaveBeenCalledOnce();
+    expect(mouseDownEvent.stopPropagation).toHaveBeenCalledOnce();
+    expect(onCloseResult).not.toHaveBeenCalled();
+
+    const auxClickEvent = { button: 1, preventDefault: vi.fn(), stopPropagation: vi.fn() };
+    resultTabLabel.props.onAuxClick(auxClickEvent);
+    expect(auxClickEvent.preventDefault).toHaveBeenCalledOnce();
+    expect(auxClickEvent.stopPropagation).toHaveBeenCalledOnce();
+    expect(onCloseResult).toHaveBeenCalledWith('result-1');
+
+    const rightAuxClickEvent = { button: 2, preventDefault: vi.fn(), stopPropagation: vi.fn() };
+    resultTabLabel.props.onAuxClick(rightAuxClickEvent);
+    expect(rightAuxClickEvent.preventDefault).not.toHaveBeenCalled();
+    expect(rightAuxClickEvent.stopPropagation).not.toHaveBeenCalled();
+    expect(onCloseResult).toHaveBeenCalledTimes(1);
+    renderer.unmount();
+  });
+
+  it('passes the current keyword case to the format menu selection', async () => {
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<QueryEditor tab={createTab()} />);
+    });
+
+    expect(renderer.root.findByType(QueryEditorToolbar).props.formatSettingsSelectedKeys).toEqual(['upper']);
+
+    await act(async () => {
+      storeState.sqlFormatOptions = { keywordCase: 'lower' };
+      notifyStoreSubscribers();
+    });
+    expect(renderer.root.findByType(QueryEditorToolbar).props.formatSettingsSelectedKeys).toEqual(['lower']);
+    renderer.unmount();
+  });
+
   beforeEach(() => {
     const completionState = (globalThis as any).__gonaviSqlCompletionState;
     if (completionState) {
@@ -771,6 +877,7 @@ describe('QueryEditor external SQL save', () => {
     storeState.saveQuery.mockReset();
     storeState.saveQuery.mockImplementation(async (query: SavedQuery) => query);
     storeState.savedQueries = [];
+    storeState.sqlFormatOptions = { keywordCase: 'upper' };
     storeState.activeTabId = 'tab-1';
     storeState.aiPanelVisible = false;
     storeState.setAIPanelVisible.mockReset();
@@ -3363,6 +3470,22 @@ describe('QueryEditor external SQL save', () => {
     })).toHaveLength(0);
   });
 
+  it('uses the query-tab popup structure for result tab context menus', () => {
+    const source = readFileSync(new URL('./QueryEditorResultsPanel.tsx', import.meta.url), 'utf8');
+    const menuSource = source.slice(
+      source.indexOf('function buildResultTabMenuItems'),
+      source.indexOf('const resultTabItems'),
+    );
+    const popupSource = source.slice(
+      source.indexOf('const resultTabItems'),
+      source.indexOf('children: (() => {', source.indexOf('const resultTabItems')),
+    );
+
+    expect(menuSource).not.toContain("type: 'group'");
+    expect(menuSource).toContain("type: 'divider'");
+    expect(popupSource).toContain('showHeader: false');
+  });
+
   it('closes the active result tab directly without switching to the log tab', async () => {
     backendApp.DBQueryMulti.mockResolvedValueOnce({
       success: true,
@@ -3827,34 +3950,44 @@ describe('QueryEditor external SQL save', () => {
     expect(textContent(renderer!.toJSON())).not.toContain('结果 1 (2)');
   });
 
-  it('keeps query result tabs flush, full-height, and readable in v2 UI', () => {
+  it('keeps query result tabs and count badges compact in v2 UI', () => {
     const source = readFileSync(new URL('./QueryEditorResultsPanel.tsx', import.meta.url), 'utf8');
     const css = readV2ThemeCss();
-    const resultNavCss = css.slice(
+    const resultNavCss = source.slice(
+      source.indexOf('.query-result-tabs .ant-tabs-nav {'),
+      source.indexOf('.query-result-tabs .ant-tabs-nav-wrap {'),
+    );
+    const resultTabCss = source.slice(
+      source.indexOf('.query-result-tabs .ant-tabs-tab {'),
+      source.indexOf('.query-result-tabs .ant-tabs-tab-btn {'),
+    );
+    const resultCountCss = source.slice(
+      source.indexOf('.query-result-tab-count {'),
+      source.indexOf('.query-result-tab-close {'),
+    );
+
+    expect(resultNavCss).toContain('min-height: 36px;');
+    expect(resultTabCss).toContain('height: 30px !important;');
+    expect(resultTabCss).toContain('min-height: 30px;');
+    expect(resultCountCss).toContain('height: 17px;');
+    expect(resultCountCss).toContain('padding: 0 5px;');
+    expect(resultCountCss).toContain('border-radius: 3px;');
+    expect(resultCountCss).toContain('font-family: var(--gn-font-mono);');
+    expect(resultCountCss).toContain('font-size: 9.5px;');
+    expect(resultCountCss).not.toContain('border-radius: 999px;');
+
+    const workbenchResultCss = css.slice(
       css.indexOf('body[data-ui-version="v2"] .gn-v2-query-results .query-result-tabs > .ant-tabs-nav {'),
       css.indexOf('body[data-ui-version="v2"] .gn-v2-query-results .query-result-tabs > .ant-tabs-nav .ant-tabs-extra-content {'),
     );
-    const resultTabCss = css.slice(
+    const workbenchResultTabCss = css.slice(
       css.indexOf('body[data-ui-version="v2"] .gn-v2-query-results .query-result-tabs > .ant-tabs-nav .ant-tabs-tab {'),
-      css.indexOf('body[data-ui-version="v2"] .gn-v2-query-results .query-result-tabs > .ant-tabs-nav .ant-tabs-nav-list {'),
+      css.indexOf('body[data-ui-version="v2"] .gn-v2-query-results .query-result-tabs > .ant-tabs-nav .ant-tabs-nav-wrap,'),
     );
-    const resultNavSizingSelector = 'body[data-ui-version="v2"] .gn-v2-query-results .query-result-tabs > .ant-tabs-nav .ant-tabs-nav-wrap,';
-    const resultNavSizingStart = css.indexOf(resultNavSizingSelector);
-    const resultNavSizingCss = resultNavSizingStart >= 0
-      ? css.slice(resultNavSizingStart, css.indexOf('}', resultNavSizingStart) + 1)
-      : '';
-    expect(css).toContain('body[data-ui-version="v2"] .gn-v2-query-results .query-result-tabs > .ant-tabs-nav .ant-tabs-tab {');
-    expect(css).toContain('body[data-ui-version="v2"] .gn-v2-query-results .query-result-tabs > .ant-tabs-nav .ant-tabs-tab-btn {');
-    expect(resultNavCss).toContain('padding: 0 8px 0 0;');
-    expect(resultNavCss).toContain('min-height: 46px;');
-    expect(resultTabCss).toContain('height: 46px !important;');
-    expect(resultTabCss).toContain('margin: 0 !important;');
-    expect(resultTabCss).toContain('border-radius: 8px !important;');
-    expect(resultNavSizingCss).toContain(resultNavSizingSelector);
-    expect(resultNavSizingCss).toContain('body[data-ui-version="v2"] .gn-v2-query-results .query-result-tabs > .ant-tabs-nav .ant-tabs-nav-list {');
-    expect(resultNavSizingCss).toContain('min-height: 46px;');
-    expect(css).toContain('user-select: none;');
-    expect(css).toContain('body[data-ui-version="v2"] .gn-v2-query-results .query-result-tab-text {');
+    expect(workbenchResultCss).toContain('min-height: 36px;');
+    expect(workbenchResultTabCss).toContain('height: 30px !important;');
+    expect(workbenchResultTabCss).toContain('min-height: 30px;');
+    expect(workbenchResultTabCss).toContain('margin: 0 !important;');
   });
 
   it('connects each query result sort state and callback to DataGrid', async () => {

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -3,8 +3,6 @@ import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import Editor, { type BeforeMount, type OnMount } from './MonacoEditor';
 import { message, Input, Form, MenuProps, Button, Segmented, type InputRef } from 'antd';
 import {
-    ArrowDownOutlined,
-    ArrowUpOutlined,
     CodeOutlined,
     EditOutlined,
     ExportOutlined,
@@ -4809,23 +4807,10 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
 
       if (isV2Ui && typeof editor.onContextMenu === 'function') {
           editor.onContextMenu(() => {
-              const decorateContextMenu = () => {
-                  const connectionName = connectionsRef.current.find(
-                      (connection) => connection.id === currentConnectionIdRef.current,
-                  )?.name;
-                  const contextMeta = [connectionName, currentDbRef.current]
-                      .filter(Boolean)
-                      .join(' · ');
-                  decorateV2MonacoContextMenu(
-                      translate('tab_manager.kind_badge.query'),
-                      contextMeta || translate('query_editor.placeholder.database'),
-                  );
-              };
-              // Monaco appends the menu asynchronously after dispatching onContextMenu.
-              // Retry across the next paint window so the first open is decorated too.
-              window.setTimeout(decorateContextMenu, 0);
-              window.setTimeout(decorateContextMenu, 48);
-              window.setTimeout(decorateContextMenu, 120);
+              decorateV2MonacoContextMenu();
+              window.setTimeout(decorateV2MonacoContextMenu, 0);
+              window.setTimeout(decorateV2MonacoContextMenu, 48);
+              window.setTimeout(decorateV2MonacoContextMenu, 120);
           });
       }
 
@@ -7670,13 +7655,13 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
               {
                   key: 'upper',
                   label: translate('query_editor.format.keyword_upper'),
-                  icon: <ArrowUpOutlined />,
+                  icon: <span aria-hidden="true" className="gn-query-format-case-icon gn-query-format-case-icon-upper">AA</span>,
                   onClick: () => setSqlFormatOptions({ keywordCase: 'upper' }),
               },
               {
                   key: 'lower',
                   label: translate('query_editor.format.keyword_lower'),
-                  icon: <ArrowDownOutlined />,
+                  icon: <span aria-hidden="true" className="gn-query-format-case-icon gn-query-format-case-icon-lower">aa</span>,
                   onClick: () => setSqlFormatOptions({ keywordCase: 'lower' }),
               },
               {

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -2,6 +2,19 @@ import Modal from './common/ResizableDraggableModal';
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import Editor, { type BeforeMount, type OnMount } from './MonacoEditor';
 import { message, Input, Form, MenuProps, Button, Segmented, type InputRef } from 'antd';
+import {
+    ArrowDownOutlined,
+    ArrowUpOutlined,
+    CodeOutlined,
+    EditOutlined,
+    ExportOutlined,
+    FileTextOutlined,
+    HistoryOutlined,
+    KeyOutlined,
+    SaveOutlined,
+    SearchOutlined,
+    UndoOutlined,
+} from '@ant-design/icons';
 import { format } from 'sql-formatter';
 import { v4 as uuidv4 } from 'uuid';
 import { TabData, ColumnDefinition, type SavedQuery, type SqlSnippet } from '../types';
@@ -7657,18 +7670,19 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
               {
                   key: 'upper',
                   label: translate('query_editor.format.keyword_upper'),
-                  icon: sqlFormatOptions.keywordCase === 'upper' ? '✓' : undefined,
+                  icon: <ArrowUpOutlined />,
                   onClick: () => setSqlFormatOptions({ keywordCase: 'upper' }),
               },
               {
                   key: 'lower',
                   label: translate('query_editor.format.keyword_lower'),
-                  icon: sqlFormatOptions.keywordCase === 'lower' ? '✓' : undefined,
+                  icon: <ArrowDownOutlined />,
                   onClick: () => setSqlFormatOptions({ keywordCase: 'lower' }),
               },
               {
                   key: 'restore-last-format',
                   label: translate('query_editor.format.restore_last_format'),
+                  icon: <UndoOutlined />,
                   disabled: !tab.formatRestoreSnapshot?.query,
                   onClick: handleRestoreLastFormat,
               },
@@ -7682,11 +7696,13 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
               {
                   key: 'snippet-settings',
                   label: translate('query_editor.format.snippet_settings'),
+                  icon: <CodeOutlined />,
                   onClick: () => window.dispatchEvent(new CustomEvent('gonavi:open-snippet-settings')),
               },
               {
                   key: 'shortcut-settings',
                   label: translate('query_editor.format.shortcut_settings'),
+                  icon: <KeyOutlined />,
                   onClick: () => window.dispatchEvent(new CustomEvent('gonavi:open-shortcut-settings')),
               },
           ],
@@ -10437,6 +10453,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
           majorVersion: elasticsearchServerMajor || 8,
       }).map((template) => ({
           key: template.id,
+          icon: <FileTextOutlined />,
           danger: template.dangerous,
           label: template.dangerous
               ? `${translate('query_editor.elasticsearch.danger_badge')} · ${translate(template.labelKey)}`
@@ -10453,6 +10470,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
           children: [
               ...(currentSavedQuery && !tab.filePath ? [{
                   key: 'save-query-as',
+                  icon: <SaveOutlined />,
                   label: (
                       <span className="gn-v2-context-menu-item-title">
                           {translate('query_editor.action.save_as')}
@@ -10468,12 +10486,14 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
               {
                   key: 'rename-query',
                   label: translate('query_editor.action.rename_query'),
+                  icon: <EditOutlined />,
                   disabled: !!tab.filePath,
                   onClick: handleRenameQuery,
               },
               {
                   key: 'export-sql-file',
                   label: translate('query_editor.action.export_sql_file'),
+                  icon: <ExportOutlined />,
                   onClick: () => void handleExportSQLFile(),
               },
           ],
@@ -10485,6 +10505,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
           children: [
               {
                   key: 'diagnose-query',
+                  icon: <SearchOutlined />,
                   label: (
                       <span className="gn-v2-context-menu-item-title">
                           {translate('app.shortcuts.action.diagnoseQuery.label' as any)}
@@ -10500,6 +10521,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
               },
               {
                   key: 'show-slow-queries',
+                  icon: <HistoryOutlined />,
                   label: (
                       <span className="gn-v2-context-menu-item-title">
                           {translate('app.shortcuts.action.showSlowQueries.label' as any)}
@@ -11196,6 +11218,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
         runDisabled={canSelectQuerySchema && schemaLoading}
         saveMoreMenuItems={saveMoreMenuItems}
         formatSettingsMenu={formatSettingsMenu}
+        formatSettingsSelectedKeys={[sqlFormatOptions.keywordCase]}
         templateMenuItems={elasticsearchTemplateMenuItems}
         onConnectionChange={(val) => {
             void switchQueryContext(val, '');

--- a/frontend/src/components/QueryEditorResultsPanel.tsx
+++ b/frontend/src/components/QueryEditorResultsPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Button, Dropdown, Segmented, Tag, Tabs, Tooltip, message, type MenuProps } from 'antd';
-import { ArrowLeftOutlined, ArrowRightOutlined, BugOutlined, ClearOutlined, CloseOutlined, CopyOutlined, DiffOutlined, ExportOutlined, EyeInvisibleOutlined, PushpinOutlined, RobotOutlined, TableOutlined } from '@ant-design/icons';
+import { ArrowLeftOutlined, ArrowRightOutlined, BugOutlined, ClearOutlined, CloseOutlined, CopyOutlined, DiffOutlined, ExportOutlined, EyeInvisibleOutlined, PushpinOutlined, RobotOutlined } from '@ant-design/icons';
 
 import { useStore } from '../store';
 import type { EditRowLocator } from '../utils/rowLocator';
@@ -497,48 +497,35 @@ const QueryEditorResultsPanel: React.FC<QueryEditorResultsPanelProps> = ({
         const hasClosableResult = resultSets.some((item) => !item.pinned);
         return [
             {
-                type: 'group',
-                key: 'result-actions',
-                label: t('query_editor.action.results'),
-                children: [
-                    {
-                        key: result?.pinned ? 'unpin' : 'pin',
-                        icon: <PushpinOutlined />,
-                        label: t(result?.pinned
-                            ? 'query_editor.results_panel.menu.unpin'
-                            : 'query_editor.results_panel.menu.pin'),
-                        onClick: () => onResultPinnedChange(key, !result?.pinned),
-                    },
-                    ...(onOpenResultInWindow
-                        ? [{
-                            key: 'open-in-window',
-                            icon: <ExportOutlined />,
-                            label: t('query_editor.results_panel.menu.open_in_window'),
-                            onClick: () => onOpenResultInWindow(key),
-                        }]
-                        : []),
-                    ...(onCompareResult
-                        ? [{
-                            key: 'compare-results',
-                            icon: <DiffOutlined />,
-                            label: t('query_editor.results_panel.menu.compare_results'),
-                            disabled: comparableCount < 2,
-                            onClick: () => onCompareResult(key),
-                        }]
-                        : []),
-                ],
+                key: result?.pinned ? 'unpin' : 'pin',
+                icon: <PushpinOutlined />,
+                label: t(result?.pinned
+                    ? 'query_editor.results_panel.menu.unpin'
+                    : 'query_editor.results_panel.menu.pin'),
+                onClick: () => onResultPinnedChange(key, !result?.pinned),
             },
-            {
-                type: 'group',
-                key: 'close-actions',
-                label: t('common.close'),
-                children: [
-                    { key: 'close-other', icon: <CloseOutlined />, label: t('query_editor.results_panel.menu.close_other'), disabled: !hasClosableOtherResult, onClick: () => onCloseOtherResultTabs(key) },
-                    { key: 'close-left', icon: <ArrowLeftOutlined />, label: t('query_editor.results_panel.menu.close_left'), disabled: !hasClosableResultToLeft, onClick: () => onCloseResultTabsToLeft(key) },
-                    { key: 'close-right', icon: <ArrowRightOutlined />, label: t('query_editor.results_panel.menu.close_right'), disabled: !hasClosableResultToRight, onClick: () => onCloseResultTabsToRight(key) },
-                    { key: 'close-all', icon: <CloseOutlined />, label: t('query_editor.results_panel.menu.close_all'), disabled: !hasClosableResult, onClick: onCloseAllResultTabs },
-                ],
-            },
+            ...(onOpenResultInWindow
+                ? [{
+                    key: 'open-in-window',
+                    icon: <ExportOutlined />,
+                    label: t('query_editor.results_panel.menu.open_in_window'),
+                    onClick: () => onOpenResultInWindow(key),
+                }]
+                : []),
+            ...(onCompareResult
+                ? [{
+                    key: 'compare-results',
+                    icon: <DiffOutlined />,
+                    label: t('query_editor.results_panel.menu.compare_results'),
+                    disabled: comparableCount < 2,
+                    onClick: () => onCompareResult(key),
+                }]
+                : []),
+            { type: 'divider' },
+            { key: 'close-other', icon: <CloseOutlined />, label: t('query_editor.results_panel.menu.close_other'), disabled: !hasClosableOtherResult, onClick: () => onCloseOtherResultTabs(key) },
+            { key: 'close-left', icon: <ArrowLeftOutlined />, label: t('query_editor.results_panel.menu.close_left'), disabled: !hasClosableResultToLeft, onClick: () => onCloseResultTabsToLeft(key) },
+            { key: 'close-right', icon: <ArrowRightOutlined />, label: t('query_editor.results_panel.menu.close_right'), disabled: !hasClosableResultToRight, onClick: () => onCloseResultTabsToRight(key) },
+            { key: 'close-all', icon: <CloseOutlined />, label: t('query_editor.results_panel.menu.close_all'), disabled: !hasClosableResult, onClick: onCloseAllResultTabs },
         ];
     }
 
@@ -553,15 +540,24 @@ const QueryEditorResultsPanel: React.FC<QueryEditorResultsPanelProps> = ({
                     title: rs.resultType === 'message'
                         ? t('query_editor.results_panel.tab.message', { index: idx + 1 })
                         : t('query_editor.results_panel.tab.result', { index: idx + 1 }),
-                    meta: Array.isArray(rs.rows) ? `${rs.rows.length} × ${rs.columns.length}` : currentDb,
-                    icon: <TableOutlined />,
-                    badge: currentDb || undefined,
+                    showHeader: false,
                 })}
             >
                 <div
                     className={`query-result-tab-label${onOpenResultInWindow ? ' is-detachable' : ''}${draggingResultKey === rs.key ? ' is-dragging-detach' : ''}`}
                     title={onOpenResultInWindow ? t('query_editor.results_panel.menu.open_in_window') : undefined}
                     onContextMenu={(event) => event.preventDefault()}
+                    onMouseDown={(event) => {
+                        if (event.button !== 1) return;
+                        event.preventDefault();
+                        event.stopPropagation();
+                    }}
+                    onAuxClick={(event) => {
+                        if (event.button !== 1) return;
+                        event.preventDefault();
+                        event.stopPropagation();
+                        onCloseResult(rs.key);
+                    }}
                     onPointerDown={(event) => handleResultTabPointerDown(event, rs.key)}
                 >
                     <Tooltip title={rs.sql}>
@@ -824,12 +820,12 @@ const QueryEditorResultsPanel: React.FC<QueryEditorResultsPanelProps> = ({
         <>
             <style>{`
               .query-result-tabs { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; overflow: hidden; }
-              .query-result-tabs .ant-tabs-nav { flex: 0 0 auto; margin: 0; min-height: 38px; padding-right: 8px; }
+              .query-result-tabs .ant-tabs-nav { flex: 0 0 auto; margin: 0; min-height: 36px; padding-right: 8px; }
               .query-result-tabs .ant-tabs-nav-wrap { flex: 0 1 auto; min-width: 0; }
               .query-result-tabs .ant-tabs-extra-content { display: inline-flex; align-items: center; padding-left: 8px; }
               .query-result-tabs .ant-tabs-nav-list { align-items: center; width: auto; }
-              .query-result-tabs .ant-tabs-tab { width: auto !important; min-width: 0 !important; max-width: 148px !important; height: 30px !important; min-height: 30px; margin: 4px 6px 4px 0 !important; padding: 0 9px !important; border-radius: 8px !important; border: 0.5px solid transparent !important; border-right: 0.5px solid transparent !important; align-items: center !important; justify-content: center !important; }
-              .query-result-tabs .ant-tabs-tab-btn { width: auto !important; height: 100%; max-width: 100%; display: inline-flex !important; align-items: center !important; justify-content: center !important; font-size: 14px !important; line-height: 1 !important; }
+              .query-result-tabs .ant-tabs-tab { width: auto !important; min-width: 0 !important; max-width: 148px !important; height: 30px !important; min-height: 30px; margin: 0 !important; padding: 0 7px !important; border-radius: 6px !important; border: 0.5px solid transparent !important; border-right: 0.5px solid transparent !important; align-items: center !important; justify-content: center !important; }
+              .query-result-tabs .ant-tabs-tab-btn { width: auto !important; height: 100%; max-width: 100%; display: inline-flex !important; align-items: center !important; justify-content: center !important; font-size: 13px !important; line-height: 1 !important; }
               .query-result-tabs .ant-tabs-tab.ant-tabs-tab-active::after { display: none; }
               .query-result-tabs .ant-tabs-content-holder, .query-result-tabs .ant-tabs-content, .query-result-tabs .ant-tabs-tabpane { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; overflow: hidden; }
               .query-result-tabs .ant-tabs-tabpane > div { flex: 1 1 auto; min-height: 0; }
@@ -845,9 +841,9 @@ const QueryEditorResultsPanel: React.FC<QueryEditorResultsPanelProps> = ({
                 -webkit-user-select: none !important;
                 cursor: grabbing !important;
               }
-              .query-result-tab-text { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 14px; font-weight: 700; }
+              .query-result-tab-text { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; font-weight: 700; }
               .query-result-tab-pin { flex: 0 0 auto; font-size: 12px; }
-              .query-result-tab-count { flex: 0 0 auto; min-width: 17px; height: 17px; padding: 0 5px; border-radius: 999px; display: inline-flex; align-items: center; justify-content: center; background: rgba(148, 163, 184, 0.16); color: inherit; font-size: 11px; font-weight: 700; line-height: 17px; }
+              .query-result-tab-count { flex: 0 0 auto; height: 17px; padding: 0 5px; border-radius: 3px; display: inline-flex; align-items: center; justify-content: center; background: var(--gn-bg-active, rgba(148, 163, 184, 0.16)); color: var(--gn-fg-4, inherit); font-family: var(--gn-font-mono); font-size: 9.5px; font-weight: 750; line-height: 17px; }
               .query-result-tab-close { display: inline-flex; align-items: center; justify-content: center; width: 16px; height: 16px; border-radius: 999px; color: #999; cursor: pointer; flex: 0 0 auto; }
               .query-result-tab-close:hover { background: rgba(0, 0, 0, 0.06); color: #666; }
               .query-result-panel-header { flex: 0 0 auto; min-height: 38px; display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 0 12px; border-bottom: 1px solid rgba(0, 0, 0, 0.06); background: rgba(255, 255, 255, 0.9); }

--- a/frontend/src/components/QueryEditorToolbar.elasticsearch.test.tsx
+++ b/frontend/src/components/QueryEditorToolbar.elasticsearch.test.tsx
@@ -34,11 +34,15 @@ vi.mock('antd', () => ({
 vi.mock('@ant-design/icons', () => {
   const Icon = () => <span />;
   return {
+    BulbOutlined: Icon,
+    CheckOutlined: Icon,
+    DatabaseOutlined: Icon,
     DiffOutlined: Icon,
     DownOutlined: Icon,
     EyeInvisibleOutlined: Icon,
     EyeOutlined: Icon,
     EllipsisOutlined: Icon,
+    FileTextOutlined: Icon,
     FormatPainterOutlined: Icon,
     PlayCircleOutlined: Icon,
     RobotOutlined: Icon,
@@ -46,6 +50,7 @@ vi.mock('@ant-design/icons', () => {
     SaveOutlined: Icon,
     SettingOutlined: Icon,
     StopOutlined: Icon,
+    ThunderboltOutlined: Icon,
   };
 });
 
@@ -108,6 +113,24 @@ const buildProps = (overrides: Record<string, unknown> = {}) => ({
 const menuKeys = (): string[] => antdState.dropdownProps.flatMap((props) => (
   (props.menu?.items || []).flatMap((item: any) => item?.key ? [String(item.key)] : [])
 ));
+
+const menuItems = (): any[] => antdState.dropdownProps.flatMap((props) => props.menu?.items || []);
+
+const formatDropdown = () => [...antdState.dropdownProps]
+  .reverse()
+  .find((props) => props.menu?.selectable === true);
+
+const findMenuItem = (key: string): any => {
+  const visit = (items: any[]): any => {
+    for (const item of items) {
+      if (item?.key === key) return item;
+      const child = Array.isArray(item?.children) ? visit(item.children) : undefined;
+      if (child) return child;
+    }
+    return undefined;
+  };
+  return visit(formatDropdown()?.menu?.items || []);
+};
 
 const buttonByLabel = (label: string) => [...antdState.buttonProps]
   .reverse()
@@ -193,6 +216,69 @@ describe('QueryEditorToolbar Elasticsearch mode', () => {
     expect(buttonByLabel('query_editor.action.more')).toBeDefined();
     expect(buttonByLabel('query_editor.elasticsearch.action.run_all')).toBeUndefined();
     expect(JSON.stringify(renderer?.toJSON())).toContain('pending transaction');
+  });
+
+  it('uses dividers instead of group headings and supplies icons for SQL action items', () => {
+    act(() => {
+      renderer = create(<QueryEditorToolbar {...buildProps()} />);
+    });
+
+    const items = menuItems();
+    expect(items.some((item) => item?.type === 'group')).toBe(false);
+    expect(items.some((item) => item?.type === 'divider')).toBe(true);
+    expect(items.filter((item) => item?.key).every((item) => item.icon)).toBe(true);
+  });
+
+  it('marks the active keyword case in the format menu', () => {
+    act(() => {
+      renderer = create(<QueryEditorToolbar {...buildProps({
+        formatSettingsMenu: [
+          {
+            type: 'group',
+            key: 'format-actions',
+            children: [
+              { key: 'upper', label: 'upper' },
+              { key: 'lower', label: 'lower' },
+            ],
+          },
+        ],
+        formatSettingsSelectedKeys: ['upper'],
+      })} />);
+    });
+
+    expect(formatDropdown()?.menu).toMatchObject({
+      selectable: true,
+      selectedKeys: ['upper'],
+    });
+    expect(findMenuItem('upper').extra.props).toMatchObject({
+      'aria-label': 'selected',
+    });
+    expect(findMenuItem('lower').extra).toBeUndefined();
+
+    act(() => {
+      renderer?.update(<QueryEditorToolbar {...buildProps({
+        formatSettingsMenu: [
+          {
+            type: 'group',
+            key: 'format-actions',
+            children: [
+              { key: 'upper', label: 'upper' },
+              { key: 'lower', label: 'lower' },
+            ],
+          },
+        ],
+        formatSettingsSelectedKeys: ['lower'],
+      })} />);
+    });
+
+    expect(formatDropdown()?.menu).toMatchObject({
+      selectable: true,
+      selectedKeys: ['lower'],
+    });
+    expect(findMenuItem('upper').extra).toBeUndefined();
+    expect(findMenuItem('lower').extra.props).toMatchObject({
+      'aria-label': 'selected',
+    });
   });
 
   it('shows a searchable schema selector for PostgreSQL query contexts', () => {

--- a/frontend/src/components/QueryEditorToolbar.layout.test.tsx
+++ b/frontend/src/components/QueryEditorToolbar.layout.test.tsx
@@ -325,4 +325,10 @@ describe('QueryEditorToolbar layout', () => {
     expect(css).toContain('.gn-v2-action-menu-body .ant-dropdown-menu-item:not(:has(.ant-dropdown-menu-item-icon))::before');
     expect(css).toContain('.monaco-menu > .gn-v2-monaco-context-menu-header {');
   });
+
+  it('uses the title-bar more menu surface for editor action popups', () => {
+    const toolbarSource = readFileSync(new URL('./QueryEditorToolbar.tsx', import.meta.url), 'utf8');
+    expect(toolbarSource).toContain("showHeader: false");
+    expect(toolbarSource).toContain('gn-v2-titlebar-quick-dropdown');
+  });
 });

--- a/frontend/src/components/QueryEditorToolbar.layout.test.tsx
+++ b/frontend/src/components/QueryEditorToolbar.layout.test.tsx
@@ -318,17 +318,50 @@ describe('QueryEditorToolbar layout', () => {
 
     expect(toolbarSource).toContain('renderV2ActionMenuPopup');
     expect(queryEditorSource).toContain('decorateV2MonacoContextMenu');
+    expect(queryEditorSource).toContain('window.setTimeout(decorateV2MonacoContextMenu, 0)');
+    expect(queryEditorSource).toContain('window.setTimeout(decorateV2MonacoContextMenu, 48)');
+    expect(queryEditorSource).toContain('window.setTimeout(decorateV2MonacoContextMenu, 120)');
     expect(sharedPopupSource).toContain('gn-v2-context-menu-header gn-v2-action-menu-header');
     expect(sharedPopupSource).toContain('gn-v2-context-menu-engine-pill');
+    expect(sharedPopupSource).toContain('.monaco-menu {');
+    expect(sharedPopupSource).toContain('font-family: var(--gn-font-sans) !important;');
+    expect(sharedPopupSource).toContain('color: var(--gn-fg-1) !important;');
+    expect(sharedPopupSource).toContain('background: transparent !important;');
+    expect(sharedPopupSource).toContain('background: var(--gn-bg-active) !important;');
+    expect(sharedPopupSource).toContain('.monaco-menu .monaco-action-bar.vertical .action-item > .action-menu-item:hover');
+    expect(sharedPopupSource).toContain('.monaco-menu .monaco-action-bar.vertical .action-item > .action-menu-item:focus');
+    expect(sharedPopupSource).not.toContain('gn-v2-monaco-context-menu-header');
+    expect(sharedPopupSource).not.toContain('menu.prepend(header)');
     expect(css).toContain('.gn-v2-action-menu-surface {');
     expect(css).toContain('.gn-v2-action-menu-body .ant-dropdown-menu-item-group-title {');
     expect(css).toContain('.gn-v2-action-menu-body .ant-dropdown-menu-item:not(:has(.ant-dropdown-menu-item-icon))::before');
-    expect(css).toContain('.monaco-menu > .gn-v2-monaco-context-menu-header {');
+    expect(css).toContain('body[data-ui-version="v2"] .monaco-menu {');
+    expect(css).toContain('body[data-ui-version="v2"] .monaco-menu .monaco-action-bar .action-item .action-label.separator {');
+    expect(css).not.toContain('.monaco-menu > .gn-v2-monaco-context-menu-header {');
   });
 
   it('uses the title-bar more menu surface for editor action popups', () => {
     const toolbarSource = readFileSync(new URL('./QueryEditorToolbar.tsx', import.meta.url), 'utf8');
     expect(toolbarSource).toContain("showHeader: false");
     expect(toolbarSource).toContain('gn-v2-titlebar-quick-dropdown');
+  });
+
+  it('uses distinct case icons for keyword case actions', () => {
+    const queryEditorSource = readFileSync(new URL('./QueryEditor.tsx', import.meta.url), 'utf8');
+    const css = readV2ThemeCss();
+    const caseIconCss = css.match(/\.gn-query-format-case-icon \{[\s\S]*?\}/)?.[0] || '';
+    expect(queryEditorSource).toContain('gn-query-format-case-icon-upper');
+    expect(queryEditorSource).toContain('gn-query-format-case-icon-lower');
+    expect(queryEditorSource).toContain('>AA</span>');
+    expect(queryEditorSource).toContain('>aa</span>');
+    expect(queryEditorSource).not.toContain('FontSizeOutlined');
+    expect(queryEditorSource).not.toContain('FontColorsOutlined');
+    expect(queryEditorSource).not.toContain('ArrowUpOutlined');
+    expect(queryEditorSource).not.toContain('ArrowDownOutlined');
+    expect(caseIconCss).toContain('.gn-query-format-case-icon {');
+    expect(caseIconCss).toContain('width: 14px;');
+    expect(caseIconCss).toContain('height: 14px;');
+    expect(caseIconCss).toContain('font-size: 10px;');
+    expect(caseIconCss).toContain('font-weight: 400;');
   });
 });

--- a/frontend/src/components/QueryEditorToolbar.tsx
+++ b/frontend/src/components/QueryEditorToolbar.tsx
@@ -1,11 +1,15 @@
 import React from "react";
 import { Button, Dropdown, Select, Tooltip, type MenuProps } from "antd";
 import {
+  BulbOutlined,
+  CheckOutlined,
+  DatabaseOutlined,
   DiffOutlined,
   DownOutlined,
   EyeInvisibleOutlined,
   EyeOutlined,
   EllipsisOutlined,
+  FileTextOutlined,
   FormatPainterOutlined,
   PlayCircleOutlined,
   RobotOutlined,
@@ -13,6 +17,7 @@ import {
   SaveOutlined,
   SettingOutlined,
   StopOutlined,
+  ThunderboltOutlined,
 } from "@ant-design/icons";
 
 import { t as defaultTranslate } from '../i18n';
@@ -63,6 +68,7 @@ export type QueryEditorToolbarProps = {
   runDisabled?: boolean;
   saveMoreMenuItems: MenuProps["items"];
   formatSettingsMenu: MenuProps["items"];
+  formatSettingsSelectedKeys?: string[];
   templateMenuItems?: MenuProps["items"];
   onConnectionChange: (connectionId: string) => void;
   onDatabaseChange: (dbName: string) => void;
@@ -160,6 +166,40 @@ type FullNameSelectOption = {
 
 type QueryToolbarMenuKey = "ai" | "more" | "format" | "templates";
 
+const normalizeV2ActionMenuItems = (
+  items: MenuProps["items"],
+  fallbackIcon: React.ReactNode,
+): MenuProps["items"] => {
+  const normalized: NonNullable<MenuProps["items"]> = [];
+  const appendDivider = () => {
+    if (normalized.length > 0 && (normalized[normalized.length - 1] as { type?: string }).type !== "divider") {
+      normalized.push({ type: "divider" });
+    }
+  };
+  const appendItem = (item: any) => {
+    if (!item) return;
+    if (item.type === "divider") {
+      appendDivider();
+      return;
+    }
+    if (item.type === "group") {
+      const children = (item.children ?? []).filter(Boolean);
+      if (children.length > 0) {
+        appendDivider();
+        children.forEach(appendItem);
+      }
+      return;
+    }
+    normalized.push({ ...item, icon: item.icon ?? fallbackIcon });
+  };
+
+  (items ?? []).forEach(appendItem);
+  if ((normalized[normalized.length - 1] as { type?: string } | undefined)?.type === "divider") {
+    normalized.pop();
+  }
+  return normalized;
+};
+
 const renderFullNameSelectTooltip = (fullName: React.ReactNode) => {
   const fullNameText = String(fullName ?? "");
 
@@ -204,6 +244,7 @@ const QueryEditorToolbar: React.FC<QueryEditorToolbarProps> = ({
   runDisabled = false,
   saveMoreMenuItems,
   formatSettingsMenu,
+  formatSettingsSelectedKeys = [],
   templateMenuItems,
   onConnectionChange,
   onDatabaseChange,
@@ -305,17 +346,12 @@ const QueryEditorToolbar: React.FC<QueryEditorToolbarProps> = ({
     ? t("query_editor.elasticsearch.action.ai")
     : `AI · ${t("query_editor.action.more")}`;
   const formatSettingsTitle = `${t("query_editor.action.format_sql")} · ${t("settings.title")}`;
-  const activeConnectionLabel = queryCapableConnections.find(
-    (connection) => connection.id === currentConnectionId,
-  )?.name;
-  const menuContextMeta = [activeConnectionLabel, currentDb].filter(Boolean).join(' · ')
-    || t('tab_manager.kind_badge.query');
   const aiMenuItems: MenuProps["items"] = isElasticsearchMode
     ? [
         {
           key: "ai-generate",
           label: t("query_editor.elasticsearch.action.ai_generate"),
-          icon: <RobotOutlined />,
+          icon: <FileTextOutlined />,
           onClick: () => onAIAction("generate"),
         },
       ]
@@ -330,26 +366,26 @@ const QueryEditorToolbar: React.FC<QueryEditorToolbarProps> = ({
         {
           key: "ai-generate",
           label: t("query_editor.action.ai_text_to_sql_menu"),
-          icon: <RobotOutlined />,
+          icon: <FileTextOutlined />,
           onClick: () => onAIAction("generate"),
         },
         {
           key: "ai-explain",
           label: t("query_editor.action.ai_explain_sql_menu"),
-          icon: <RobotOutlined />,
+          icon: <BulbOutlined />,
           onClick: () => onAIAction("explain"),
         },
         {
           key: "ai-optimize",
           label: t("query_editor.action.ai_optimize_sql_menu"),
-          icon: <RobotOutlined />,
+          icon: <ThunderboltOutlined />,
           onClick: () => onAIAction("optimize"),
         },
         { type: "divider" as const },
         {
           key: "ai-schema",
           label: t("query_editor.action.ai_schema_analysis"),
-          icon: <RobotOutlined />,
+          icon: <DatabaseOutlined />,
           onClick: () => onAIAction("schema"),
         },
       ];
@@ -373,6 +409,24 @@ const QueryEditorToolbar: React.FC<QueryEditorToolbarProps> = ({
         },
       ]
     : baseMoreMenuItems;
+  const templateActionMenuItems = normalizeV2ActionMenuItems(templateMenuItems, <FileTextOutlined />);
+  const aiActionMenuItems = normalizeV2ActionMenuItems(aiMenuItems, <RobotOutlined />);
+  const moreActionMenuItems = normalizeV2ActionMenuItems(moreMenuItems, <EllipsisOutlined />);
+  const selectedFormatKeys = new Set(formatSettingsSelectedKeys);
+  const markSelectedFormatItems = (items: MenuProps['items']): MenuProps['items'] => (items ?? []).map((item) => {
+    if (!item || item.type === 'divider') {
+      return item;
+    }
+    if (item.type === 'group') {
+      return { ...item, children: markSelectedFormatItems(item.children) };
+    }
+    return {
+      ...item,
+      extra: selectedFormatKeys.has(String(item.key)) ? <CheckOutlined aria-label="selected" /> : undefined,
+    };
+  });
+  const formatMenuItemsWithSelection = markSelectedFormatItems(formatSettingsMenu);
+  const formatActionMenuItems = normalizeV2ActionMenuItems(formatMenuItemsWithSelection, <FormatPainterOutlined />);
   const selects = (
     <div
       className={isV2Ui ? "gn-v2-query-toolbar-selects" : undefined}
@@ -447,15 +501,14 @@ const QueryEditorToolbar: React.FC<QueryEditorToolbarProps> = ({
           open={isV2Ui && openToolbarMenu === "templates" ? false : undefined}
         >
           <span className={isV2Ui ? "gn-v2-query-toolbar-menu-trigger" : undefined}>
-              <Dropdown
-                menu={{ items: templateMenuItems }}
+            <Dropdown
+                menu={{ items: isV2Ui ? templateActionMenuItems : templateMenuItems }}
                 placement="bottomLeft"
                 trigger={["click"]}
-                rootClassName={isV2Ui ? 'gn-v2-action-menu-popup-host' : undefined}
+                rootClassName={isV2Ui ? 'gn-v2-titlebar-quick-dropdown gn-v2-action-menu-popup-host' : undefined}
                 popupRender={(menu) => renderV2ActionMenuPopup(menu, isV2Ui, {
                   title: t('query_editor.elasticsearch.action.templates'),
-                  meta: menuContextMeta,
-                  icon: <DownOutlined />,
+                  showHeader: false,
                 })}
                 open={isV2Ui ? openToolbarMenu === "templates" : undefined}
               onOpenChange={isV2Ui ? (open) => updateToolbarMenuOpen("templates", open) : undefined}
@@ -631,15 +684,13 @@ const QueryEditorToolbar: React.FC<QueryEditorToolbarProps> = ({
           >
             <span className={isV2Ui ? "gn-v2-query-toolbar-menu-trigger" : undefined}>
               <Dropdown
-                menu={{ items: aiMenuItems }}
+                menu={{ items: isV2Ui ? aiActionMenuItems : aiMenuItems }}
                 placement="bottomRight"
                 trigger={["click"]}
-                rootClassName={isV2Ui ? 'gn-v2-action-menu-popup-host' : undefined}
+                  rootClassName={isV2Ui ? 'gn-v2-titlebar-quick-dropdown gn-v2-action-menu-popup-host' : undefined}
                 popupRender={(menu) => renderV2ActionMenuPopup(menu, isV2Ui, {
                   title: aiMoreTitle,
-                  meta: menuContextMeta,
-                  icon: <RobotOutlined />,
-                  badge: 'AI',
+                  showHeader: false,
                 })}
                 open={isV2Ui ? openToolbarMenu === "ai" : undefined}
                 onOpenChange={isV2Ui ? (open) => updateToolbarMenuOpen("ai", open) : undefined}
@@ -679,15 +730,13 @@ const QueryEditorToolbar: React.FC<QueryEditorToolbarProps> = ({
               >
                 <span className={isV2Ui ? "gn-v2-query-toolbar-menu-trigger" : undefined}>
                   <Dropdown
-                    menu={{ items: aiMenuItems }}
+                    menu={{ items: isV2Ui ? aiActionMenuItems : aiMenuItems }}
                     placement="bottomRight"
                     trigger={["click"]}
-                    rootClassName={isV2Ui ? 'gn-v2-action-menu-popup-host' : undefined}
+                    rootClassName={isV2Ui ? 'gn-v2-titlebar-quick-dropdown gn-v2-action-menu-popup-host' : undefined}
                     popupRender={(menu) => renderV2ActionMenuPopup(menu, isV2Ui, {
                       title: aiMoreTitle,
-                      meta: menuContextMeta,
-                      icon: <RobotOutlined />,
-                      badge: 'AI',
+                      showHeader: false,
                     })}
                     open={isV2Ui ? openToolbarMenu === "ai" : undefined}
                     onOpenChange={isV2Ui ? (open) => updateToolbarMenuOpen("ai", open) : undefined}
@@ -710,15 +759,13 @@ const QueryEditorToolbar: React.FC<QueryEditorToolbarProps> = ({
             >
               <span className={isV2Ui ? "gn-v2-query-toolbar-menu-trigger" : undefined}>
                 <Dropdown
-                  menu={{ items: moreMenuItems }}
+                  menu={{ items: isV2Ui ? moreActionMenuItems : moreMenuItems }}
                   placement="bottomRight"
                   trigger={["click"]}
-                  rootClassName={isV2Ui ? 'gn-v2-action-menu-popup-host' : undefined}
+                  rootClassName={isV2Ui ? 'gn-v2-titlebar-quick-dropdown gn-v2-action-menu-popup-host' : undefined}
                   popupRender={(menu) => renderV2ActionMenuPopup(menu, isV2Ui, {
                     title: t('query_editor.action.more'),
-                    meta: menuContextMeta,
-                    icon: <EllipsisOutlined />,
-                    badge: t('tab_manager.kind_badge.query'),
+                    showHeader: false,
                   })}
                   open={isV2Ui ? openToolbarMenu === "more" : undefined}
                   onOpenChange={isV2Ui ? (open) => updateToolbarMenuOpen("more", open) : undefined}
@@ -799,16 +846,18 @@ const QueryEditorToolbar: React.FC<QueryEditorToolbarProps> = ({
             open={isV2Ui && openToolbarMenu === "format" ? false : undefined}
           >
             <span className={isV2Ui ? "gn-v2-query-toolbar-menu-trigger" : undefined}>
-              <Dropdown
-                menu={{ items: formatSettingsMenu }}
+            <Dropdown
+                menu={{
+                  items: isV2Ui ? formatActionMenuItems : formatMenuItemsWithSelection,
+                  selectable: true,
+                  selectedKeys: formatSettingsSelectedKeys,
+                }}
                 placement="bottomRight"
                 trigger={["click"]}
-                rootClassName={isV2Ui ? 'gn-v2-action-menu-popup-host' : undefined}
+                rootClassName={isV2Ui ? 'gn-v2-titlebar-quick-dropdown gn-v2-action-menu-popup-host' : undefined}
                 popupRender={(menu) => renderV2ActionMenuPopup(menu, isV2Ui, {
                   title: formatSettingsTitle,
-                  meta: menuContextMeta,
-                  icon: <FormatPainterOutlined />,
-                  badge: t('tab_manager.kind_badge.query'),
+                  showHeader: false,
                 })}
                 open={isV2Ui ? openToolbarMenu === "format" : undefined}
                 onOpenChange={isV2Ui ? (open) => updateToolbarMenuOpen("format", open) : undefined}

--- a/frontend/src/components/TabManager.hover.test.tsx
+++ b/frontend/src/components/TabManager.hover.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { readFileSync } from 'node:fs';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -51,6 +52,18 @@ afterEach(() => {
 });
 
 describe('TabManager hover info', () => {
+  it('renders the v2 tab context menu without headings and separates action regions with a divider', () => {
+    const source = readFileSync(new URL('./TabManager.tsx', import.meta.url), 'utf8');
+    const menuSource = source.slice(
+      source.indexOf("const menuItems: MenuProps['items'] = ["),
+      source.indexOf('return {', source.indexOf("const menuItems: MenuProps['items'] = [")),
+    );
+
+    expect(source).toContain('showHeader: false');
+    expect(menuSource).not.toContain("type: 'group'");
+    expect(menuSource).toContain("type: 'divider'");
+  });
+
   it('starts tab dragging only from a primary pointer on non-interactive tab content', () => {
     const tabContent = {
       closest: vi.fn(() => null),

--- a/frontend/src/components/TabManager.tsx
+++ b/frontend/src/components/TabManager.tsx
@@ -635,9 +635,7 @@ const SortableTabLabel: React.FC<SortableTabLabelProps> = ({
       rootClassName={isV2Ui ? 'gn-v2-tab-context-menu-popup' : undefined}
       popupRender={(menu) => renderV2ActionMenuPopup(menu, Boolean(isV2Ui), {
         title: displayTitle,
-        meta: displayModel.secondaryText || getTabKindLabel(tab),
-        icon: tab.type === 'query' ? <ConsoleSqlOutlined /> : <FileTextOutlined />,
-        badge: getTabKindLabel(tab),
+        showHeader: false,
       })}
     >
       {wrappedLabel}
@@ -1344,74 +1342,61 @@ const TabManager: React.FC<TabManagerProps> = React.memo<TabManagerProps>(({ onF
     const renameQueryMenuState = resolveQueryTabRenameMenuState(tab);
 
     const menuItems: MenuProps['items'] = [
+      ...(renameQueryMenuState.visible ? [{
+        key: 'rename-query',
+        icon: <EditOutlined />,
+        label: t('query_editor.action.rename_query'),
+        disabled: renameQueryMenuState.disabled,
+        onClick: () => {
+          setActiveTab(tab.id);
+          window.setTimeout(() => {
+            window.dispatchEvent(new CustomEvent(QUERY_TAB_RENAME_REQUEST_EVENT, {
+              detail: { tabId: tab.id },
+            }));
+          }, 0);
+        },
+      }] : []),
       {
-        type: 'group',
-        key: 'tab-actions',
-        label: t('tab_manager.kind_badge.fallback'),
-        children: [
-          ...(renameQueryMenuState.visible ? [{
-            key: 'rename-query',
-            icon: <EditOutlined />,
-            label: t('query_editor.action.rename_query'),
-            disabled: renameQueryMenuState.disabled,
-            onClick: () => {
-              setActiveTab(tab.id);
-              window.setTimeout(() => {
-                window.dispatchEvent(new CustomEvent(QUERY_TAB_RENAME_REQUEST_EVENT, {
-                  detail: { tabId: tab.id },
-                }));
-              }, 0);
-            },
-          }] : []),
-          {
-            key: 'tab-display-settings',
-            icon: <SettingOutlined />,
-            label: t('tab_manager.menu.tab_display_settings'),
-            onClick: openTabDisplaySettings,
-          },
-          {
-            key: 'open-in-window',
-            icon: <ExportOutlined />,
-            label: t('tab_manager.menu.open_in_window'),
-            disabled: isBackgroundTaskWorkbenchTab(tab),
-            onClick: () => detachTabToWindow(tab.id),
-          },
-        ],
+        key: 'tab-display-settings',
+        icon: <SettingOutlined />,
+        label: t('tab_manager.menu.tab_display_settings'),
+        onClick: openTabDisplaySettings,
       },
       {
-        type: 'group',
-        key: 'close-actions',
-        label: t('common.close'),
-        children: [
-          {
-            key: 'close-other',
-            icon: <CloseCircleOutlined />,
-            label: t('tab_manager.menu.close_other'),
-            disabled: tabs.length <= 1,
-            onClick: () => closeTabsWithSQLFilePrompt(getCloseOtherTabIds(tabs, tab.id), () => closeOtherTabs(tab.id)),
-          },
-          {
-            key: 'close-left',
-            icon: <ArrowLeftOutlined />,
-            label: t('tab_manager.menu.close_left'),
-            disabled: index === 0,
-            onClick: () => closeTabsWithSQLFilePrompt(getCloseTabsToLeftIds(dockedTabs, tab.id), () => closeTabsToLeft(tab.id)),
-          },
-          {
-            key: 'close-right',
-            icon: <ArrowRightOutlined />,
-            label: t('tab_manager.menu.close_right'),
-            disabled: index === dockedTabs.length - 1,
-            onClick: () => closeTabsWithSQLFilePrompt(getCloseTabsToRightIds(dockedTabs, tab.id), () => closeTabsToRight(tab.id)),
-          },
-          {
-            key: 'close-all',
-            icon: <CloseOutlined />,
-            label: t('tab_manager.menu.close_all'),
-            disabled: tabs.length === 0,
-            onClick: () => closeTabsWithSQLFilePrompt(tabs.map((item) => item.id), () => closeAllTabs()),
-          },
-        ],
+        key: 'open-in-window',
+        icon: <ExportOutlined />,
+        label: t('tab_manager.menu.open_in_window'),
+        disabled: isBackgroundTaskWorkbenchTab(tab),
+        onClick: () => detachTabToWindow(tab.id),
+      },
+      { type: 'divider' },
+      {
+        key: 'close-other',
+        icon: <CloseCircleOutlined />,
+        label: t('tab_manager.menu.close_other'),
+        disabled: tabs.length <= 1,
+        onClick: () => closeTabsWithSQLFilePrompt(getCloseOtherTabIds(tabs, tab.id), () => closeOtherTabs(tab.id)),
+      },
+      {
+        key: 'close-left',
+        icon: <ArrowLeftOutlined />,
+        label: t('tab_manager.menu.close_left'),
+        disabled: index === 0,
+        onClick: () => closeTabsWithSQLFilePrompt(getCloseTabsToLeftIds(dockedTabs, tab.id), () => closeTabsToLeft(tab.id)),
+      },
+      {
+        key: 'close-right',
+        icon: <ArrowRightOutlined />,
+        label: t('tab_manager.menu.close_right'),
+        disabled: index === dockedTabs.length - 1,
+        onClick: () => closeTabsWithSQLFilePrompt(getCloseTabsToRightIds(dockedTabs, tab.id), () => closeTabsToRight(tab.id)),
+      },
+      {
+        key: 'close-all',
+        icon: <CloseOutlined />,
+        label: t('tab_manager.menu.close_all'),
+        disabled: tabs.length === 0,
+        onClick: () => closeTabsWithSQLFilePrompt(tabs.map((item) => item.id), () => closeAllTabs()),
       },
     ];
     

--- a/frontend/src/components/common/V2ActionMenuPopup.tsx
+++ b/frontend/src/components/common/V2ActionMenuPopup.tsx
@@ -52,66 +52,38 @@ const MONACO_CONTEXT_MENU_STYLES = `
   border-radius: var(--gn-v2-menu-surface-radius, 10px) !important;
   background: var(--gn-bg-panel) !important;
   color: var(--gn-fg-1) !important;
+  font-family: var(--gn-font-sans) !important;
+  font-size: 12.5px !important;
   box-shadow: var(--gn-shadow-lg) !important;
-}
-.monaco-menu > .gn-v2-monaco-context-menu-header {
-  display: grid;
-  grid-template-columns: 16px minmax(0, 1fr);
-  column-gap: 6px;
-  row-gap: 3px;
-  align-items: center;
-  margin: -4px -4px 4px;
-  padding: 10px 12px;
-  border-bottom: 0.5px solid var(--gn-br-1);
-  border-radius: 9px 9px 0 0;
-  background: var(--gn-bg-panel-2);
-  font-family: var(--gn-font-sans);
-}
-.gn-v2-monaco-context-menu-header .gn-v2-action-menu-header-icon {
-  width: 16px;
-  color: var(--gn-info);
-  font-family: var(--gn-font-mono);
-  font-size: 8px;
-  font-weight: 700;
-  letter-spacing: -0.04em;
-}
-.gn-v2-monaco-context-menu-header .gn-v2-context-menu-heading { display: contents; }
-.gn-v2-monaco-context-menu-header strong {
-  grid-column: 2;
-  min-width: 0;
-  overflow: hidden;
-  color: var(--gn-fg-1);
-  font-family: var(--gn-font-mono);
-  font-size: 12.5px;
-  font-weight: 600;
-  line-height: 1.25;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.gn-v2-monaco-context-menu-header small {
-  grid-column: 1 / -1;
-  overflow: hidden;
-  color: var(--gn-fg-4);
-  font-family: var(--gn-font-mono);
-  font-size: 10.5px;
-  line-height: 1.25;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 .monaco-menu .monaco-action-bar.vertical .action-menu-item,
 .monaco-menu .monaco-action-bar.vertical .action-label:not(.separator) {
   min-height: var(--gn-v2-menu-row-height, 28px) !important;
   border-radius: var(--gn-v2-menu-item-radius, 5px) !important;
+  background: transparent !important;
+  color: var(--gn-fg-1) !important;
+  font-family: var(--gn-font-sans) !important;
   font-size: 12.5px !important;
+  font-weight: 500 !important;
   line-height: var(--gn-v2-menu-row-height, 28px) !important;
+}
+.monaco-menu .monaco-action-bar.vertical .action-menu-item {
+  margin: 0 !important;
 }
 .monaco-menu .monaco-action-bar.vertical .action-label:not(.separator) {
   padding: 0 8px !important;
 }
-.monaco-menu .monaco-action-bar.vertical .action-menu-item:focus {
+.monaco-menu .monaco-action-bar.vertical .action-item > .action-menu-item:hover,
+.monaco-menu .monaco-action-bar.vertical .action-item > .action-menu-item:focus {
   background: var(--gn-bg-active) !important;
   color: var(--gn-fg-1) !important;
   outline: none !important;
+}
+.monaco-menu .keybinding {
+  color: var(--gn-fg-4) !important;
+  font-family: var(--gn-font-mono) !important;
+  font-size: 10.5px !important;
+  font-weight: 500 !important;
 }
 .monaco-menu .monaco-action-bar .action-item .action-label.separator {
   width: auto !important;
@@ -124,54 +96,20 @@ const MONACO_CONTEXT_MENU_STYLES = `
 }
 `;
 
-export const decorateV2MonacoContextMenu = (title: string, meta?: string): void => {
+export const decorateV2MonacoContextMenu = (): void => {
   const roots: Array<Document | ShadowRoot> = [document];
   document.querySelectorAll<HTMLElement>('*').forEach((element) => {
     if (element.shadowRoot) roots.push(element.shadowRoot);
   });
 
-  const menus = roots.flatMap((root) => {
+  roots.forEach((root) => {
     if (root instanceof ShadowRoot && !root.getElementById(MONACO_CONTEXT_MENU_STYLE_ID)) {
       const style = document.createElement('style');
       style.id = MONACO_CONTEXT_MENU_STYLE_ID;
       style.textContent = MONACO_CONTEXT_MENU_STYLES;
       root.append(style);
     }
-    return Array.from(root.querySelectorAll<HTMLElement>('.monaco-menu'));
-  }).filter((menu) => menu.getClientRects().length > 0);
-  const menu = menus[menus.length - 1];
-  if (!menu) return;
-
-  const existing = menu.querySelector<HTMLElement>(':scope > .gn-v2-monaco-context-menu-header');
-  if (existing) {
-    const titleElement = existing.querySelector<HTMLElement>('.gn-v2-context-menu-heading strong');
-    if (titleElement) titleElement.textContent = title;
-    const metaElement = existing.querySelector<HTMLElement>('.gn-v2-context-menu-heading small');
-    if (metaElement) metaElement.textContent = meta || '';
-    return;
-  }
-
-  const header = document.createElement('div');
-  header.className = 'gn-v2-context-menu-header gn-v2-action-menu-header gn-v2-monaco-context-menu-header';
-
-  const icon = document.createElement('span');
-  icon.className = 'gn-v2-context-menu-table-icon gn-v2-action-menu-header-icon gn-v2-monaco-context-menu-icon';
-  icon.setAttribute('aria-hidden', 'true');
-  icon.textContent = 'SQL';
-
-  const heading = document.createElement('span');
-  heading.className = 'gn-v2-context-menu-heading';
-  const strong = document.createElement('strong');
-  strong.textContent = title;
-  heading.appendChild(strong);
-  if (meta) {
-    const small = document.createElement('small');
-    small.textContent = meta;
-    heading.appendChild(small);
-  }
-
-  header.append(icon, heading);
-  menu.prepend(header);
+  });
 };
 
 export default V2ActionMenuPopup;

--- a/frontend/src/styles/v2-theme-workbench.css
+++ b/frontend/src/styles/v2-theme-workbench.css
@@ -470,7 +470,7 @@ body[data-ui-version="v2"] .gn-v2-query-results .query-result-tabs > .ant-tabs-n
   box-sizing: border-box;
   background: var(--gn-bg-panel-2);
   padding: 0 8px 0 0;
-  min-height: 46px;
+  min-height: 36px;
 }
 
 body[data-ui-version="v2"] .gn-v2-query-results .query-result-tabs > .ant-tabs-nav .ant-tabs-extra-content {
@@ -483,22 +483,22 @@ body[data-ui-version="v2"] .gn-v2-query-results .query-result-tabs > .ant-tabs-n
   width: auto !important;
   min-width: 0 !important;
   max-width: 148px !important;
-  height: 46px !important;
-  min-height: 46px;
+  height: 30px !important;
+  min-height: 30px;
   margin: 0 !important;
-  padding: 0 9px !important;
+  padding: 0 7px !important;
   border: 0.5px solid var(--gn-br-1) !important;
-  border-radius: 8px !important;
+  border-radius: 6px !important;
   background: color-mix(in srgb, var(--gn-bg-panel) 72%, transparent) !important;
   color: var(--gn-fg-3) !important;
   align-items: center !important;
   justify-content: center !important;
-  font-size: 14px;
+  font-size: 13px;
 }
 
 body[data-ui-version="v2"] .gn-v2-query-results .query-result-tabs > .ant-tabs-nav .ant-tabs-nav-wrap,
 body[data-ui-version="v2"] .gn-v2-query-results .query-result-tabs > .ant-tabs-nav .ant-tabs-nav-list {
-  min-height: 46px;
+  min-height: 36px;
 }
 
 body[data-ui-version="v2"] .gn-v2-query-results .query-result-tabs > .ant-tabs-nav .ant-tabs-nav-list {
@@ -512,7 +512,7 @@ body[data-ui-version="v2"] .gn-v2-query-results .query-result-tabs > .ant-tabs-n
   display: inline-flex !important;
   align-items: center !important;
   justify-content: center !important;
-  font-size: 14px !important;
+  font-size: 13px !important;
   line-height: 1 !important;
 }
 
@@ -524,7 +524,7 @@ body[data-ui-version="v2"] .gn-v2-query-results .query-result-tab-label {
 }
 
 body[data-ui-version="v2"] .gn-v2-query-results .query-result-tab-text {
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 700;
 }
 

--- a/frontend/src/v2-theme.css
+++ b/frontend/src/v2-theme.css
@@ -533,6 +533,20 @@ body[data-ui-version="v2"] .ant-dropdown-menu-submenu-title .ant-dropdown-menu-i
   line-height: 1 !important;
 }
 
+.gn-query-format-case-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  color: currentColor;
+  font-family: var(--gn-font-sans);
+  font-size: 10px;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
 body[data-ui-version="v2"] .ant-dropdown-menu-submenu-expand-icon {
   display: inline-flex !important;
   align-items: center !important;
@@ -559,22 +573,10 @@ body[data-ui-version="v2"] .monaco-menu {
   border: 0.5px solid var(--gn-br-2) !important;
   border-radius: var(--gn-v2-menu-surface-radius) !important;
   background: var(--gn-bg-panel) !important;
+  color: var(--gn-fg-1) !important;
+  font-family: var(--gn-font-sans) !important;
+  font-size: 12.5px !important;
   box-shadow: var(--gn-shadow-lg) !important;
-}
-
-body[data-ui-version="v2"] .monaco-menu > .gn-v2-monaco-context-menu-header {
-  margin: calc(var(--gn-v2-menu-surface-padding) * -1) calc(var(--gn-v2-menu-surface-padding) * -1) 4px;
-  border-radius: calc(var(--gn-v2-menu-surface-radius) - 1px) calc(var(--gn-v2-menu-surface-radius) - 1px) 0 0;
-  font-family: var(--gn-font-sans);
-}
-
-body[data-ui-version="v2"] .gn-v2-monaco-context-menu-icon {
-  width: 18px;
-  color: var(--gn-info);
-  font-family: var(--gn-font-mono);
-  font-size: 8px;
-  font-weight: 700;
-  letter-spacing: -0.04em;
 }
 
 body[data-ui-version="v2"] .monaco-menu-option,
@@ -582,8 +584,16 @@ body[data-ui-version="v2"] .monaco-menu .monaco-action-bar.vertical .action-menu
 body[data-ui-version="v2"] .monaco-menu .monaco-action-bar.vertical .action-label:not(.separator) {
   min-height: var(--gn-v2-menu-row-height) !important;
   border-radius: var(--gn-v2-menu-item-radius) !important;
+  background: transparent !important;
+  color: var(--gn-fg-1) !important;
+  font-family: var(--gn-font-sans) !important;
   font-size: 12.5px !important;
+  font-weight: 500 !important;
   line-height: var(--gn-v2-menu-row-height) !important;
+}
+
+body[data-ui-version="v2"] .monaco-menu .monaco-action-bar.vertical .action-menu-item {
+  margin: 0 !important;
 }
 
 body[data-ui-version="v2"] .monaco-menu-option,
@@ -592,10 +602,18 @@ body[data-ui-version="v2"] .monaco-menu .monaco-action-bar.vertical .action-labe
 }
 
 body[data-ui-version="v2"] .monaco-menu-option.active,
-body[data-ui-version="v2"] .monaco-menu .monaco-action-bar.vertical .action-menu-item:focus {
+body[data-ui-version="v2"] .monaco-menu .monaco-action-bar.vertical .action-item > .action-menu-item:hover,
+body[data-ui-version="v2"] .monaco-menu .monaco-action-bar.vertical .action-item > .action-menu-item:focus {
   background: var(--gn-bg-active) !important;
   color: var(--gn-fg-1) !important;
   outline: none !important;
+}
+
+body[data-ui-version="v2"] .monaco-menu .keybinding {
+  color: var(--gn-fg-4) !important;
+  font-family: var(--gn-font-mono) !important;
+  font-size: 10.5px !important;
+  font-weight: 500 !important;
 }
 
 body[data-ui-version="v2"] .monaco-menu .monaco-action-bar .action-item .action-label.separator {


### PR DESCRIPTION
## 背景

查询工作台中的操作菜单、结果标签菜单和 SQL 编辑器右键菜单样式不一致，设置下拉框中的关键字大小写图标也不够清晰。同时，结果标签交互和右键菜单首次打开时存在体验问题。

## 变更点

- 统一 V2 操作菜单的字体、背景、图标、分割线、悬浮和选中状态
- 对齐 SQL 编辑器 Monaco 右键菜单与设置下拉框的视觉样式
- 保留 Monaco 原生右键命令、快捷键、焦点管理和子菜单逻辑
- 修复右键菜单首次打开时样式注入延迟
- 使用轻量的 `AA` / `aa` 区分关键字大小写，并保持原有图标尺寸
- 支持中键关闭结果标签，优化标签紧凑布局
- 简化查询标签和结果标签的右键菜单
- 补充菜单样式、标签交互、首次打开时序和大小写图标回归测试

## 影响范围

- 仅涉及前端查询工作台、SQL 编辑器菜单、结果标签和主题样式
- 不涉及后端接口、数据库逻辑或数据结构变更
- 不改变 Monaco 编辑器原有命令和快捷键行为

## 验证

- `npm test -- QueryEditorToolbar.layout.test.tsx`：16/16 通过
- `npx tsc --noEmit`：通过
- `git diff --check origin/dev...HEAD`：通过