### PR TITLE
perf(sqlite): cache table statistics for faster tree loading

### DIFF
--- a/frontend/src/components/TableOverview.tdengine.test.tsx
+++ b/frontend/src/components/TableOverview.tdengine.test.tsx
@@ -46,6 +46,7 @@ const storeState = vi.hoisted(() => ({
 
 const backendApp = vi.hoisted(() => ({
   DBGetTables: vi.fn(),
+  DBRefreshTableStats: vi.fn(),
   DBQuery: vi.fn(),
   DBShowCreateTable: vi.fn(),
   ExportTable: vi.fn(),
@@ -215,6 +216,7 @@ describe('TableOverview metadata compatibility', () => {
         { Table: 'meters' },
       ],
     });
+    backendApp.DBRefreshTableStats.mockResolvedValue({ success: false });
     backendApp.DBQuery.mockResolvedValue({
       success: false,
       message: '[0x2600] syntax error near',
@@ -377,6 +379,7 @@ describe('TableOverview metadata compatibility', () => {
     await flushPromises();
 
     expect(backendApp.DBGetTables).toHaveBeenCalledWith(expect.any(Object), 'main');
+    expect(backendApp.DBRefreshTableStats).toHaveBeenCalledWith(expect.any(Object), 'main', ['users', 'orders']);
     expect(backendApp.DBQuery).not.toHaveBeenCalled();
     expect(messageApi.error).not.toHaveBeenCalled();
     const renderedText = collectText(renderer!.toJSON());
@@ -389,6 +392,51 @@ describe('TableOverview metadata compatibility', () => {
     expect(renderedText).toContain('2.0 KB');
     expect(renderedText).toContain('0 B');
     expect(renderedText).toContain('100%');
+  });
+
+  it('shows cached sqlite rows before an asynchronous stats refresh completes', async () => {
+    storeState.connections = [
+      {
+        id: 'conn-1',
+        config: {
+          type: 'sqlite',
+          host: '',
+          port: 0,
+          user: '',
+          password: '',
+          database: 'E:\\data\\app.db',
+          useSSH: false,
+          ssh: { host: '', port: 22, user: '', password: '', keyPath: '' },
+        },
+      },
+    ];
+    const refresh = createDeferred<{ success: boolean; data: Array<Record<string, string>> }>();
+    backendApp.DBGetTables.mockResolvedValue({
+      success: true,
+      data: [{ Table: 'users', Rows: '12' }],
+    });
+    backendApp.DBRefreshTableStats.mockReturnValue(refresh.promise);
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<TableOverview tab={{
+        id: 'tab-1',
+        title: '表概览 - main',
+        type: 'table-overview',
+        connectionId: 'conn-1',
+        dbName: 'main',
+      } as any} />);
+    });
+    await flushPromises();
+
+    expect(collectText(renderer!.toJSON())).toContain('12');
+
+    refresh.resolve({ success: true, data: [{ Table: 'users', Rows: '25' }] });
+    await flushPromises();
+
+    const refreshedText = collectText(renderer!.toJSON());
+    expect(refreshedText).toContain('25');
+    expect(refreshedText).not.toContain('12');
   });
 
   it('loads milvus collections through DBGetTables instead of information_schema SQL', async () => {

--- a/frontend/src/components/TableOverview.tsx
+++ b/frontend/src/components/TableOverview.tsx
@@ -6,7 +6,7 @@ import { Input, Spin, Empty, Dropdown, message, Tooltip, Button } from 'antd';
 import type { MenuProps } from 'antd';
 import { TableOutlined, SearchOutlined, ReloadOutlined, SortAscendingOutlined, DatabaseOutlined, ConsoleSqlOutlined, EditOutlined, CopyOutlined, SaveOutlined, DeleteOutlined, ExportOutlined, AppstoreOutlined, UnorderedListOutlined, WarningOutlined, CaretUpFilled, CaretDownFilled } from '@ant-design/icons';
 import { buildSidebarTablePinKey, useStore, type TableOverviewViewMode } from '../store';
-import { DBGetTables, DBQuery, DBShowCreateTable, DropTable, RenameTable } from '../../wailsjs/go/app/App';
+import { DBGetTables, DBQuery, DBRefreshTableStats, DBShowCreateTable, DropTable, RenameTable } from '../../wailsjs/go/app/App';
 import type { TabData } from '../types';
 import { useAutoFetchVisibility } from '../utils/autoFetchVisibility';
 import { buildRpcConnectionConfig } from '../utils/connectionRpcConfig';
@@ -345,6 +345,21 @@ const TableOverview: React.FC<TableOverviewProps> = ({ tab }) => {
                 if (!isLatestRequest()) return;
                 if (res.success && Array.isArray(res.data)) {
                     setTables(parseTableStats(metadataDialect, res.data));
+                    if (metadataDialect === 'sqlite' || metadataDialect === 'sqlite3') {
+                        setLoading(false);
+                        const tableNames = res.data
+                            .map((row: Record<string, any>) => extractTableNameFromMetadataRow(row))
+                            .filter((tableName: string) => tableName !== '');
+                        const refreshed = await DBRefreshTableStats(
+                            buildRpcConnectionConfig(config) as any,
+                            tab.dbName || '',
+                            tableNames,
+                        ).catch(() => null);
+                        if (!isLatestRequest()) return;
+                        if (refreshed?.success && Array.isArray(refreshed.data)) {
+                            setTables(parseTableStats(metadataDialect, refreshed.data));
+                        }
+                    }
                 } else {
                     message.error(t('table_overview.message.load_tables_failed', {
                         detail: res.message || t('table_overview.message.unknown_error'),

--- a/frontend/src/components/sidebar/useSidebarTreeLoaders.partitions.test.tsx
+++ b/frontend/src/components/sidebar/useSidebarTreeLoaders.partitions.test.tsx
@@ -9,6 +9,7 @@ import { useSidebarTreeLoaders } from './useSidebarTreeLoaders';
 const mocks = vi.hoisted(() => ({
   dbGetDatabases: vi.fn(),
   dbGetTables: vi.fn(),
+  dbRefreshTableStats: vi.fn(),
   dbQuery: vi.fn(),
   getDriverStatusList: vi.fn(),
   jvmProbeCapabilities: vi.fn(),
@@ -54,6 +55,7 @@ vi.mock('../../store', async () => {
 vi.mock('../../../wailsjs/go/app/App', () => ({
   DBGetDatabases: mocks.dbGetDatabases,
   DBGetTables: mocks.dbGetTables,
+  DBRefreshTableStats: mocks.dbRefreshTableStats,
   DBQuery: mocks.dbQuery,
   GetDriverStatusList: mocks.getDriverStatusList,
   JVMProbeCapabilities: mocks.jvmProbeCapabilities,
@@ -70,6 +72,7 @@ describe('useSidebarTreeLoaders PostgreSQL partitions', () => {
     mocks.storeState.pinnedSidebarTables = [];
     mocks.storeState.pinnedSidebarDatabases = [];
     mocks.replaceTreeNodeChildren.mockImplementation((_key, children) => children || []);
+    mocks.dbRefreshTableStats.mockResolvedValue({ success: false });
   });
 
   afterEach(() => {
@@ -427,5 +430,81 @@ describe('useSidebarTreeLoaders PostgreSQL partitions', () => {
 
     expect(freshLoadResolved).toBe(true);
     expect(loadingNodesRef.current.size).toBe(0);
+  });
+
+  it('renders cached sqlite table stats before applying the asynchronous refresh', async () => {
+    const refresh = deferred<any>();
+    const connection = {
+      id: 'conn-sqlite',
+      name: 'SQLite',
+      dbName: 'main',
+      config: {
+        id: 'conn-sqlite',
+        type: 'sqlite',
+        database: 'E:\\data\\app.db',
+      },
+    } as SavedConnection & { dbName: string };
+    mocks.storeState.connections = [connection];
+    mocks.dbGetTables.mockResolvedValue({
+      success: true,
+      data: [{ Table: 'orders', Rows: '5', Data_length: '1024' }],
+    });
+    mocks.dbQuery.mockResolvedValue({ success: true, data: [] });
+    mocks.dbRefreshTableStats.mockReturnValue(refresh.promise);
+
+    let loaders: ReturnType<typeof useSidebarTreeLoaders> | undefined;
+    const Harness = () => {
+      loaders = useSidebarTreeLoaders({
+        savedQueries: [],
+        tableSortPreference: {},
+        tableAccessCount: {},
+        pinnedSidebarTables: [],
+        pinnedSidebarDatabases: [],
+        isV2Ui: true,
+        loadingNodesRef: { current: new Set<string>() },
+        setConnectionStates: vi.fn(),
+        setLoadedKeys: vi.fn(),
+        replaceTreeNodeChildren: mocks.replaceTreeNodeChildren,
+        buildRuntimeConfig: (conn) => conn.config,
+        buildJVMRuntimeConfig: (conn) => conn.config,
+        buildJVMDiagnosticTreeNodes: () => [],
+        resolveSavedQueryDisplayName: (name) => String(name || ''),
+      });
+      return null;
+    };
+
+    act(() => {
+      renderer = create(<Harness />);
+    });
+    const load = loaders!.loadTables({ key: 'conn-sqlite-main', dataRef: connection });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.replaceTreeNodeChildren).toHaveBeenCalledTimes(1);
+    const initialChildren = mocks.replaceTreeNodeChildren.mock.calls[0][1];
+    const findTableNode = (nodes: any[]): any => {
+      for (const node of nodes || []) {
+        if (node.type === 'table' && node.dataRef?.tableName === 'orders') return node;
+        const nested = findTableNode(node.children || []);
+        if (nested) return nested;
+      }
+      return undefined;
+    };
+    expect(findTableNode(initialChildren).dataRef).toMatchObject({ rowCount: 5, tableSize: 1024 });
+
+    refresh.resolve({
+      success: true,
+      data: [{ Table: 'orders', Rows: '9', Data_length: '2048' }],
+    });
+    await act(async () => {
+      await load;
+    });
+
+    expect(mocks.replaceTreeNodeChildren).toHaveBeenCalledTimes(2);
+    const refreshedChildren = mocks.replaceTreeNodeChildren.mock.calls[1][1];
+    expect(findTableNode(refreshedChildren).dataRef).toMatchObject({ rowCount: 9, tableSize: 2048 });
   });
 });

--- a/frontend/src/components/sidebar/useSidebarTreeLoaders.tsx
+++ b/frontend/src/components/sidebar/useSidebarTreeLoaders.tsx
@@ -64,7 +64,7 @@ import {
 import {
   groupSidebarPartitionTableEntries,
 } from './sidebarPartitions';
-import { DBGetDatabases, DBGetTables, DBQuery, GetDriverStatusList, JVMProbeCapabilities } from '../../../wailsjs/go/app/App';
+import { DBGetDatabases, DBGetTables, DBQuery, DBRefreshTableStats, GetDriverStatusList, JVMProbeCapabilities } from '../../../wailsjs/go/app/App';
 import type { SidebarTableMetadataSnapshot } from '../../utils/sidebarTableMetadata';
 import { collectNacosServiceGroupsByPage } from '../nacosServiceName';
 
@@ -94,6 +94,46 @@ type SidebarLoadedTableEntry = {
   tableComment?: string;
   partitionParentTableName?: string;
   partitionTables?: SidebarLoadedTableEntry[];
+};
+
+const applyRefreshedSQLiteStatsToTree = (
+  nodes: TreeNode[],
+  rows: Record<string, any>[],
+): TreeNode[] => {
+  const statsByTable = new Map<string, { rowCount?: number; tableSize?: number }>();
+  rows.forEach((row) => {
+    const tableName = getSidebarTableName(row).trim().toLowerCase();
+    if (!tableName) return;
+    const rowCount = parseMetadataRowCount(row);
+    const rawTableSize = getCaseInsensitiveValue(row, ['Data_length', 'data_length', 'DATA_LENGTH']);
+    const parsedTableSize = rawTableSize === undefined || rawTableSize === null || rawTableSize === ''
+      ? undefined
+      : Number(rawTableSize);
+    statsByTable.set(tableName, {
+      ...(rowCount !== undefined ? { rowCount } : {}),
+      ...(parsedTableSize !== undefined && Number.isFinite(parsedTableSize) ? { tableSize: parsedTableSize } : {}),
+    });
+  });
+
+  const updateNode = (node: TreeNode): TreeNode => {
+    const dataRef = node.dataRef as Record<string, any> | undefined;
+    const tableName = String(dataRef?.tableName || '').trim().toLowerCase();
+    const stat = tableName ? statsByTable.get(tableName) : undefined;
+    const children = Array.isArray(node.children) ? node.children.map(updateNode) : node.children;
+    return {
+      ...node,
+      ...(stat && dataRef ? {
+        dataRef: {
+          ...dataRef,
+          ...(stat.rowCount !== undefined ? { rowCount: stat.rowCount } : {}),
+          ...(stat.tableSize !== undefined ? { tableSize: stat.tableSize } : {}),
+        },
+      } : {}),
+      ...(children ? { children } : {}),
+    };
+  };
+
+  return nodes.map(updateNode);
 };
 
 export type SidebarTreeLoadOptions = {
@@ -881,8 +921,16 @@ export const useSidebarTreeLoaders = ({
                 tableRows.forEach((row: Record<string, any>) => {
                     const tableName = getSidebarTableName(row);
                     const rowCount = parseMetadataRowCount(row);
-                    if (tableName && rowCount !== undefined) {
-                        mergeTableMetadata(tableName, { rowCount });
+                    const tableSize = readNumericMetadataValue(row, [
+                        'Data_length',
+                        'data_length',
+                        'DATA_LENGTH',
+                    ]);
+                    if (tableName && (rowCount !== undefined || tableSize !== undefined)) {
+                        mergeTableMetadata(tableName, {
+                            ...(rowCount !== undefined ? { rowCount } : {}),
+                            ...(tableSize !== undefined ? { tableSize } : {}),
+                        });
                     }
                 });
                 if (tableStatsResult?.success && Array.isArray(tableStatsResult.data)) {
@@ -1358,6 +1406,7 @@ export const useSidebarTreeLoaders = ({
 	                };
 	            };
 
+	            let renderedDatabaseChildren: TreeNode[];
 	            if (shouldGroupBySchema) {
 	                type SchemaBucket = {
 	                    schemaName: string;
@@ -1444,7 +1493,7 @@ export const useSidebarTreeLoaders = ({
 	                        };
 	                    });
 
-	                replaceTreeNodeChildren(key, [queriesNode, ...schemaNodes], latestDatabaseConnection);
+	                renderedDatabaseChildren = [queriesNode, ...schemaNodes];
 	            } else {
 	                const dialect = getMetadataDialect(conn as SavedConnection);
 	                const includeMaterializedViews = dialect === 'starrocks';
@@ -1462,10 +1511,29 @@ export const useSidebarTreeLoaders = ({
 	                    ...(includeEvents ? [buildObjectGroup(key as string, 'events', t('sidebar.object_group.events'), <ClockCircleOutlined />, eventEntries.map(buildEventNode))] : []),
 	                ];
 
-	                replaceTreeNodeChildren(key, [queriesNode, ...groupedNodes], latestDatabaseConnection);
+	                renderedDatabaseChildren = [queriesNode, ...groupedNodes];
 	            }
+	            replaceTreeNodeChildren(key, renderedDatabaseChildren, latestDatabaseConnection);
                 onDatabaseTreeLoaded?.(String(key));
                 shouldMarkDatabaseSuccess = true;
+
+	            if (getMetadataDialect(conn as SavedConnection) === 'sqlite') {
+	                const tableNames = tableRows
+	                    .map((row) => getSidebarTableName(row as Record<string, any>))
+	                    .filter((tableName) => String(tableName || '').trim() !== '');
+	                const refreshed = await DBRefreshTableStats(
+	                    buildRpcConnectionConfig(config) as any,
+	                    conn.dbName,
+	                    tableNames,
+	                ).catch(() => null);
+	                if (refreshed?.success && Array.isArray(refreshed.data)) {
+	                    renderedDatabaseChildren = applyRefreshedSQLiteStatsToTree(
+	                        renderedDatabaseChildren,
+	                        refreshed.data as Record<string, any>[],
+	                    );
+	                    replaceTreeNodeChildren(key, renderedDatabaseChildren, latestDatabaseConnection);
+	                }
+	            }
 	          } else {
 	            setConnectionStates(prev => ({ ...prev, [key as string]: 'error' }));
 	            message.error({ content: res.message, key: `db-${key}-tables` });

--- a/frontend/wailsjs/go/app/App.d.ts
+++ b/frontend/wailsjs/go/app/App.d.ts
@@ -109,6 +109,8 @@ export function DBQueryMultiTransactional(arg1:connection.ConnectionConfig,arg2:
 
 export function DBQueryWithCancel(arg1:connection.ConnectionConfig,arg2:string,arg3:string,arg4:string):Promise<connection.QueryResult>;
 
+export function DBRefreshTableStats(arg1:connection.ConnectionConfig,arg2:string,arg3:Array<string>):Promise<connection.QueryResult>;
+
 export function DBReleaseConnection(arg1:connection.ConnectionConfig):Promise<connection.QueryResult>;
 
 export function DBRollbackTransaction(arg1:string):Promise<connection.QueryResult>;

--- a/frontend/wailsjs/go/app/App.js
+++ b/frontend/wailsjs/go/app/App.js
@@ -202,6 +202,10 @@ export function DBQueryWithCancel(arg1, arg2, arg3, arg4) {
   return window['go']['app']['App']['DBQueryWithCancel'](arg1, arg2, arg3, arg4);
 }
 
+export function DBRefreshTableStats(arg1, arg2, arg3) {
+  return window['go']['app']['App']['DBRefreshTableStats'](arg1, arg2, arg3);
+}
+
 export function DBReleaseConnection(arg1) {
   return window['go']['app']['App']['DBReleaseConnection'](arg1);
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -192,6 +192,7 @@ type App struct {
 	importTasksClosing            bool
 	dataRootApplyMu               sync.Mutex
 	configDir                     string
+	sqliteTableStatsMu            sync.Mutex
 	secretStore                   secretstore.SecretStore
 	runningQueries                map[string]queryContext // queryID -> cancelFunc and start time
 	sqlTransactionMu              sync.Mutex

--- a/internal/app/methods_db.go
+++ b/internal/app/methods_db.go
@@ -2238,6 +2238,23 @@ func (a *App) DBGetTables(config connection.ConnectionConfig, dbName string) con
 		return connection.QueryResult{Success: false, Message: err.Error()}
 	}
 
+	if isSQLiteConnection(runConfig) {
+		cachedStats, cacheErr := a.readSQLiteTableStats(runConfig, dbName)
+		if cacheErr != nil {
+			logger.Warnf("DBGetTables 读取 SQLite 表统计缓存失败（保留表列表）：%s err=%v", formatConnSummary(runConfig), cacheErr)
+			cachedStats = map[string]sqliteCachedTableStat{}
+		}
+		resData := make([]map[string]string, 0, len(tables))
+		for _, name := range tables {
+			item := map[string]string{"Table": name}
+			if stat, ok := cachedStats[name]; ok {
+				applySQLiteTableStats(item, stat)
+			}
+			resData = append(resData, item)
+		}
+		return connection.QueryResult{Success: true, Data: resData}
+	}
+
 	tableRowCounts := map[string]int64{}
 	if rowCounter, ok := dbInst.(db.TableRowCounter); ok {
 		var countErr error
@@ -2268,6 +2285,75 @@ func (a *App) DBGetTables(config connection.ConnectionConfig, dbName string) con
 		resData = append(resData, item)
 	}
 
+	return connection.QueryResult{Success: true, Data: resData}
+}
+
+func (a *App) DBRefreshTableStats(config connection.ConnectionConfig, dbName string, rawTables []string) connection.QueryResult {
+	runConfig := normalizeMetadataRunConfig(config, dbName)
+	if !isSQLiteConnection(runConfig) {
+		return connection.QueryResult{Success: false, Message: "table statistics refresh is only supported for SQLite connections"}
+	}
+
+	tables := make([]string, 0, len(rawTables))
+	seen := make(map[string]struct{}, len(rawTables))
+	for _, rawTable := range rawTables {
+		tableName := strings.TrimSpace(rawTable)
+		if tableName == "" {
+			continue
+		}
+		if _, ok := seen[tableName]; ok {
+			continue
+		}
+		seen[tableName] = struct{}{}
+		tables = append(tables, tableName)
+	}
+
+	dbInst, err := a.getDatabase(runConfig)
+	if err != nil {
+		logger.Error(err, "DBRefreshTableStats 获取连接失败：%s", formatConnSummary(runConfig))
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+
+	tableRowCounts := map[string]int64{}
+	if rowCounter, ok := dbInst.(db.TableRowCounter); ok {
+		tableRowCounts, err = rowCounter.GetTableRowCounts(dbName, tables)
+		if err != nil {
+			logger.Warnf("DBRefreshTableStats 获取 SQLite 表行数失败（保留旧缓存）：%s err=%v", formatConnSummary(runConfig), err)
+			return connection.QueryResult{Success: false, Message: err.Error()}
+		}
+	}
+
+	tableStorageStats := map[string]db.TableStorageStats{}
+	if storageProvider, ok := dbInst.(db.TableStorageStatsProvider); ok {
+		tableStorageStats, err = storageProvider.GetTableStorageStats(dbName, tables)
+		if err != nil {
+			logger.Warnf("DBRefreshTableStats 获取 SQLite 表存储大小失败（保留旧缓存大小）：%s err=%v", formatConnSummary(runConfig), err)
+			tableStorageStats = map[string]db.TableStorageStats{}
+		}
+	}
+
+	if err := a.mergeSQLiteTableStats(runConfig, dbName, tables, tableRowCounts, tableStorageStats); err != nil {
+		logger.Warnf("DBRefreshTableStats 写入 SQLite 表统计缓存失败（仍返回实时结果）：%s err=%v", formatConnSummary(runConfig), err)
+	}
+	cachedStats, cacheErr := a.readSQLiteTableStats(runConfig, dbName)
+	if cacheErr != nil {
+		cachedStats = map[string]sqliteCachedTableStat{}
+	}
+	resData := make([]map[string]string, 0, len(tables))
+	for _, name := range tables {
+		item := map[string]string{"Table": name}
+		if stat, ok := cachedStats[name]; ok {
+			applySQLiteTableStats(item, stat)
+		}
+		if rowCount, ok := tableRowCounts[name]; ok {
+			item["Rows"] = strconv.FormatInt(rowCount, 10)
+		}
+		if storage, ok := tableStorageStats[name]; ok {
+			item["Data_length"] = strconv.FormatInt(storage.DataLength, 10)
+			item["Index_length"] = strconv.FormatInt(storage.IndexLength, 10)
+		}
+		resData = append(resData, item)
+	}
 	return connection.QueryResult{Success: true, Data: resData}
 }
 

--- a/internal/app/methods_db_sqlite_test.go
+++ b/internal/app/methods_db_sqlite_test.go
@@ -9,15 +9,17 @@ import (
 	"GoNavi-Wails/internal/connection"
 )
 
-func TestDBGetTablesIncludesSQLiteRowCounts(t *testing.T) {
+func TestDBGetTablesUsesRefreshedSQLiteRowCounts(t *testing.T) {
 	app := newSQLAuditTestApp(t)
 	databasePath := filepath.Join(t.TempDir(), "table-counts.sqlite")
 	config := connection.ConnectionConfig{
+		ID:       "sqlite-table-counts",
 		Type:     "custom",
 		Driver:   "sqlite",
 		DSN:      databasePath,
 		Database: databasePath,
 	}
+	config = config.WithResolvedSavedSnapshot()
 	t.Cleanup(func() { app.DBReleaseConnection(config) })
 
 	for _, statement := range []string{
@@ -30,7 +32,13 @@ func TestDBGetTablesIncludesSQLiteRowCounts(t *testing.T) {
 		}
 	}
 
-	result := app.DBGetTables(config, databasePath)
+	initial := app.DBGetTables(config, databasePath)
+	initialTable := findTableStatRow(t, initial, "orders")
+	if _, ok := initialTable["Rows"]; ok {
+		t.Fatalf("DBGetTables should not query a live SQLite row count: %#v", initialTable)
+	}
+
+	result := app.DBRefreshTableStats(config, databasePath, []string{"orders"})
 	if !result.Success {
 		t.Fatalf("DBGetTables returned failure: %s", result.Message)
 	}

--- a/internal/app/sqlite_table_stats_cache.go
+++ b/internal/app/sqlite_table_stats_cache.go
@@ -1,0 +1,181 @@
+package app
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"GoNavi-Wails/internal/appdata"
+	"GoNavi-Wails/internal/connection"
+	"GoNavi-Wails/internal/db"
+)
+
+const sqliteTableStatsCacheFileName = "sqlite_table_stats.json"
+
+type sqliteCachedTableStat struct {
+	Rows        *int64 `json:"rows,omitempty"`
+	DataLength  *int64 `json:"dataLength,omitempty"`
+	IndexLength *int64 `json:"indexLength,omitempty"`
+	UpdatedAt   int64  `json:"updatedAt"`
+}
+
+type sqliteTableStatsCache map[string]map[string]map[string]sqliteCachedTableStat
+
+func isSQLiteConnection(config connection.ConnectionConfig) bool {
+	return resolveDDLDBType(config) == "sqlite" || strings.EqualFold(strings.TrimSpace(config.Type), "sqlite3")
+}
+
+func sqliteTableStatsDatabaseName(dbName string) string {
+	if normalized := strings.TrimSpace(dbName); normalized != "" {
+		return normalized
+	}
+	return "main"
+}
+
+func (a *App) sqliteTableStatsCachePath() string {
+	root := strings.TrimSpace(a.configDir)
+	if root == "" {
+		root = resolveAppConfigDir()
+	}
+	return filepath.Join(root, "cache", sqliteTableStatsCacheFileName)
+}
+
+func (a *App) readSQLiteTableStats(config connection.ConnectionConfig, dbName string) (map[string]sqliteCachedTableStat, error) {
+	connectionID := strings.TrimSpace(config.ID)
+	if connectionID == "" {
+		return map[string]sqliteCachedTableStat{}, nil
+	}
+
+	a.sqliteTableStatsMu.Lock()
+	defer a.sqliteTableStatsMu.Unlock()
+	cache, err := a.loadSQLiteTableStatsCacheLocked()
+	if err != nil {
+		return nil, err
+	}
+	databaseStats := cache[connectionID][sqliteTableStatsDatabaseName(dbName)]
+	result := make(map[string]sqliteCachedTableStat, len(databaseStats))
+	for tableName, stat := range databaseStats {
+		result[tableName] = stat
+	}
+	return result, nil
+}
+
+func (a *App) mergeSQLiteTableStats(
+	config connection.ConnectionConfig,
+	dbName string,
+	tables []string,
+	rowCounts map[string]int64,
+	storageStats map[string]db.TableStorageStats,
+) error {
+	connectionID := strings.TrimSpace(config.ID)
+	if connectionID == "" {
+		return nil
+	}
+
+	a.sqliteTableStatsMu.Lock()
+	defer a.sqliteTableStatsMu.Unlock()
+	cache, err := a.loadSQLiteTableStatsCacheLocked()
+	if err != nil {
+		cache = sqliteTableStatsCache{}
+	}
+	if cache == nil {
+		cache = sqliteTableStatsCache{}
+	}
+	if cache[connectionID] == nil {
+		cache[connectionID] = map[string]map[string]sqliteCachedTableStat{}
+	}
+	databaseName := sqliteTableStatsDatabaseName(dbName)
+	if cache[connectionID][databaseName] == nil {
+		cache[connectionID][databaseName] = map[string]sqliteCachedTableStat{}
+	}
+
+	updatedAt := time.Now().Unix()
+	for _, rawTableName := range tables {
+		tableName := strings.TrimSpace(rawTableName)
+		if tableName == "" {
+			continue
+		}
+		stat := cache[connectionID][databaseName][tableName]
+		updated := false
+		if rowCount, ok := rowCounts[tableName]; ok {
+			value := rowCount
+			stat.Rows = &value
+			updated = true
+		}
+		if storage, ok := storageStats[tableName]; ok {
+			dataLength := storage.DataLength
+			indexLength := storage.IndexLength
+			stat.DataLength = &dataLength
+			stat.IndexLength = &indexLength
+			updated = true
+		}
+		if updated {
+			stat.UpdatedAt = updatedAt
+			cache[connectionID][databaseName][tableName] = stat
+		}
+	}
+	return a.saveSQLiteTableStatsCacheLocked(cache)
+}
+
+func (a *App) loadSQLiteTableStatsCacheLocked() (sqliteTableStatsCache, error) {
+	data, err := os.ReadFile(a.sqliteTableStatsCachePath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return sqliteTableStatsCache{}, nil
+		}
+		return nil, err
+	}
+	cache := sqliteTableStatsCache{}
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return nil, err
+	}
+	return cache, nil
+}
+
+func (a *App) saveSQLiteTableStatsCacheLocked(cache sqliteTableStatsCache) error {
+	path := a.sqliteTableStatsCachePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(cache, "", "  ")
+	if err != nil {
+		return err
+	}
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".sqlite-table-stats-*.tmp")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if err := temporary.Chmod(0o600); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if _, err := temporary.Write(data); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return appdata.AtomicReplaceFile(temporaryPath, path)
+}
+
+func applySQLiteTableStats(item map[string]string, stat sqliteCachedTableStat) {
+	if stat.Rows != nil {
+		item["Rows"] = strconv.FormatInt(*stat.Rows, 10)
+	}
+	if stat.DataLength != nil {
+		item["Data_length"] = strconv.FormatInt(*stat.DataLength, 10)
+	}
+	if stat.IndexLength != nil {
+		item["Index_length"] = strconv.FormatInt(*stat.IndexLength, 10)
+	}
+}

--- a/internal/app/sqlite_table_stats_cache_test.go
+++ b/internal/app/sqlite_table_stats_cache_test.go
@@ -1,0 +1,177 @@
+package app
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"GoNavi-Wails/internal/connection"
+	"GoNavi-Wails/internal/db"
+	"GoNavi-Wails/internal/secretstore"
+)
+
+type tableStatsTestDB struct {
+	releaseRecordingDB
+	tables       []string
+	rowCounts    map[string]int64
+	storageStats map[string]db.TableStorageStats
+	rowCountErr  error
+	storageErr   error
+	rowCalls     int
+	storageCalls int
+}
+
+func (database *tableStatsTestDB) GetTables(string) ([]string, error) {
+	return append([]string(nil), database.tables...), nil
+}
+
+func (database *tableStatsTestDB) GetTableRowCounts(string, []string) (map[string]int64, error) {
+	database.rowCalls++
+	return database.rowCounts, database.rowCountErr
+}
+
+func (database *tableStatsTestDB) GetTableStorageStats(string, []string) (map[string]db.TableStorageStats, error) {
+	database.storageCalls++
+	return database.storageStats, database.storageErr
+}
+
+func newTableStatsTestApp(t *testing.T, configDir string, config connection.ConnectionConfig, database db.Database) *App {
+	t.Helper()
+	application := NewAppWithSecretStore(secretstore.NewUnavailableStore("test"))
+	application.configDir = configDir
+	application.dbCache[getCacheKey(config)] = cachedDatabase{
+		inst:     database,
+		lastPing: time.Now(),
+		config:   normalizeCacheKeyConfig(config),
+	}
+	return application
+}
+
+func findTableStatRow(t *testing.T, result connection.QueryResult, tableName string) map[string]string {
+	t.Helper()
+	if !result.Success {
+		t.Fatalf("table stats request failed: %s", result.Message)
+	}
+	rows, ok := result.Data.([]map[string]string)
+	if !ok {
+		t.Fatalf("table stats data type = %T, want []map[string]string", result.Data)
+	}
+	for _, row := range rows {
+		if row["Table"] == tableName {
+			return row
+		}
+	}
+	t.Fatalf("table %q missing from result: %#v", tableName, rows)
+	return nil
+}
+
+func TestDBGetTablesDoesNotQueryLiveSQLiteStats(t *testing.T) {
+	tables := make([]string, 100)
+	for index := range tables {
+		tables[index] = fmt.Sprintf("table_%03d", index)
+	}
+	database := &tableStatsTestDB{tables: tables}
+	config := connection.ConnectionConfig{ID: "sqlite-100", Type: "custom", Driver: "sqlite", DSN: "large.sqlite", Database: "large.sqlite"}
+	config = config.WithResolvedSavedSnapshot()
+	application := newTableStatsTestApp(t, t.TempDir(), config, database)
+
+	result := application.DBGetTables(config, "main")
+	if !result.Success {
+		t.Fatalf("DBGetTables returned failure: %s", result.Message)
+	}
+	rows := result.Data.([]map[string]string)
+	if len(rows) != len(tables) {
+		t.Fatalf("DBGetTables returned %d tables, want %d", len(rows), len(tables))
+	}
+	if database.rowCalls != 0 || database.storageCalls != 0 {
+		t.Fatalf("DBGetTables queried live SQLite stats: rows=%d storage=%d", database.rowCalls, database.storageCalls)
+	}
+}
+
+func TestDBRefreshTableStatsPersistsAndDBGetTablesReadsCache(t *testing.T) {
+	configDir := t.TempDir()
+	config := connection.ConnectionConfig{ID: "sqlite-persisted", Type: "custom", Driver: "sqlite", Database: "app.sqlite"}
+	config = config.WithResolvedSavedSnapshot()
+	database := &tableStatsTestDB{
+		tables:    []string{"orders"},
+		rowCounts: map[string]int64{"orders": 42},
+		storageStats: map[string]db.TableStorageStats{
+			"orders": {DataLength: 4096, IndexLength: 1024},
+		},
+	}
+	application := newTableStatsTestApp(t, configDir, config, database)
+
+	refreshed := findTableStatRow(t, application.DBRefreshTableStats(config, "main", []string{"orders"}), "orders")
+	if refreshed["Rows"] != "42" || refreshed["Data_length"] != "4096" || refreshed["Index_length"] != "1024" {
+		t.Fatalf("unexpected refreshed stats: %#v", refreshed)
+	}
+	if _, err := os.Stat(filepath.Join(configDir, "cache", sqliteTableStatsCacheFileName)); err != nil {
+		t.Fatalf("SQLite stats cache was not persisted: %v", err)
+	}
+
+	restartedDB := &tableStatsTestDB{tables: []string{"orders"}}
+	restarted := newTableStatsTestApp(t, configDir, config, restartedDB)
+	cached := findTableStatRow(t, restarted.DBGetTables(config, "main"), "orders")
+	if cached["Rows"] != "42" || cached["Data_length"] != "4096" || cached["Index_length"] != "1024" {
+		t.Fatalf("unexpected persisted stats after restart: %#v", cached)
+	}
+	if restartedDB.rowCalls != 0 || restartedDB.storageCalls != 0 {
+		t.Fatalf("cached DBGetTables queried live stats: rows=%d storage=%d", restartedDB.rowCalls, restartedDB.storageCalls)
+	}
+}
+
+func TestDBRefreshTableStatsFailurePreservesCachedValues(t *testing.T) {
+	configDir := t.TempDir()
+	config := connection.ConnectionConfig{ID: "sqlite-failure", Type: "custom", Driver: "sqlite", DSN: "app.sqlite", Database: "app.sqlite"}
+	config = config.WithResolvedSavedSnapshot()
+	seedDB := &tableStatsTestDB{
+		tables:    []string{"orders"},
+		rowCounts: map[string]int64{"orders": 7},
+	}
+	application := newTableStatsTestApp(t, configDir, config, seedDB)
+	if result := application.DBRefreshTableStats(config, "main", []string{"orders"}); !result.Success {
+		t.Fatalf("seed refresh failed: %s", result.Message)
+	}
+
+	failingDB := &tableStatsTestDB{
+		tables:      []string{"orders"},
+		rowCounts:   map[string]int64{"orders": 99},
+		rowCountErr: errors.New("count failed"),
+	}
+	application.dbCache[getCacheKey(config)] = cachedDatabase{
+		inst:     failingDB,
+		lastPing: time.Now(),
+		config:   normalizeCacheKeyConfig(config),
+	}
+	if result := application.DBRefreshTableStats(config, "main", []string{"orders"}); result.Success {
+		t.Fatal("refresh with a row count error should fail")
+	}
+	cached := findTableStatRow(t, application.DBGetTables(config, "main"), "orders")
+	if cached["Rows"] != "7" {
+		t.Fatalf("failed refresh overwrote cached row count: %#v", cached)
+	}
+}
+
+func TestSQLiteTableStatsCacheIsExcludedFromCloudBackup(t *testing.T) {
+	configDir := t.TempDir()
+	config := connection.ConnectionConfig{ID: "sqlite-backup", Type: "custom", Driver: "sqlite", DSN: "app.sqlite", Database: "app.sqlite"}
+	config = config.WithResolvedSavedSnapshot()
+	application := newTableStatsTestApp(t, configDir, config, &tableStatsTestDB{})
+	if err := application.mergeSQLiteTableStats(config, "main", []string{"orders"}, map[string]int64{"orders": 1}, nil); err != nil {
+		t.Fatalf("write SQLite stats cache: %v", err)
+	}
+	payloadData, err := application.buildCloudBackupPayload(CloudBackupConfig{BackupCategories: defaultCloudBackupCategories()})
+	if err != nil {
+		t.Fatalf("build cloud backup payload: %v", err)
+	}
+	if string(payloadData) == "" {
+		t.Fatal("cloud backup payload is empty")
+	}
+	if bytes.Contains(payloadData, []byte(sqliteTableStatsCacheFileName)) {
+		t.Fatalf("cloud backup payload contains %s", sqliteTableStatsCacheFileName)
+	}
+}


### PR DESCRIPTION
## Summary

- stop synchronous SQLite row counting from blocking `DBGetTables`
- persist per-connection table statistics under the local app cache and refresh them on database load or explicit refresh
- show cached statistics immediately in the sidebar and table overview, then apply refreshed values asynchronously
- preserve cached values when refreshes fail and keep the cache outside cloud backups

## Tests

- `go test ./internal/app ./internal/db -count=1`
- `go test -tags gonavi_sqlite_driver ./internal/app -run TestDBGetTablesUsesRefreshedSQLiteRowCounts -count=1`
- `npm --prefix frontend test -- --run src/components/TableOverview.tdengine.test.tsx src/components/sidebar/useSidebarTreeLoaders.partitions.test.tsx`
- `npm --prefix frontend run build`
- `wails build -clean`

Closes #971