### PR TITLE
🐛 fix(query): 明确无 Context 驱动的取消状态

### DIFF
--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -2114,6 +2114,7 @@ export namespace connection {
 	    fields?: string[];
 	    messages?: string[];
 	    queryId?: string;
+	    cancellationState?: string;
 	    transactionId?: string;
 	    transactionPending?: boolean;
 
@@ -2129,6 +2130,7 @@ export namespace connection {
 	        this.fields = source["fields"];
 	        this.messages = source["messages"];
 	        this.queryId = source["queryId"];
+	        this.cancellationState = source["cancellationState"];
 	        this.transactionId = source["transactionId"];
 	        this.transactionPending = source["transactionPending"];
 	    }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -138,10 +138,11 @@ type databaseConnectResult struct {
 }
 
 type queryContext struct {
-	cancel          context.CancelFunc
-	started         time.Time
-	retainUntilDone bool
-	registrationID  uint64
+	cancel                  context.CancelFunc
+	started                 time.Time
+	retainUntilDone         bool
+	cancellationUnsupported bool
+	registrationID          uint64
 }
 
 type managedSQLTransaction struct {
@@ -1887,6 +1888,11 @@ func generateQueryID() string {
 }
 
 func (a *App) registerRunningQuery(queryID string, cancel context.CancelFunc, retainUntilDone bool) func() {
+	cleanup, _ := a.registerRunningQueryWithCancellationCapability(queryID, cancel, retainUntilDone)
+	return cleanup
+}
+
+func (a *App) registerRunningQueryWithCancellationCapability(queryID string, cancel context.CancelFunc, retainUntilDone bool) (func(), func(bool)) {
 	a.queryMu.Lock()
 	if a.runningQueries == nil {
 		a.runningQueries = make(map[string]queryContext)
@@ -1904,13 +1910,22 @@ func (a *App) registerRunningQuery(queryID string, cancel context.CancelFunc, re
 	}
 	a.queryMu.Unlock()
 
-	return func() {
+	cleanup := func() {
 		a.queryMu.Lock()
 		if current, exists := a.runningQueries[queryID]; exists && current.registrationID == registrationID {
 			delete(a.runningQueries, queryID)
 		}
 		a.queryMu.Unlock()
 	}
+	setCancellable := func(cancellable bool) {
+		a.queryMu.Lock()
+		if current, exists := a.runningQueries[queryID]; exists && current.registrationID == registrationID {
+			current.cancellationUnsupported = !cancellable
+			a.runningQueries[queryID] = current
+		}
+		a.queryMu.Unlock()
+	}
+	return cleanup, setCancellable
 }
 
 // registerExclusiveRunningQuery registers a long-running task only when the
@@ -1954,6 +1969,14 @@ func (a *App) CancelQuery(queryID string) connection.QueryResult {
 	defer a.queryMu.Unlock()
 
 	if ctx, exists := a.runningQueries[queryID]; exists {
+		if ctx.cancellationUnsupported {
+			logger.Warnf("取消查询失败：queryID=%s 的底层驱动不支持取消", queryID)
+			return connection.QueryResult{
+				Success:           false,
+				Message:           a.appText("query_editor.message.cancel_unsupported", nil),
+				CancellationState: connection.QueryCancellationStateUnsupported,
+			}
+		}
 		ctx.cancel()
 		if !ctx.retainUntilDone {
 			delete(a.runningQueries, queryID)

--- a/internal/app/methods_db.go
+++ b/internal/app/methods_db.go
@@ -1100,6 +1100,16 @@ func buildQueryExecutionFailure(ctx context.Context, err error, message string, 
 	return result
 }
 
+func (a *App) buildCancellationUnsupportedExecutionResult(result connection.QueryResult, err error) connection.QueryResult {
+	result.Success = err == nil
+	result.CancellationState = connection.QueryCancellationStateUnsupported
+	result.Message = a.appText("query_editor.message.cancel_unsupported", nil)
+	if err != nil {
+		result.Message += ": " + err.Error()
+	}
+	return result
+}
+
 func containsSQLAuditWrite(dbType string, query string) bool {
 	statements := splitSQLStatementsForDialect(dbType, query)
 	if len(statements) == 0 {
@@ -1218,7 +1228,7 @@ func (a *App) dbQueryWithCancel(
 	}
 
 	ctx, cancel := newQueryExecutionContextWithParent(auditOptions.executionContext, runConfig)
-	cleanupRunningQuery := a.registerRunningQuery(queryID, cancel, true)
+	cleanupRunningQuery, setRunningQueryCancellable := a.registerRunningQueryWithCancellationCapability(queryID, cancel, true)
 	defer func() {
 		cancel()
 		cleanupRunningQuery()
@@ -1232,20 +1242,31 @@ func (a *App) dbQueryWithCancel(
 
 	isReadQuery := isReadOnlySQLQuery(runConfig.Type, query)
 	tryQueryFirst := shouldTryQueryResultFirst(runConfig.Type, query)
+	legacyCancellationUnsupported := false
 
 	runReadQuery := func(inst db.Database) ([]map[string]interface{}, []string, error) {
 		startedAt := time.Now()
 		defer func() { queryExecutionDuration += time.Since(startedAt) }()
-		if q, ok := inst.(interface {
-			QueryContext(context.Context, string) ([]map[string]interface{}, []string, error)
-		}); ok {
+		if q, ok := inst.(db.QueryContexter); ok {
+			setRunningQueryCancellable(true)
 			return q.QueryContext(ctx, query)
 		}
-		return inst.Query(query)
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+		setRunningQueryCancellable(false)
+		if err := ctx.Err(); err != nil {
+			setRunningQueryCancellable(true)
+			return nil, nil, err
+		}
+		data, columns, err := inst.Query(query)
+		legacyCancellationUnsupported = ctx.Err() != nil
+		return data, columns, err
 	}
 
 	runReadQueryWithMessages := func(inst db.Database) ([]map[string]interface{}, []string, []string, error) {
 		if q, ok := inst.(db.QueryMessageExecer); ok {
+			setRunningQueryCancellable(true)
 			startedAt := time.Now()
 			data, columns, messages, err := q.QueryContextWithMessages(ctx, query)
 			queryExecutionDuration += time.Since(startedAt)
@@ -1258,24 +1279,44 @@ func (a *App) dbQueryWithCancel(
 	runExecQuery := func(inst db.Database) (int64, error) {
 		startedAt := time.Now()
 		defer func() { queryExecutionDuration += time.Since(startedAt) }()
-		if e, ok := inst.(interface {
-			ExecContext(context.Context, string) (int64, error)
-		}); ok {
+		if e, ok := inst.(db.ExecContexter); ok {
+			setRunningQueryCancellable(true)
 			return e.ExecContext(ctx, query)
 		}
-		return inst.Exec(query)
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		setRunningQueryCancellable(false)
+		if err := ctx.Err(); err != nil {
+			setRunningQueryCancellable(true)
+			return 0, err
+		}
+		affected, err := inst.Exec(query)
+		legacyCancellationUnsupported = ctx.Err() != nil
+		return affected, err
 	}
 
 	if isReadQuery || tryQueryFirst {
 		data, columns, messages, err := runReadQueryWithMessages(dbInst)
+		if legacyCancellationUnsupported {
+			return a.buildCancellationUnsupportedExecutionResult(connection.QueryResult{
+				Data: data, Fields: columns, Messages: messages, QueryID: queryID,
+			}, err)
+		}
 		if err != nil && isReadQuery && shouldRefreshCachedConnection(err) {
 			if a.invalidateCachedDatabase(runConfig, err) {
+				setRunningQueryCancellable(true)
 				retryInst, retryErr := a.getDatabaseWithContext(ctx, runConfig, true)
 				if retryErr != nil {
 					logger.Error(retryErr, "DBQuery 重建连接失败：%s SQL片段=%q", formatConnSummary(runConfig), sqlSnippet(query))
 					return buildQueryConnectionFailure(retryErr, queryID, auditOptions.classifyConnectionErrors)
 				}
 				data, columns, messages, err = runReadQueryWithMessages(retryInst)
+				if legacyCancellationUnsupported {
+					return a.buildCancellationUnsupportedExecutionResult(connection.QueryResult{
+						Data: data, Fields: columns, Messages: messages, QueryID: queryID,
+					}, err)
+				}
 			}
 		}
 		if err == nil {
@@ -1294,6 +1335,11 @@ func (a *App) dbQueryWithCancel(
 	}
 
 	affected, err := runExecQuery(dbInst)
+	if legacyCancellationUnsupported {
+		return a.buildCancellationUnsupportedExecutionResult(connection.QueryResult{
+			Data: map[string]int64{"affectedRows": affected}, QueryID: queryID,
+		}, err)
+	}
 	if err != nil {
 		if shouldRefreshCachedConnection(err) {
 			a.invalidateCachedDatabase(runConfig, err)
@@ -1399,7 +1445,7 @@ func (a *App) dbQueryMulti(
 	}
 
 	ctx, cancel := newQueryExecutionContextWithParent(auditOptions.executionContext, runConfig)
-	cleanupRunningQuery := a.registerRunningQuery(queryID, cancel, true)
+	cleanupRunningQuery, setRunningQueryCancellable := a.registerRunningQueryWithCancellationCapability(queryID, cancel, true)
 	defer func() {
 		cancel()
 		cleanupRunningQuery()
@@ -1416,6 +1462,7 @@ func (a *App) dbQueryMulti(
 			a.markCachedDatabaseHealthy(dbInst, time.Now())
 		}
 	}()
+	legacyCancellationUnsupported := false
 
 	// 尝试使用驱动原生多结果集支持。
 	// 注意：原生 conn.Query() 执行写操作（UPDATE/INSERT/DELETE）时，
@@ -1481,29 +1528,46 @@ func (a *App) dbQueryMulti(
 			err      error
 		)
 		if q, ok := inst.(db.MultiResultQueryMessageExecer); ok {
+			setRunningQueryCancellable(true)
 			measureQueryExecution(func() {
 				results, messages, err = q.QueryMultiContextWithMessages(ctx, query)
 			})
 			return results, messages, err
 		}
 		if q, ok := inst.(db.MultiResultQuerierContext); ok {
+			setRunningQueryCancellable(true)
 			measureQueryExecution(func() {
 				results, err = q.QueryMultiContext(ctx, query)
 			})
 			return results, nil, err
 		}
 		if q, ok := inst.(db.MultiResultQuerier); ok {
+			if err := ctx.Err(); err != nil {
+				return nil, nil, err
+			}
+			setRunningQueryCancellable(false)
+			if err := ctx.Err(); err != nil {
+				setRunningQueryCancellable(true)
+				return nil, nil, err
+			}
 			measureQueryExecution(func() {
 				results, err = q.QueryMulti(query)
 			})
+			legacyCancellationUnsupported = ctx.Err() != nil
 			return results, nil, err
 		}
 		return nil, nil, nil // 返回 nil 表示不支持
 	}
 
 	results, resultMessages, err := runMultiQuery(dbInst)
+	if legacyCancellationUnsupported {
+		return a.buildCancellationUnsupportedExecutionResult(connection.QueryResult{
+			Data: results, Messages: resultMessages, QueryID: queryID,
+		}, err)
+	}
 	if err != nil && shouldRefreshCachedConnection(err) {
 		if a.invalidateCachedDatabase(runConfig, err) {
+			setRunningQueryCancellable(true)
 			retryInst, retryErr := a.getDatabaseWithContext(ctx, runConfig, true)
 			if retryErr != nil {
 				logger.Error(retryErr, "DBQueryMulti 重建连接失败：%s SQL片段=%q", formatConnSummary(runConfig), sqlSnippet(query))
@@ -1511,6 +1575,11 @@ func (a *App) dbQueryMulti(
 			}
 			dbInst = retryInst
 			results, resultMessages, err = runMultiQuery(retryInst)
+			if legacyCancellationUnsupported {
+				return a.buildCancellationUnsupportedExecutionResult(connection.QueryResult{
+					Data: results, Messages: resultMessages, QueryID: queryID,
+				}, err)
+			}
 		}
 	}
 	if err != nil {
@@ -1550,6 +1619,7 @@ func (a *App) dbQueryMulti(
 	var sessionBatchTarget db.BatchWriteExecer
 	closeExecTarget := func() {}
 	if provider, ok := dbInst.(db.SessionExecerProvider); ok {
+		setRunningQueryCancellable(true)
 		sessionExecer, sessionErr := provider.OpenSessionExecer(ctx)
 		if sessionErr != nil {
 			logger.Warnf("DBQueryMulti 打开会话级执行器失败，将回退共享连接：%s SQL片段=%q err=%v", formatConnSummary(runConfig), sqlSnippet(query), sessionErr)
@@ -1614,6 +1684,7 @@ func (a *App) dbQueryMulti(
 					batchErr error
 				)
 				measureQueryExecution(func() {
+					setRunningQueryCancellable(true)
 					affected, batchErr = batcher.ExecBatchContext(ctx, query)
 				})
 				if batchErr != nil {
@@ -1659,17 +1730,30 @@ func (a *App) dbQueryMulti(
 			runStatementQuery := func() error {
 				measureQueryExecution(func() {
 					if sessionQueryMessageTarget != nil {
+						setRunningQueryCancellable(true)
 						data, columns, messages, err = sessionQueryMessageTarget.QueryContextWithMessages(ctx, stmt)
 					} else if sessionQueryTarget != nil {
+						setRunningQueryCancellable(true)
 						data, columns, err = sessionQueryTarget.QueryContext(ctx, stmt)
 					} else if q, ok := dbInst.(db.QueryMessageExecer); ok {
+						setRunningQueryCancellable(true)
 						data, columns, messages, err = q.QueryContextWithMessages(ctx, stmt)
-					} else if q, ok := dbInst.(interface {
-						QueryContext(context.Context, string) ([]map[string]interface{}, []string, error)
-					}); ok {
+					} else if q, ok := dbInst.(db.QueryContexter); ok {
+						setRunningQueryCancellable(true)
 						data, columns, err = q.QueryContext(ctx, stmt)
 					} else {
+						if ctxErr := ctx.Err(); ctxErr != nil {
+							err = ctxErr
+							return
+						}
+						setRunningQueryCancellable(false)
+						if ctxErr := ctx.Err(); ctxErr != nil {
+							setRunningQueryCancellable(true)
+							err = ctxErr
+							return
+						}
 						data, columns, err = dbInst.Query(stmt)
+						legacyCancellationUnsupported = ctx.Err() != nil
 					}
 				})
 				return err
@@ -1677,32 +1761,65 @@ func (a *App) dbQueryMulti(
 			if preferPlainReadQuery {
 				err = runStatementQuery()
 			} else if sessionMultiQueryMessageTarget != nil {
+				setRunningQueryCancellable(true)
 				measureQueryExecution(func() {
 					statementResults, messages, err = sessionMultiQueryMessageTarget.QueryMultiContextWithMessages(ctx, stmt)
 				})
 				usedMultiResult = true
 			} else if sessionMultiQueryTarget != nil {
+				setRunningQueryCancellable(true)
 				measureQueryExecution(func() {
 					statementResults, err = sessionMultiQueryTarget.QueryMultiContext(ctx, stmt)
 				})
 				usedMultiResult = true
 			} else if q, ok := dbInst.(db.MultiResultQueryMessageExecer); ok {
+				setRunningQueryCancellable(true)
 				measureQueryExecution(func() {
 					statementResults, messages, err = q.QueryMultiContextWithMessages(ctx, stmt)
 				})
 				usedMultiResult = true
 			} else if q, ok := dbInst.(db.MultiResultQuerierContext); ok {
+				setRunningQueryCancellable(true)
 				measureQueryExecution(func() {
 					statementResults, err = q.QueryMultiContext(ctx, stmt)
 				})
 				usedMultiResult = true
 			} else if q, ok := dbInst.(db.MultiResultQuerier); ok {
-				measureQueryExecution(func() {
-					statementResults, err = q.QueryMulti(stmt)
-				})
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					err = ctxErr
+				} else {
+					setRunningQueryCancellable(false)
+					if ctxErr := ctx.Err(); ctxErr != nil {
+						setRunningQueryCancellable(true)
+						err = ctxErr
+					} else {
+						measureQueryExecution(func() {
+							statementResults, err = q.QueryMulti(stmt)
+						})
+						legacyCancellationUnsupported = ctx.Err() != nil
+					}
+				}
 				usedMultiResult = true
 			} else {
 				err = runStatementQuery()
+			}
+			if legacyCancellationUnsupported {
+				cancellationResults := append([]connection.ResultSetData(nil), resultSets...)
+				if err == nil {
+					if usedMultiResult {
+						for resultIndex := range statementResults {
+							statementResults[resultIndex].StatementIndex = idx + 1
+						}
+						cancellationResults = append(cancellationResults, statementResults...)
+					} else {
+						cancellationResults = append(cancellationResults, connection.ResultSetData{
+							Rows: data, Columns: columns, Messages: messages, StatementIndex: idx + 1,
+						})
+					}
+				}
+				return a.buildCancellationUnsupportedExecutionResult(connection.QueryResult{
+					Data: cancellationResults, QueryID: queryID,
+				}, err)
 			}
 			if err == nil && usedMultiResult && shouldFallbackToPlainQueryAfterMultiResult(isReadStmt, statementResults, messages) {
 				logger.Warnf("DBQueryMulti 逐条多结果集返回空结果，将回退普通查询（第 %d/%d 条）：%s SQL片段=%q", idx+1, len(statements), formatConnSummary(runConfig), sqlSnippet(stmt))
@@ -1775,15 +1892,37 @@ func (a *App) dbQueryMulti(
 		var affected int64
 		measureQueryExecution(func() {
 			if sessionExecTarget != nil {
+				setRunningQueryCancellable(true)
 				affected, err = sessionExecTarget.ExecContext(ctx, stmt)
-			} else if e, ok := dbInst.(interface {
-				ExecContext(context.Context, string) (int64, error)
-			}); ok {
+			} else if e, ok := dbInst.(db.ExecContexter); ok {
+				setRunningQueryCancellable(true)
 				affected, err = e.ExecContext(ctx, stmt)
 			} else {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					err = ctxErr
+					return
+				}
+				setRunningQueryCancellable(false)
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					setRunningQueryCancellable(true)
+					err = ctxErr
+					return
+				}
 				affected, err = dbInst.Exec(stmt)
+				legacyCancellationUnsupported = ctx.Err() != nil
 			}
 		})
+		if legacyCancellationUnsupported {
+			cancellationResults := append([]connection.ResultSetData(nil), resultSets...)
+			if err == nil {
+				cancellationResults = append(cancellationResults, connection.ResultSetData{
+					Rows: []map[string]interface{}{{"affectedRows": affected}}, Columns: []string{"affectedRows"}, StatementIndex: idx + 1,
+				})
+			}
+			return a.buildCancellationUnsupportedExecutionResult(connection.QueryResult{
+				Data: cancellationResults, QueryID: queryID,
+			}, err)
+		}
 		if err != nil {
 			if shouldRefreshCachedConnection(err) {
 				a.invalidateCachedDatabase(runConfig, err)

--- a/internal/app/methods_db_cancel_test.go
+++ b/internal/app/methods_db_cancel_test.go
@@ -18,6 +18,59 @@ type blockingConnectCancelDB struct {
 	queryContextErr chan error
 }
 
+type blockingLegacyCancelDB struct {
+	db.Database
+	queryStarted chan struct{}
+	queryRelease chan struct{}
+	queryDone    chan struct{}
+	execStarted  chan struct{}
+	execRelease  chan struct{}
+	execDone     chan struct{}
+}
+
+func (f *blockingLegacyCancelDB) Connect(connection.ConnectionConfig) error { return nil }
+func (f *blockingLegacyCancelDB) Close() error                              { return nil }
+func (f *blockingLegacyCancelDB) Ping() error                               { return nil }
+
+func (f *blockingLegacyCancelDB) Query(string) ([]map[string]interface{}, []string, error) {
+	close(f.queryStarted)
+	<-f.queryRelease
+	close(f.queryDone)
+	return []map[string]interface{}{{"value": 1}}, []string{"value"}, nil
+}
+
+func (f *blockingLegacyCancelDB) Exec(string) (int64, error) {
+	if f.execStarted == nil || f.execRelease == nil || f.execDone == nil {
+		return 0, errors.New("unexpected legacy Exec call")
+	}
+	close(f.execStarted)
+	<-f.execRelease
+	close(f.execDone)
+	return 1, nil
+}
+
+type blockingContextCancelDB struct {
+	*blockingLegacyCancelDB
+	contextQueryStarted chan struct{}
+	contextQueryDone    chan struct{}
+	contextExecStarted  chan struct{}
+	contextExecDone     chan struct{}
+}
+
+func (f *blockingContextCancelDB) QueryContext(ctx context.Context, _ string) ([]map[string]interface{}, []string, error) {
+	close(f.contextQueryStarted)
+	<-ctx.Done()
+	close(f.contextQueryDone)
+	return nil, nil, ctx.Err()
+}
+
+func (f *blockingContextCancelDB) ExecContext(ctx context.Context, _ string) (int64, error) {
+	close(f.contextExecStarted)
+	<-ctx.Done()
+	close(f.contextExecDone)
+	return 0, ctx.Err()
+}
+
 func (f *blockingConnectCancelDB) Connect(connection.ConnectionConfig) error {
 	close(f.connectStarted)
 	<-f.connectRelease
@@ -181,6 +234,267 @@ func TestDBQueryMulti_CanBeCancelledWhileConnecting(t *testing.T) {
 	}
 	if thirdCancel := app.CancelQuery(queryID); thirdCancel.Success {
 		t.Fatal("cancellation should fail after the query owner exits")
+	}
+}
+
+func TestDBQueryWithCancel_LegacyOnlyDriverReportsCancellationUnsupported(t *testing.T) {
+	originalNewDatabaseFunc := newDatabaseFunc
+	t.Cleanup(func() { newDatabaseFunc = originalNewDatabaseFunc })
+
+	database := &blockingLegacyCancelDB{
+		queryStarted: make(chan struct{}),
+		queryRelease: make(chan struct{}),
+		queryDone:    make(chan struct{}),
+	}
+	newDatabaseFunc = func(string) (db.Database, error) { return database, nil }
+
+	app := NewApp()
+	t.Cleanup(app.Shutdown)
+	const queryID = "legacy-single-query"
+	resultCh := make(chan connection.QueryResult, 1)
+	go func() {
+		resultCh <- app.DBQueryWithCancel(connection.ConnectionConfig{
+			Type: "postgres", Host: "legacy-single.test", Port: 5432,
+		}, "app", "SELECT 1", queryID)
+	}()
+
+	select {
+	case <-database.queryStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for legacy query execution")
+	}
+
+	cancelResult := app.CancelQuery(queryID)
+	if cancelResult.Success || cancelResult.CancellationState != connection.QueryCancellationStateUnsupported {
+		t.Fatalf("legacy cancellation must report unsupported, got %#v", cancelResult)
+	}
+	select {
+	case result := <-resultCh:
+		t.Fatalf("legacy query falsely returned before underlying execution completed: %#v", result)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(database.queryRelease)
+	result := <-resultCh
+	if !result.Success {
+		t.Fatalf("legacy query should return its real completion result, got %#v", result)
+	}
+	select {
+	case <-database.queryDone:
+	default:
+		t.Fatal("query result returned before the legacy driver completed")
+	}
+	app.queryMu.RLock()
+	_, stillRegistered := app.runningQueries[queryID]
+	app.queryMu.RUnlock()
+	if stillRegistered {
+		t.Fatal("legacy query registration was not released after real completion")
+	}
+}
+
+func TestDBQueryMulti_LegacyOnlyParentCancellationIsExplicit(t *testing.T) {
+	originalNewDatabaseFunc := newDatabaseFunc
+	t.Cleanup(func() { newDatabaseFunc = originalNewDatabaseFunc })
+
+	database := &blockingLegacyCancelDB{
+		queryStarted: make(chan struct{}),
+		queryRelease: make(chan struct{}),
+		queryDone:    make(chan struct{}),
+	}
+	newDatabaseFunc = func(string) (db.Database, error) { return database, nil }
+
+	app := NewApp()
+	t.Cleanup(app.Shutdown)
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan connection.QueryResult, 1)
+	go func() {
+		resultCh <- NewCLIQueryExecutor(app).DBQueryMulti(ctx, connection.ConnectionConfig{
+			Type: "postgres", Host: "legacy-parent-context.test", Port: 5432,
+		}, "app", "SELECT 1", "legacy-parent-context")
+	}()
+
+	select {
+	case <-database.queryStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for legacy multi-query execution")
+	}
+	cancel()
+	select {
+	case result := <-resultCh:
+		t.Fatalf("legacy multi-query falsely returned on parent cancellation: %#v", result)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(database.queryRelease)
+	result := <-resultCh
+	if !result.Success || result.CancellationState != connection.QueryCancellationStateUnsupported {
+		t.Fatalf("legacy parent cancellation must be explicit, got %#v", result)
+	}
+	data, _ := result.Data.(map[string]any)
+	if data["cancelled"] == true {
+		t.Fatalf("legacy execution must not be reported as stopped, got %#v", result)
+	}
+	select {
+	case <-database.queryDone:
+	default:
+		t.Fatal("legacy multi-query returned before its underlying execution completed")
+	}
+}
+
+func TestDBQueryMulti_ContextDriverStopsOnParentCancellation(t *testing.T) {
+	originalNewDatabaseFunc := newDatabaseFunc
+	t.Cleanup(func() { newDatabaseFunc = originalNewDatabaseFunc })
+
+	legacy := &blockingLegacyCancelDB{
+		queryStarted: make(chan struct{}),
+		queryRelease: make(chan struct{}),
+		queryDone:    make(chan struct{}),
+	}
+	database := &blockingContextCancelDB{
+		blockingLegacyCancelDB: legacy,
+		contextQueryStarted:    make(chan struct{}),
+		contextQueryDone:       make(chan struct{}),
+	}
+	newDatabaseFunc = func(string) (db.Database, error) { return database, nil }
+
+	app := NewApp()
+	t.Cleanup(app.Shutdown)
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan connection.QueryResult, 1)
+	go func() {
+		resultCh <- NewCLIQueryExecutor(app).DBQueryMulti(ctx, connection.ConnectionConfig{
+			Type: "postgres", Host: "context-parent.test", Port: 5432,
+		}, "app", "SELECT 1", "context-parent")
+	}()
+
+	select {
+	case <-database.contextQueryStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for QueryContext execution")
+	}
+	cancel()
+	select {
+	case result := <-resultCh:
+		if result.Success {
+			t.Fatalf("cancelled Context query should fail, got %#v", result)
+		}
+		data, _ := result.Data.(map[string]any)
+		if data["cancelled"] != true || result.CancellationState != "" {
+			t.Fatalf("Context cancellation should report a real stop, got %#v", result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Context-capable query did not stop after parent cancellation")
+	}
+	select {
+	case <-database.contextQueryDone:
+	default:
+		t.Fatal("QueryContext result returned before the driver observed cancellation")
+	}
+	select {
+	case <-legacy.queryStarted:
+		t.Fatal("Context-capable driver unexpectedly fell back to legacy Query")
+	default:
+	}
+}
+
+func TestDBQueryMulti_LegacyOnlyWriteParentCancellationIsExplicit(t *testing.T) {
+	originalNewDatabaseFunc := newDatabaseFunc
+	t.Cleanup(func() { newDatabaseFunc = originalNewDatabaseFunc })
+
+	database := &blockingLegacyCancelDB{
+		execStarted: make(chan struct{}),
+		execRelease: make(chan struct{}),
+		execDone:    make(chan struct{}),
+	}
+	newDatabaseFunc = func(string) (db.Database, error) { return database, nil }
+
+	app := NewApp()
+	t.Cleanup(app.Shutdown)
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan connection.QueryResult, 1)
+	go func() {
+		resultCh <- NewCLIQueryExecutor(app).DBQueryMulti(ctx, connection.ConnectionConfig{
+			Type: "postgres", Host: "legacy-write-context.test", Port: 5432,
+		}, "app", "UPDATE users SET active = 1", "legacy-write-context")
+	}()
+
+	select {
+	case <-database.execStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for legacy Exec")
+	}
+	cancel()
+	select {
+	case result := <-resultCh:
+		t.Fatalf("legacy Exec falsely returned on parent cancellation: %#v", result)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(database.execRelease)
+	result := <-resultCh
+	if !result.Success || result.CancellationState != connection.QueryCancellationStateUnsupported {
+		t.Fatalf("legacy Exec cancellation must report unsupported, got %#v", result)
+	}
+	select {
+	case <-database.execDone:
+	default:
+		t.Fatal("legacy write result returned before Exec completed")
+	}
+}
+
+func TestDBQueryMulti_ContextWriteStopsOnParentCancellation(t *testing.T) {
+	originalNewDatabaseFunc := newDatabaseFunc
+	t.Cleanup(func() { newDatabaseFunc = originalNewDatabaseFunc })
+
+	legacy := &blockingLegacyCancelDB{
+		execStarted: make(chan struct{}),
+		execRelease: make(chan struct{}),
+		execDone:    make(chan struct{}),
+	}
+	database := &blockingContextCancelDB{
+		blockingLegacyCancelDB: legacy,
+		contextExecStarted:     make(chan struct{}),
+		contextExecDone:        make(chan struct{}),
+	}
+	newDatabaseFunc = func(string) (db.Database, error) { return database, nil }
+
+	app := NewApp()
+	t.Cleanup(app.Shutdown)
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan connection.QueryResult, 1)
+	go func() {
+		resultCh <- NewCLIQueryExecutor(app).DBQueryMulti(ctx, connection.ConnectionConfig{
+			Type: "postgres", Host: "context-write.test", Port: 5432,
+		}, "app", "UPDATE users SET active = 1", "context-write")
+	}()
+
+	select {
+	case <-database.contextExecStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for ExecContext")
+	}
+	cancel()
+	select {
+	case result := <-resultCh:
+		if result.Success || result.CancellationState != "" {
+			t.Fatalf("cancelled Context write returned an invalid state: %#v", result)
+		}
+		data, _ := result.Data.(map[string]any)
+		if data["outcomeUnknown"] != true {
+			t.Fatalf("dispatched Context write cancellation must keep outcome unknown, got %#v", result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Context-capable Exec did not stop after parent cancellation")
+	}
+	select {
+	case <-database.contextExecDone:
+	default:
+		t.Fatal("ExecContext result returned before the driver observed cancellation")
+	}
+	select {
+	case <-legacy.execStarted:
+		t.Fatal("Context-capable driver unexpectedly fell back to legacy Exec")
+	default:
 	}
 }
 

--- a/internal/connection/types.go
+++ b/internal/connection/types.go
@@ -191,6 +191,8 @@ type ResultSetData struct {
 	StatementIndex int                      `json:"statementIndex,omitempty"`
 }
 
+const QueryCancellationStateUnsupported = "unsupported"
+
 // QueryResult 是 Wails 绑定方法的统一响应格式，前端通过此结构体接收后端结果。
 type QueryResult struct {
 	Success            bool        `json:"success"`
@@ -199,6 +201,7 @@ type QueryResult struct {
 	Fields             []string    `json:"fields,omitempty"`
 	Messages           []string    `json:"messages,omitempty"`
 	QueryID            string      `json:"queryId,omitempty"` // Unique ID for query cancellation
+	CancellationState  string      `json:"cancellationState,omitempty"`
 	TransactionID      string      `json:"transactionId,omitempty"`
 	TransactionPending bool        `json:"transactionPending,omitempty"`
 }

--- a/internal/db/database.go
+++ b/internal/db/database.go
@@ -244,6 +244,18 @@ type MultiResultQuerier interface {
 	QueryMulti(query string) ([]connection.ResultSetData, error)
 }
 
+// QueryContexter is the optional cancellation-capable query contract.
+// Callers must not assume Database.Query can be interrupted without it.
+type QueryContexter interface {
+	QueryContext(ctx context.Context, query string) ([]map[string]interface{}, []string, error)
+}
+
+// ExecContexter is the optional cancellation-capable write contract.
+// Callers must not assume Database.Exec can be interrupted without it.
+type ExecContexter interface {
+	ExecContext(ctx context.Context, query string) (int64, error)
+}
+
 // MultiResultQuerierContext 是带 context 的多结果集查询接口。
 type MultiResultQuerierContext interface {
 	QueryMultiContext(ctx context.Context, query string) ([]connection.ResultSetData, error)

--- a/internal/mcpserver/service.go
+++ b/internal/mcpserver/service.go
@@ -161,15 +161,16 @@ type sqlResultSet struct {
 }
 
 type executeSQLResult struct {
-	ConnectionID   string                `json:"connectionId"`
-	DBName         string                `json:"dbName,omitempty"`
-	StatementCount int                   `json:"statementCount"`
-	ReadOnly       bool                  `json:"readOnly"`
-	QueryID        string                `json:"queryId,omitempty"`
-	Message        string                `json:"message,omitempty"`
-	Truncated      bool                  `json:"truncated,omitempty"`
-	Statements     []sqlStatementSummary `json:"statements"`
-	Results        []sqlResultSet        `json:"results"`
+	ConnectionID      string                `json:"connectionId"`
+	DBName            string                `json:"dbName,omitempty"`
+	StatementCount    int                   `json:"statementCount"`
+	ReadOnly          bool                  `json:"readOnly"`
+	QueryID           string                `json:"queryId,omitempty"`
+	CancellationState string                `json:"cancellationState,omitempty"`
+	Message           string                `json:"message,omitempty"`
+	Truncated         bool                  `json:"truncated,omitempty"`
+	Statements        []sqlStatementSummary `json:"statements"`
+	Results           []sqlResultSet        `json:"results"`
 }
 
 func (s *Service) GetConnections(ctx context.Context, req *mcp.CallToolRequest, args emptyArgs) (*mcp.CallToolResult, getConnectionsResult, error) {
@@ -553,6 +554,9 @@ func (s *Service) ExecuteSQL(ctx context.Context, req *mcp.CallToolRequest, args
 	dbName := effectiveDBName(args.DBName, view.Config)
 	queryResult := s.executeAuthorizedSQL(ctx, view, dbName, sqlText, args.AllowMutating)
 	if !queryResult.Success {
+		if queryResult.CancellationState != "" {
+			return toolError("SQL 执行失败（cancellationState=%s）: %s", queryResult.CancellationState, strings.TrimSpace(queryResult.Message)), executeSQLResult{}, nil
+		}
 		return toolError("SQL 执行失败: %s", strings.TrimSpace(queryResult.Message)), executeSQLResult{}, nil
 	}
 
@@ -563,15 +567,16 @@ func (s *Service) ExecuteSQL(ctx context.Context, req *mcp.CallToolRequest, args
 
 	normalizedResults, truncated := normalizeResultSets(resultSets, normalizeMaxRowsPerResult(args.MaxRowsPerResult))
 	output := executeSQLResult{
-		ConnectionID:   view.ID,
-		DBName:         dbName,
-		StatementCount: inspection.StatementCount,
-		ReadOnly:       inspection.ReadOnly,
-		QueryID:        strings.TrimSpace(queryResult.QueryID),
-		Message:        strings.TrimSpace(queryResult.Message),
-		Truncated:      truncated,
-		Statements:     toStatementSummaries(inspection.Statements),
-		Results:        normalizedResults,
+		ConnectionID:      view.ID,
+		DBName:            dbName,
+		StatementCount:    inspection.StatementCount,
+		ReadOnly:          inspection.ReadOnly,
+		QueryID:           strings.TrimSpace(queryResult.QueryID),
+		CancellationState: strings.TrimSpace(queryResult.CancellationState),
+		Message:           strings.TrimSpace(queryResult.Message),
+		Truncated:         truncated,
+		Statements:        toStatementSummaries(inspection.Statements),
+		Results:           normalizedResults,
 	}
 	return textResult(formatExecuteSQLResultContent(output)), output, nil
 }
@@ -956,6 +961,10 @@ func formatExecuteSQLResultContent(result executeSQLResult) string {
 	builder.WriteString(fmt.Sprintf("语句数：%d，结果集：%d", result.StatementCount, len(result.Results)))
 	if result.Truncated {
 		builder.WriteString("，结果已截断")
+	}
+	if result.CancellationState != "" {
+		builder.WriteString("\n取消状态：")
+		builder.WriteString(result.CancellationState)
 	}
 	if result.Message != "" {
 		builder.WriteString("\n消息：")

--- a/internal/mcpserver/service_test.go
+++ b/internal/mcpserver/service_test.go
@@ -836,6 +836,48 @@ func TestExecuteSQLForwardsRequestContextToBackend(t *testing.T) {
 	}
 }
 
+func TestExecuteSQLExposesUnsupportedCancellationState(t *testing.T) {
+	backend := &fakeBackend{
+		editableConnection: connection.SavedConnectionView{
+			ID: "legacy-main",
+			Config: connection.ConnectionConfig{
+				Type:     "custom",
+				Database: "app",
+			},
+		},
+		inspection: appcore.SQLInspection{
+			StatementCount: 1,
+			ReadOnly:       true,
+			Statements: []appcore.SQLStatementInspection{
+				{Index: 1, Keyword: "select", ReadOnly: true},
+			},
+		},
+		queryResult: connection.QueryResult{
+			Success:           true,
+			Message:           "driver cannot stop the underlying SQL",
+			CancellationState: connection.QueryCancellationStateUnsupported,
+			Data:              []connection.ResultSetData{},
+		},
+	}
+
+	result, out, err := NewService(backend).ExecuteSQL(context.Background(), nil, executeSQLArgs{
+		ConnectionID: "legacy-main",
+		SQL:          "SELECT 1",
+	})
+	if err != nil {
+		t.Fatalf("ExecuteSQL returned error: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("expected the completed SQL result with explicit cancellation state, got %#v", result)
+	}
+	if out.CancellationState != connection.QueryCancellationStateUnsupported {
+		t.Fatalf("unsupported cancellation state was lost from structured MCP output: %#v", out)
+	}
+	if text := firstTextContent(result); !strings.Contains(text, "取消状态：unsupported") {
+		t.Fatalf("unsupported cancellation state was lost at the MCP boundary: %q", text)
+	}
+}
+
 func TestExecuteSQLAllowsDDLWhenAISafetyIsFullAndAllowMutating(t *testing.T) {
 	backend := &fakeBackend{
 		editableConnection: connection.SavedConnectionView{

--- a/shared/i18n/de-DE.json
+++ b/shared/i18n/de-DE.json
@@ -6858,6 +6858,7 @@
   "query_editor.message.cancel_failed": "Abfrage konnte nicht abgebrochen werden: {{error}}",
   "query_editor.message.cancel_no_running": "Keine laufende Abfrage zum Abbrechen.",
   "query_editor.message.cancel_success": "Abfrage abgebrochen.",
+  "query_editor.message.cancel_unsupported": "Die Abbruchanforderung hat die zugrunde liegende SQL-Ausführung nicht beendet, da der aktuelle Datenbanktreiber laufende Anweisungen nicht abbrechen kann.",
   "query_editor.message.clipboard_permission_required": "Der Browser kann die Zwischenablage nicht lesen. Erlauben Sie dieser Website den Zugriff auf die Zwischenablage und versuchen Sie es erneut.",
   "query_editor.message.clipboard_read_failed": "Die Zwischenablage kann nicht gelesen werden. Versuchen Sie es erneut.",
   "query_editor.message.connection_not_found": "Verbindung nicht gefunden.",

--- a/shared/i18n/en-US.json
+++ b/shared/i18n/en-US.json
@@ -6858,6 +6858,7 @@
   "query_editor.message.cancel_failed": "Failed to cancel query: {{error}}",
   "query_editor.message.cancel_no_running": "No running query to cancel.",
   "query_editor.message.cancel_success": "Query canceled.",
+  "query_editor.message.cancel_unsupported": "The cancellation request did not stop the underlying SQL because the current database driver cannot cancel in-flight statements.",
   "query_editor.message.clipboard_permission_required": "The browser cannot read the clipboard. Allow clipboard access for this site and try again.",
   "query_editor.message.clipboard_read_failed": "Unable to read the clipboard. Try again.",
   "query_editor.message.connection_not_found": "Connection not found.",

--- a/shared/i18n/ja-JP.json
+++ b/shared/i18n/ja-JP.json
@@ -6858,6 +6858,7 @@
   "query_editor.message.cancel_failed": "クエリのキャンセルに失敗しました: {{error}}",
   "query_editor.message.cancel_no_running": "キャンセルできる実行中のクエリはありません。",
   "query_editor.message.cancel_success": "クエリをキャンセルしました。",
+  "query_editor.message.cancel_unsupported": "現在のデータベースドライバーは実行中のステートメントをキャンセルできないため、キャンセル要求は基盤側の SQL を停止できませんでした。",
   "query_editor.message.clipboard_permission_required": "ブラウザーがクリップボードを読み取れません。このサイトのクリップボード権限を許可してから再試行してください。",
   "query_editor.message.clipboard_read_failed": "クリップボードを読み取れません。再試行してください。",
   "query_editor.message.connection_not_found": "接続が見つかりません。",

--- a/shared/i18n/ru-RU.json
+++ b/shared/i18n/ru-RU.json
@@ -6858,6 +6858,7 @@
   "query_editor.message.cancel_failed": "Не удалось отменить запрос: {{error}}",
   "query_editor.message.cancel_no_running": "Нет выполняющегося запроса для отмены.",
   "query_editor.message.cancel_success": "Запрос отменен.",
+  "query_editor.message.cancel_unsupported": "Запрос на отмену не остановил выполнение SQL, поскольку текущий драйвер базы данных не поддерживает отмену выполняемых операторов.",
   "query_editor.message.clipboard_permission_required": "Браузер не может прочитать буфер обмена. Разрешите этому сайту доступ к буферу обмена и повторите попытку.",
   "query_editor.message.clipboard_read_failed": "Не удалось прочитать буфер обмена. Повторите попытку.",
   "query_editor.message.connection_not_found": "Подключение не найдено.",

--- a/shared/i18n/zh-CN.json
+++ b/shared/i18n/zh-CN.json
@@ -6858,6 +6858,7 @@
   "query_editor.message.cancel_failed": "取消查询失败：{{error}}",
   "query_editor.message.cancel_no_running": "没有正在运行的查询可取消。",
   "query_editor.message.cancel_success": "查询已中止。",
+  "query_editor.message.cancel_unsupported": "取消请求未能中止底层 SQL；当前数据库驱动不支持取消执行中的语句。",
   "query_editor.message.clipboard_permission_required": "浏览器无法读取剪贴板，请允许此站点的剪贴板权限后重试。",
   "query_editor.message.clipboard_read_failed": "无法读取剪贴板，请重试。",
   "query_editor.message.connection_not_found": "未找到连接。",

--- a/shared/i18n/zh-TW.json
+++ b/shared/i18n/zh-TW.json
@@ -6858,6 +6858,7 @@
   "query_editor.message.cancel_failed": "取消查詢失敗：{{error}}",
   "query_editor.message.cancel_no_running": "沒有正在執行的查詢可取消。",
   "query_editor.message.cancel_success": "查詢已終止。",
+  "query_editor.message.cancel_unsupported": "取消要求未能中止底層 SQL；目前資料庫驅動程式不支援取消執行中的語句。",
   "query_editor.message.clipboard_permission_required": "瀏覽器無法讀取剪貼簿，請允許此網站的剪貼簿權限後重試。",
   "query_editor.message.clipboard_read_failed": "無法讀取剪貼簿，請重試。",
   "query_editor.message.connection_not_found": "找不到連線。",


### PR DESCRIPTION
## 关联 Issue

Closes #968

## 问题

查询层在驱动缺少 `QueryContext` / `ExecContext` 时会回退到 legacy `Query` / `Exec`，但取消操作仍返回成功。此时底层 SQL 实际继续占用连接和服务端资源，`DBQueryMulti` 和 MCP 请求断开也可能被误标为已停止。

## 修复

- 增加命名的可选 `QueryContexter` / `ExecContexter` 能力接口。
- 查询连接阶段保持可取消；仅在实际进入 legacy 调用期间标记为不可取消。
- `CancelQuery` 对 legacy 调用返回 `cancellationState=unsupported`，并保留运行登记直到底层真实结束。
- 父 Context 或 deadline 在 legacy 调用期间取消时，不提前返回、不设置 `cancelled=true`；底层返回后保留真实 SQL 成功/失败，并附加 `unsupported` 状态。
- `DBQueryMulti` 覆盖原生多结果集、逐条查询、逐条写入及会话执行回退。
- MCP 文本与结构化结果显式透传取消状态。
- 同步 Wails TypeScript 模型和多语言提示。

## 行为验证

- Context 查询/写入：驱动在 Context 取消后退出，查询返回真实取消状态；已派发写入仍保持 `outcomeUnknown`。
- legacy 查询/写入：取消不会让调用提前返回；底层释放后才结束，并返回 `cancellationState=unsupported`。
- 手动取消 legacy SQL：取消请求明确失败，前端不会停止等待或伪报查询已中止。

## 测试

- `go test ./internal/app -run 'Test(DBQuery|CLIQuery|CancelQuery|RegisterRunningQuery|CleanupStaleQueries)' -count=1`
- `go test ./internal/mcpserver ./internal/db ./shared/i18n -count=1`
- `npm --prefix frontend test -- src/i18n/catalog.test.ts`（52 项通过）
- `tsc --noEmit -p frontend/tsconfig.json`