### PR TITLE
fix(db): 为 SQLite 和 DuckDB 设置连接池边界

### DIFF
--- a/internal/db/duckdb_impl.go
+++ b/internal/db/duckdb_impl.go
@@ -68,6 +68,7 @@ func (d *DuckDB) Connect(config connection.ConnectionConfig) error {
 	if err != nil {
 		return duckDBWrapRuntimeError("db.backend.error.connection_open_failed_prefix", err)
 	}
+	configureSQLConnectionPool(db, "duckdb")
 	d.conn = db
 	d.pingTimeout = getConnectTimeout(config)
 

--- a/internal/db/duckdb_pool_integration_test.go
+++ b/internal/db/duckdb_pool_integration_test.go
@@ -1,0 +1,32 @@
+//go:build gonavi_duckdb_driver
+
+package db
+
+import (
+	"path/filepath"
+	"testing"
+
+	"GoNavi-Wails/internal/connection"
+)
+
+func TestDuckDBConnectConfiguresBoundedPool(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "pool.duckdb")
+	client := &DuckDB{}
+	if err := client.Connect(connection.ConnectionConfig{Type: "duckdb", Host: dbPath}); err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+
+	if got := client.conn.Stats().MaxOpenConnections; got != duckDBSQLMaxOpenConns {
+		t.Fatalf("expected max open connections %d, got %d", duckDBSQLMaxOpenConns, got)
+	}
+	if _, err := client.Query("SELECT 1"); err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	stats := client.conn.Stats()
+	if stats.OpenConnections > duckDBSQLMaxOpenConns || stats.Idle > duckDBSQLMaxIdleConns {
+		t.Fatalf("DuckDB connection pool exceeded its bounds: %+v", stats)
+	}
+}

--- a/internal/db/sql_pool.go
+++ b/internal/db/sql_pool.go
@@ -9,6 +9,10 @@ import (
 const (
 	defaultSQLMaxOpenConns    = 4
 	defaultSQLMaxIdleConns    = 1
+	sqliteSQLMaxOpenConns     = 1
+	sqliteSQLMaxIdleConns     = 1
+	duckDBSQLMaxOpenConns     = 4
+	duckDBSQLMaxIdleConns     = 1
 	defaultSQLConnMaxLifetime = 30 * time.Minute
 	defaultSQLConnMaxIdleTime = 30 * time.Second
 	// SQL Server login can be expensive. Keep its single idle connection warm
@@ -28,7 +32,13 @@ func configureSQLConnectionPool(db *sql.DB, dbType string) {
 		return
 	}
 	switch strings.ToLower(strings.TrimSpace(dbType)) {
-	case "sqlite", "duckdb":
+	case "sqlite":
+		db.SetMaxOpenConns(sqliteSQLMaxOpenConns)
+		db.SetMaxIdleConns(sqliteSQLMaxIdleConns)
+		return
+	case "duckdb":
+		db.SetMaxOpenConns(duckDBSQLMaxOpenConns)
+		db.SetMaxIdleConns(duckDBSQLMaxIdleConns)
 		return
 	case "oracle", "oceanbase", "kingbase":
 		db.SetMaxOpenConns(defaultSQLMaxOpenConns)

--- a/internal/db/sql_pool_test.go
+++ b/internal/db/sql_pool_test.go
@@ -5,19 +5,28 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
-const poolRecordingDriverName = "gonavi_pool_recording"
+const (
+	poolRecordingDriverName = "gonavi_pool_recording"
+	poolBlockingDriverName  = "gonavi_pool_blocking"
+)
 
 var (
 	poolRecordingOpenCount  atomic.Int64
 	poolRecordingCloseCount atomic.Int64
+	poolBlockingStatesMu    sync.Mutex
+	poolBlockingStates      = map[string]*poolBlockingState{}
 )
 
 func init() {
 	sql.Register(poolRecordingDriverName, poolRecordingDriver{})
+	sql.Register(poolBlockingDriverName, poolBlockingDriver{})
 }
 
 type poolRecordingDriver struct{}
@@ -46,6 +55,81 @@ func (poolRecordingConn) Ping(ctx context.Context) error {
 	return nil
 }
 
+type poolBlockingState struct {
+	release      chan struct{}
+	releaseOnce  sync.Once
+	started      chan struct{}
+	openCount    atomic.Int64
+	closeCount   atomic.Int64
+	activePings  atomic.Int64
+	maxPingCount atomic.Int64
+}
+
+func newPoolBlockingState(requestCount int) *poolBlockingState {
+	return &poolBlockingState{
+		release: make(chan struct{}),
+		started: make(chan struct{}, requestCount),
+	}
+}
+
+func (s *poolBlockingState) releaseAll() {
+	s.releaseOnce.Do(func() {
+		close(s.release)
+	})
+}
+
+func (s *poolBlockingState) recordActivePing() {
+	active := s.activePings.Add(1)
+	for {
+		current := s.maxPingCount.Load()
+		if active <= current || s.maxPingCount.CompareAndSwap(current, active) {
+			return
+		}
+	}
+}
+
+type poolBlockingDriver struct{}
+
+func (poolBlockingDriver) Open(name string) (driver.Conn, error) {
+	poolBlockingStatesMu.Lock()
+	state := poolBlockingStates[name]
+	poolBlockingStatesMu.Unlock()
+	if state == nil {
+		return nil, fmt.Errorf("blocking pool state not found: %s", name)
+	}
+	state.openCount.Add(1)
+	return &poolBlockingConn{state: state}, nil
+}
+
+type poolBlockingConn struct {
+	state *poolBlockingState
+}
+
+func (c *poolBlockingConn) Prepare(query string) (driver.Stmt, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *poolBlockingConn) Close() error {
+	c.state.closeCount.Add(1)
+	return nil
+}
+
+func (c *poolBlockingConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *poolBlockingConn) Ping(ctx context.Context) error {
+	c.state.recordActivePing()
+	defer c.state.activePings.Add(-1)
+	c.state.started <- struct{}{}
+	select {
+	case <-c.state.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 func resetPoolRecordingDriverCounters() {
 	poolRecordingOpenCount.Store(0)
 	poolRecordingCloseCount.Store(0)
@@ -63,6 +147,118 @@ func openConfiguredPoolForTest(t *testing.T, dbType string) *sql.DB {
 		_ = dbConn.Close()
 	})
 	return dbConn
+}
+
+func openBlockingPoolForTest(t *testing.T, dbType string, requestCount int) (*sql.DB, *poolBlockingState) {
+	t.Helper()
+	stateKey := t.Name()
+	state := newPoolBlockingState(requestCount)
+	poolBlockingStatesMu.Lock()
+	poolBlockingStates[stateKey] = state
+	poolBlockingStatesMu.Unlock()
+
+	dbConn, err := sql.Open(poolBlockingDriverName, stateKey)
+	if err != nil {
+		t.Fatalf("sql.Open failed: %v", err)
+	}
+	configureSQLConnectionPool(dbConn, dbType)
+	t.Cleanup(func() {
+		state.releaseAll()
+		_ = dbConn.Close()
+		poolBlockingStatesMu.Lock()
+		delete(poolBlockingStates, stateKey)
+		poolBlockingStatesMu.Unlock()
+	})
+	return dbConn, state
+}
+
+func waitForPoolCondition(t *testing.T, description string, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", description)
+}
+
+func TestConfigureLocalSQLConnectionPoolBoundsConcurrentRequests(t *testing.T) {
+	const requestCount = 20
+	tests := []struct {
+		name    string
+		dbType  string
+		maxOpen int
+		maxIdle int
+	}{
+		{name: "SQLite", dbType: "sqlite", maxOpen: sqliteSQLMaxOpenConns, maxIdle: sqliteSQLMaxIdleConns},
+		{name: "DuckDB", dbType: "duckdb", maxOpen: duckDBSQLMaxOpenConns, maxIdle: duckDBSQLMaxIdleConns},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dbConn, state := openBlockingPoolForTest(t, tt.dbType, requestCount)
+			if got := dbConn.Stats().MaxOpenConnections; got != tt.maxOpen {
+				t.Fatalf("expected max open connections %d, got %d", tt.maxOpen, got)
+			}
+
+			start := make(chan struct{})
+			errCh := make(chan error, requestCount)
+			for i := 0; i < requestCount; i++ {
+				go func() {
+					<-start
+					errCh <- dbConn.PingContext(context.Background())
+				}()
+			}
+			close(start)
+
+			for i := 0; i < tt.maxOpen; i++ {
+				select {
+				case <-state.started:
+				case <-time.After(5 * time.Second):
+					t.Fatalf("timed out waiting for %d active connections", tt.maxOpen)
+				}
+			}
+			waitForPoolCondition(t, "excess requests to wait", func() bool {
+				return dbConn.Stats().WaitCount >= int64(requestCount-tt.maxOpen)
+			})
+
+			stats := dbConn.Stats()
+			if stats.OpenConnections > tt.maxOpen {
+				t.Fatalf("open connections exceeded limit: limit=%d stats=%+v", tt.maxOpen, stats)
+			}
+			if got := state.openCount.Load(); got != int64(tt.maxOpen) {
+				t.Fatalf("expected %d physical connections, opened %d", tt.maxOpen, got)
+			}
+			if got := state.maxPingCount.Load(); got != int64(tt.maxOpen) {
+				t.Fatalf("expected at most %d concurrent pings, got %d", tt.maxOpen, got)
+			}
+
+			state.releaseAll()
+			for i := 0; i < requestCount; i++ {
+				select {
+				case err := <-errCh:
+					if err != nil {
+						t.Fatalf("concurrent ping failed: %v", err)
+					}
+				case <-time.After(5 * time.Second):
+					t.Fatal("timed out waiting for concurrent pings to finish")
+				}
+			}
+
+			waitForPoolCondition(t, "idle connections to respect the limit", func() bool {
+				stats := dbConn.Stats()
+				return stats.InUse == 0 && stats.Idle <= tt.maxIdle && stats.OpenConnections <= tt.maxIdle
+			})
+			if err := dbConn.Close(); err != nil {
+				t.Fatalf("close failed: %v", err)
+			}
+			waitForPoolCondition(t, "all physical connections to close", func() bool {
+				return state.closeCount.Load() == state.openCount.Load()
+			})
+		})
+	}
 }
 
 func TestConfigureSQLConnectionPoolKeepsOneIdleSQLServerConnection(t *testing.T) {

--- a/internal/db/sqlite_impl.go
+++ b/internal/db/sqlite_impl.go
@@ -38,6 +38,7 @@ func (s *SQLiteDB) Connect(config connection.ConnectionConfig) error {
 	if err != nil {
 		return wrapDatabaseConnectionOpenError(err)
 	}
+	configureSQLConnectionPool(db, "sqlite")
 	s.conn = db
 	s.pingTimeout = getConnectTimeout(config)
 

--- a/internal/db/sqlite_impl_test.go
+++ b/internal/db/sqlite_impl_test.go
@@ -3,13 +3,70 @@
 package db
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"GoNavi-Wails/internal/connection"
 )
+
+func TestSQLiteConnectConfiguresBoundedPoolAndSerializesWrites(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "pool.sqlite")
+	client := &SQLiteDB{}
+	if err := client.Connect(connection.ConnectionConfig{Type: "sqlite", Host: dbPath}); err != nil {
+		t.Fatalf("连接 SQLite 失败: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+
+	if got := client.conn.Stats().MaxOpenConnections; got != sqliteSQLMaxOpenConns {
+		t.Fatalf("期望最大连接数为 %d，实际=%d", sqliteSQLMaxOpenConns, got)
+	}
+	if _, err := client.conn.Exec(`CREATE TABLE pool_items (id INTEGER PRIMARY KEY, value TEXT NOT NULL)`); err != nil {
+		t.Fatalf("创建测试表失败: %v", err)
+	}
+
+	const requestCount = 20
+	var wg sync.WaitGroup
+	errCh := make(chan error, requestCount)
+	for i := 0; i < requestCount; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			_, err := client.conn.ExecContext(
+				context.Background(),
+				`INSERT INTO pool_items (id, value) VALUES (?, ?)`,
+				id,
+				fmt.Sprintf("value-%d", id),
+			)
+			errCh <- err
+		}(i)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("并发写入失败: %v", err)
+		}
+	}
+
+	var count int
+	if err := client.conn.QueryRow(`SELECT COUNT(*) FROM pool_items`).Scan(&count); err != nil {
+		t.Fatalf("统计写入结果失败: %v", err)
+	}
+	if count != requestCount {
+		t.Fatalf("期望写入 %d 行，实际=%d", requestCount, count)
+	}
+	stats := client.conn.Stats()
+	if stats.OpenConnections > sqliteSQLMaxOpenConns || stats.Idle > sqliteSQLMaxIdleConns {
+		t.Fatalf("SQLite 连接池超出边界: %+v", stats)
+	}
+}
 
 func TestResolveSQLiteDSNRejectsHostPort(t *testing.T) {
 	_, err := resolveSQLiteDSN(connection.ConnectionConfig{Type: "sqlite", Host: "localhost:3306"})


### PR DESCRIPTION
## 变更内容

- 为 SQLite 设置 1 个最大打开连接和 1 个最大空闲连接，串行化本地文件库写入
- 为 DuckDB 设置 4 个最大打开连接和 1 个最大空闲连接，限制连接和内存压力
- 内置 SQLite、DuckDB 与自定义驱动路径统一应用连接池配置
- 增加 20 路并发、连接等待、空闲回收和真实 SQLite 并发写入回归测试
- 增加 DuckDB 驱动连接池集成测试

## 测试

- `go test ./internal/db -count=1`
- `go test -tags gonavi_sqlite_driver ./internal/db -count=1`
- 连接池 20 路并发测试连续运行 10 次
- SQLite 20 路并发写入测试连续运行 10 次
- `go test ./internal/app -run "TestGetDatabaseWithPing_CoalescesConcurrentColdConnectsPerCacheKey" -count=1`

本机 `CGO_ENABLED=0` 且未安装 GCC，因此未运行真实 DuckDB 驱动测试；对应集成测试已纳入 DuckDB 标签测试集。

Closes #963