### PR TITLE
🐛 fix(driver-agent): 按驱动隔离 revision 依赖 (#974)

### DIFF
--- a/tools/generate-driver-agent-revisions.sh
+++ b/tools/generate-driver-agent-revisions.sh
@@ -79,10 +79,8 @@ files_equal() {
   [[ "$(hash_file "$left")" == "$(hash_file "$right")" ]]
 }
 
-should_include_internal_db_file() {
-  local driver="$1"
-  local identity="$2"
-
+should_include_shared_internal_db_file() {
+  local identity="$1"
   case "$identity" in
     internal/db/agent_process_stub.go|\
 internal/db/agent_process_windows.go|\
@@ -103,6 +101,13 @@ internal/db/timeout.go)
       return 0
       ;;
   esac
+
+  return 1
+}
+
+should_include_driver_internal_db_file() {
+  local driver="$1"
+  local identity="$2"
 
   case "$driver:$identity" in
     mariadb:internal/db/mariadb_impl.go|\
@@ -150,19 +155,84 @@ trino:internal/db/trino_impl.go)
   return 1
 }
 
+should_include_internal_db_file() {
+  local driver="$1"
+  local identity="$2"
+
+  if should_include_shared_internal_db_file "$identity"; then
+    return 0
+  fi
+  should_include_driver_internal_db_file "$driver" "$identity"
+}
+
 should_include_source_file() {
   local driver="$1"
   local identity="$2"
+
+  # revision 用于验证 agent IPC 兼容性，不是整个二进制依赖树的版本号。
+  # optional-driver-agent 依赖 monolithic internal/db 包，go list 会同时列出
+  # 内置驱动和其他 optional driver 的依赖；把它们纳入指纹会让无关升级要求
+  # 用户重装所有 driver-agent。
   case "$identity" in
-    internal/appdata/*|internal/connection/*|internal/logger/*)
-      return 1
+    cmd/optional-driver-agent/*)
+      return 0
       ;;
   esac
   if [[ "$identity" == internal/db/* ]]; then
     should_include_internal_db_file "$driver" "$identity"
     return
   fi
-  return 0
+  return 1
+}
+
+list_go_imports() {
+  awk '
+    $1 == "import" && $2 == "(" { in_import = 1; next }
+    $1 == "import" {
+      for (i = 2; i <= NF; i++) {
+        if ($i ~ /^"[^"]+"$/) {
+          gsub(/^"|"$/, "", $i)
+          print $i
+          next
+        }
+      }
+    }
+    in_import && $1 == ")" { in_import = 0; next }
+    in_import {
+      for (i = 1; i <= NF; i++) {
+        if ($i ~ /^"[^"]+"$/) {
+          gsub(/^"|"$/, "", $i)
+          print $i
+          next
+        }
+      }
+    }
+  ' "$1"
+}
+
+is_external_import() {
+  local first_segment="${1%%/*}"
+  [[ "$first_segment" == *.* ]]
+}
+
+source_identity() {
+  local file="${1//\\//}"
+  if [[ -n "$gomodcache" && "$file" == "$gomodcache"/* ]]; then
+    printf 'gomod/%s\n' "${file#$gomodcache/}"
+    return
+  fi
+  if [[ -n "$SCRIPT_DIR_WINDOWS" && "$file" == "$SCRIPT_DIR_WINDOWS"/* ]]; then
+    printf '%s\n' "${file#$SCRIPT_DIR_WINDOWS/}"
+    return
+  fi
+  case "$file" in
+    "$SCRIPT_DIR"/*)
+      printf '%s\n' "${file#$SCRIPT_DIR/}"
+      ;;
+    *)
+      printf '%s\n' "$file"
+      ;;
+  esac
 }
 
 target_platform=""
@@ -274,7 +344,9 @@ fi
 
 fingerprint_driver() {
   local driver="$1"
-  local build_driver tag cgo_enabled tmp dependency_files file identity file_hash revision
+  local build_driver tag cgo_enabled tmp dependency_files included_files external_imports external_dependency_files hash_entries
+  local file identity import_path file_hash revision
+  local -a direct_external_imports=()
   build_driver="$(build_driver_name "$driver")"
   tag="$(driver_build_tags "$driver")"
   cgo_enabled=0
@@ -301,34 +373,73 @@ fingerprint_driver() {
     return 1
   fi
 
+  included_files="$(mktemp "${TMPDIR:-/tmp}/gonavi-agent-included-files.XXXXXX")"
+  external_imports="$(mktemp "${TMPDIR:-/tmp}/gonavi-agent-external-imports.XXXXXX")"
+  external_dependency_files="$(mktemp "${TMPDIR:-/tmp}/gonavi-agent-external-dependencies.XXXXXX")"
+  hash_entries="$(mktemp "${TMPDIR:-/tmp}/gonavi-agent-hash-entries.XXXXXX")"
+
+  # 只从 agent 入口和目标 driver 源码提取外部 import，避免 internal/db
+  # 包级依赖把其他驱动的 module closure 一并带入当前 revision。
   while IFS= read -r file; do
     file="${file//\\//}"
     [[ -n "$file" && -f "$file" ]] || continue
-    if [[ -n "$SCRIPT_DIR_WINDOWS" && "$file" == "$SCRIPT_DIR_WINDOWS"/* ]]; then
-      identity="${file#$SCRIPT_DIR_WINDOWS/}"
-    else
-      case "$file" in
-        "$SCRIPT_DIR"/*)
-          identity="${file#$SCRIPT_DIR/}"
-          ;;
-        "$gomodcache"/*)
-          identity="gomod/${file#$gomodcache/}"
-          ;;
-        *)
-          identity="$file"
-          ;;
-      esac
-    fi
+    identity="$(source_identity "$file")"
     if [[ "$identity" == "$OUTPUT_FILE" ]]; then
       continue
     fi
     if ! should_include_source_file "$driver" "$identity"; then
       continue
     fi
+    printf '%s\n' "$file" >>"$included_files"
+
+    if [[ "$identity" == cmd/optional-driver-agent/* ]] || should_include_driver_internal_db_file "$driver" "$identity"; then
+      while IFS= read -r import_path; do
+        if is_external_import "$import_path"; then
+          printf '%s\n' "$import_path" >>"$external_imports"
+        fi
+      done < <(list_go_imports "$file")
+    fi
+  done <"$dependency_files"
+
+  LC_ALL=C sort -u "$external_imports" -o "$external_imports"
+  while IFS= read -r import_path; do
+    [[ -n "$import_path" ]] || continue
+    direct_external_imports+=("$import_path")
+  done <"$external_imports"
+
+  if [[ ${#direct_external_imports[@]} -gt 0 ]]; then
+    if ! CGO_ENABLED="$cgo_enabled" GOOS="$goos" GOARCH="$goarch" GOTOOLCHAIN=auto \
+      go list -deps \
+        -tags "$tag" \
+        -f '{{if not .Standard}}{{range .GoFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}{{range .CgoFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}{{end}}' \
+        "${direct_external_imports[@]}" | LC_ALL=C sort -u >"$external_dependency_files"; then
+      rm -f "$tmp" "$dependency_files" "$included_files" "$external_imports" "$external_dependency_files" "$hash_entries"
+      echo "driver-agent external dependency enumeration failed: $driver ($goos/$goarch)" >&2
+      return 1
+    fi
+  fi
+
+  while IFS= read -r file; do
+    file="${file//\\//}"
+    [[ -n "$file" && -f "$file" ]] || continue
+    identity="$(source_identity "$file")"
+    case "$identity" in
+      gomod/*|third_party/*)
+        printf '%s\n' "$file" >>"$included_files"
+        ;;
+    esac
+  done <"$external_dependency_files"
+
+  LC_ALL=C sort -u "$included_files" -o "$included_files"
+  while IFS= read -r file; do
+    file="${file//\\//}"
+    [[ -n "$file" && -f "$file" ]] || continue
+    identity="$(source_identity "$file")"
     file_hash="$(hash_file "$file")"
-    printf '%s  %s\n' "$file_hash" "$identity"
-  done <"$dependency_files" >>"$tmp"
-  rm -f "$dependency_files"
+    printf '%s  %s\n' "$file_hash" "$identity" >>"$hash_entries"
+  done <"$included_files"
+  LC_ALL=C sort -k2,2 "$hash_entries" >>"$tmp"
+  rm -f "$dependency_files" "$included_files" "$external_imports" "$external_dependency_files" "$hash_entries"
 
   revision="$(hash_file "$tmp" | cut -c1-16)"
   rm -f "$tmp"

--- a/tools/generate-driver-agent-revisions.test.sh
+++ b/tools/generate-driver-agent-revisions.test.sh
@@ -19,10 +19,11 @@ copy_repo_to_tmp() {
 tmpdir_failure="$(mktemp -d "${TMPDIR:-/tmp}/gonavi-generate-driver-revisions-failure.XXXXXX")"
 tmpdir_platform="$(mktemp -d "${TMPDIR:-/tmp}/gonavi-generate-driver-revisions-platform.XXXXXX")"
 tmpdir_connection="$(mktemp -d "${TMPDIR:-/tmp}/gonavi-generate-driver-revisions-connection.XXXXXX")"
+tmpdir_scope="$(mktemp -d "${TMPDIR:-/tmp}/gonavi-generate-driver-revisions-scope.XXXXXX")"
 darwin_file="$(mktemp "${TMPDIR:-/tmp}/gonavi-darwin-revisions.XXXXXX")"
 windows_file="$(mktemp "${TMPDIR:-/tmp}/gonavi-windows-revisions.XXXXXX")"
 cleanup() {
-  rm -rf "$tmpdir_failure" "$tmpdir_platform" "$tmpdir_connection"
+  rm -rf "$tmpdir_failure" "$tmpdir_platform" "$tmpdir_connection" "$tmpdir_scope"
   rm -f "$darwin_file" "$windows_file"
 }
 trap cleanup EXIT
@@ -109,6 +110,116 @@ copy_repo_to_tmp "$tmpdir_connection"
   fi
   if [[ "$before_sqlserver" != "$after_sqlserver" ]]; then
     echo "expected Redis-only connection field change to keep sqlserver revision stable, before=$before_sqlserver after=$after_sqlserver" >&2
+    exit 1
+  fi
+)
+
+copy_repo_to_tmp "$tmpdir_scope"
+
+(
+  cd "$tmpdir_scope"
+  fake_gomodcache="$(mktemp -d "${TMPDIR:-/tmp}/gonavi-fake-gomodcache.XXXXXX")"
+  mkdir -p fake-bin "$fake_gomodcache/example.com/unrelated@v1.0.0" "$fake_gomodcache/modernc.org/sqlite@v1.0.0"
+  cat >"$fake_gomodcache/example.com/unrelated@v1.0.0/unrelated.go" <<'EOF'
+package unrelated
+
+const Revision = "first"
+EOF
+  cat >"$fake_gomodcache/modernc.org/sqlite@v1.0.0/sqlite.go" <<'EOF'
+package sqlite
+
+const Revision = "first"
+EOF
+  cat >fake-bin/go <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "env" && "${2:-}" == "GOMODCACHE" ]]; then
+  printf '%s\n' "${FAKE_GOMODCACHE:?}"
+  exit 0
+fi
+
+if [[ "${1:-}" == "list" ]]; then
+  for arg in "$@"; do
+    case "$arg" in
+      ./cmd/optional-driver-agent)
+        printf '%s\n' "$PWD/cmd/optional-driver-agent/main.go"
+        printf '%s\n' "$PWD/internal/db/sqlite_impl.go"
+        printf '%s\n' "$PWD/internal/db/mysql_impl.go"
+        printf '%s\n' "$PWD/internal/utils/utils.go"
+        printf '%s\n' "${FAKE_GOMODCACHE:?}/example.com/unrelated@v1.0.0/unrelated.go"
+        exit 0
+        ;;
+      modernc.org/sqlite)
+        printf '%s\n' "${FAKE_GOMODCACHE:?}/modernc.org/sqlite@v1.0.0/sqlite.go"
+        exit 0
+        ;;
+    esac
+  done
+fi
+
+exec "${REAL_GO:?}" "$@"
+EOF
+  chmod +x fake-bin/go
+
+  before_file="$(mktemp "${TMPDIR:-/tmp}/gonavi-sqlite-revision-before.XXXXXX")"
+  external_file="$(mktemp "${TMPDIR:-/tmp}/gonavi-sqlite-revision-external.XXXXXX")"
+  other_driver_file="$(mktemp "${TMPDIR:-/tmp}/gonavi-sqlite-revision-other-driver.XXXXXX")"
+  dependency_file="$(mktemp "${TMPDIR:-/tmp}/gonavi-sqlite-revision-dependency.XXXXXX")"
+  own_driver_file="$(mktemp "${TMPDIR:-/tmp}/gonavi-sqlite-revision-own-driver.XXXXXX")"
+  cleanup_scope_revision_files() {
+    rm -rf "$fake_gomodcache"
+    rm -f "$before_file" "$external_file" "$other_driver_file" "$dependency_file" "$own_driver_file"
+  }
+  trap cleanup_scope_revision_files EXIT
+
+  export FAKE_GOMODCACHE="$fake_gomodcache"
+  export REAL_GO="$(command -v go)"
+  export PATH="$PWD/fake-bin:$PATH"
+
+  GONAVI_DRIVER_REVISION_JOBS=1 bash ./tools/generate-driver-agent-revisions.sh --platform windows/amd64 --drivers sqlite >/dev/null
+  cp internal/db/driver_agent_revisions_gen.go "$before_file"
+
+  perl -0pi -e 's/const Revision = "first"/const Revision = "second"/' "$FAKE_GOMODCACHE/example.com/unrelated@v1.0.0/unrelated.go"
+  GONAVI_DRIVER_REVISION_JOBS=1 bash ./tools/generate-driver-agent-revisions.sh --platform windows/amd64 --drivers sqlite >/dev/null
+  cp internal/db/driver_agent_revisions_gen.go "$external_file"
+
+  printf '\n// unrelated mysql revision test marker\n' >>internal/db/mysql_impl.go
+  printf '\n// unrelated shared revision test marker\n' >>internal/utils/utils.go
+  GONAVI_DRIVER_REVISION_JOBS=1 bash ./tools/generate-driver-agent-revisions.sh --platform windows/amd64 --drivers sqlite >/dev/null
+  cp internal/db/driver_agent_revisions_gen.go "$other_driver_file"
+
+  perl -0pi -e 's/const Revision = "first"/const Revision = "second"/' "$FAKE_GOMODCACHE/modernc.org/sqlite@v1.0.0/sqlite.go"
+  GONAVI_DRIVER_REVISION_JOBS=1 bash ./tools/generate-driver-agent-revisions.sh --platform windows/amd64 --drivers sqlite >/dev/null
+  cp internal/db/driver_agent_revisions_gen.go "$dependency_file"
+
+  printf '\n// sqlite revision test marker\n' >>internal/db/sqlite_impl.go
+  GONAVI_DRIVER_REVISION_JOBS=1 bash ./tools/generate-driver-agent-revisions.sh --platform windows/amd64 --drivers sqlite >/dev/null
+  cp internal/db/driver_agent_revisions_gen.go "$own_driver_file"
+
+  before_sqlite="$(extract_revision "$before_file" sqlite)"
+  external_sqlite="$(extract_revision "$external_file" sqlite)"
+  other_driver_sqlite="$(extract_revision "$other_driver_file" sqlite)"
+  dependency_sqlite="$(extract_revision "$dependency_file" sqlite)"
+  own_driver_sqlite="$(extract_revision "$own_driver_file" sqlite)"
+  if [[ -z "$before_sqlite" || -z "$external_sqlite" || -z "$other_driver_sqlite" || -z "$dependency_sqlite" || -z "$own_driver_sqlite" ]]; then
+    echo "expected sqlite revision to be generated for every scope check" >&2
+    exit 1
+  fi
+  if [[ "$before_sqlite" != "$external_sqlite" ]]; then
+    echo "expected unrelated external dependency change to keep sqlite revision stable, before=$before_sqlite after=$external_sqlite" >&2
+    exit 1
+  fi
+  if [[ "$before_sqlite" != "$other_driver_sqlite" ]]; then
+    echo "expected unrelated driver and shared source changes to keep sqlite revision stable, before=$before_sqlite after=$other_driver_sqlite" >&2
+    exit 1
+  fi
+  if [[ "$before_sqlite" == "$dependency_sqlite" ]]; then
+    echo "expected sqlite dependency change to update sqlite revision, revision=$before_sqlite" >&2
+    exit 1
+  fi
+  if [[ "$dependency_sqlite" == "$own_driver_sqlite" ]]; then
+    echo "expected sqlite implementation change to update sqlite revision, revision=$dependency_sqlite" >&2
     exit 1
   fi
 )


### PR DESCRIPTION
## 背景

GoNavi 每次版本升级时，driver-agent revision 会因为整个 monolithic internal/db 包及无关第三方依赖变化而整体变化，导致所有已安装的 optional driver-agent 被判定为不匹配并要求重新安装。本次将 revision 范围收窄到 agent 协议共享代码、目标驱动实现及目标驱动的外部依赖，避免无关升级触发重装。

Fixes #974

## 变更点

- 按目标驱动隔离 internal/db 实现文件，并解析目标驱动的外部依赖闭包。
- 保留共享 agent 协议和兼容代码的统一指纹计算。
- 增加无关依赖、其他驱动、目标依赖和目标实现变化的回归断言。

## 影响范围

- 仅影响 optional driver-agent revision 生成和驱动变更检测逻辑。
- 共享协议代码变化仍会触发全部相关 agent；目标驱动变化只触发对应 agent。
- 未修改连接、查询、数据库执行或前端运行时业务逻辑。

## 验证

- bash ./tools/generate-driver-agent-revisions.test.sh：通过。
- bash ./tools/detect-changed-driver-agents.test.sh：通过。
- GONAVI_DRIVER_REVISION_JOBS=1 bash ./tools/generate-driver-agent-revisions.sh --platform windows/amd64 --drivers sqlite：通过。
- bash -n tools/generate-driver-agent-revisions.sh tools/generate-driver-agent-revisions.test.sh：通过。
- git diff --check：通过。
- 用户自测：通过。