### PR TITLE
fix(metadata): report partial object metadata failures

### DIFF
--- a/frontend/src/components/sidebar/sidebarMetadataLoaders.test.ts
+++ b/frontend/src/components/sidebar/sidebarMetadataLoaders.test.ts
@@ -120,6 +120,20 @@ describe("buildSchemasMetadataQuerySpecs", () => {
       { viewName: "CHARACTER_SETS", schemaName: "information_schema" },
     ]);
   });
+
+  it("retains a view metadata failure when every fallback query fails", async () => {
+    mockedDBQuery.mockResolvedValue({
+      success: false,
+      message: "view metadata permission denied",
+      data: [],
+    });
+
+    await expect(loadViews({ config: { type: "mysql" } }, "app")).resolves.toMatchObject({
+      supported: false,
+      views: [],
+      failureMessage: "view metadata permission denied",
+    });
+  });
 });
 
 describe("PostgreSQL sequence metadata", () => {

--- a/frontend/src/components/sidebar/sidebarMetadataLoaders.ts
+++ b/frontend/src/components/sidebar/sidebarMetadataLoaders.ts
@@ -129,6 +129,11 @@ type MetadataQueryResult = {
   inferredType?: "FUNCTION" | "PROCEDURE";
 };
 
+type MetadataLoadState = {
+  supported: boolean;
+  failureMessage?: string;
+};
+
 const isSphinxConnection = (conn: SavedConnection | undefined): boolean => {
   const type = String(conn?.config?.type || "")
     .trim()
@@ -784,7 +789,7 @@ const queryMetadataRowsBySpecs = async (
   conn: any,
   dbName: string,
   specs: MetadataQuerySpec[],
-): Promise<{ results: MetadataQueryResult[]; hasSuccessfulQuery: boolean }> => {
+): Promise<{ results: MetadataQueryResult[]; hasSuccessfulQuery: boolean; failureMessage?: string }> => {
   const normalizedSpecs = normalizeMetadataQuerySpecs(specs);
   if (normalizedSpecs.length === 0) {
     return { results: [], hasSuccessfulQuery: false };
@@ -792,6 +797,7 @@ const queryMetadataRowsBySpecs = async (
   const config = buildSidebarRuntimeConfig(conn, dbName);
   const results: MetadataQueryResult[] = [];
   let hasSuccessfulQuery = false;
+  let failureMessage = "";
   // Full queries (no inferredType) are mutually exclusive fallbacks: first success wins.
   // Partial queries (inferredType set) are complementary (e.g. SHOW FUNCTION + SHOW PROCEDURE).
   let hasFullSuccess = false;
@@ -807,6 +813,9 @@ const queryMetadataRowsBySpecs = async (
         spec.sql,
       );
       if (!result.success || !Array.isArray(result.data)) {
+        if (!failureMessage) {
+          failureMessage = String(result.message || "metadata query failed").trim();
+        }
         continue;
       }
       hasSuccessfulQuery = true;
@@ -819,21 +828,27 @@ const queryMetadataRowsBySpecs = async (
         // (Kingbase/PG 上多条成功会把同一函数叠加多次).
         hasFullSuccess = true;
       }
-    } catch {
-      // 忽略单条查询失败，继续尝试后续回退语句
+    } catch (error) {
+      if (!failureMessage) {
+        failureMessage = error instanceof Error ? error.message : String(error || "metadata query failed");
+      }
     }
   }
-  return { results, hasSuccessfulQuery };
+  return {
+    results,
+    hasSuccessfulQuery,
+    ...(hasSuccessfulQuery || !failureMessage ? {} : { failureMessage }),
+  };
 };
 
 const loadViews = async (
   conn: any,
   dbName: string,
-): Promise<{ views: SidebarViewMetadataEntry[]; supported: boolean }> => {
+): Promise<{ views: SidebarViewMetadataEntry[] } & MetadataLoadState> => {
   const savedConn = conn as SavedConnection;
   const dialect = getMetadataDialect(savedConn);
   const querySpecs = buildViewsMetadataQuerySpecs(dialect, dbName);
-  const { results, hasSuccessfulQuery } = await queryMetadataRowsBySpecs(
+  const { results, hasSuccessfulQuery, failureMessage } = await queryMetadataRowsBySpecs(
     conn,
     dbName,
     querySpecs,
@@ -878,13 +893,13 @@ const loadViews = async (
       views.push(entry);
     });
   });
-  return { views, supported: hasSuccessfulQuery };
+  return { views, supported: hasSuccessfulQuery, failureMessage };
 };
 
 const loadStarRocksMaterializedViews = async (
   conn: any,
   dbName: string,
-): Promise<{ views: SidebarViewMetadataEntry[]; supported: boolean }> => {
+): Promise<{ views: SidebarViewMetadataEntry[] } & MetadataLoadState> => {
   const dialect = getMetadataDialect(conn as SavedConnection);
   if (dialect !== "starrocks") {
     return { views: [], supported: false };
@@ -903,7 +918,7 @@ const loadStarRocksMaterializedViews = async (
     { sql: dbIdent ? `SHOW MATERIALIZED VIEWS FROM \`${dbIdent}\`` : "" },
     { sql: `SHOW MATERIALIZED VIEWS` },
   ]);
-  const { results, hasSuccessfulQuery } = await queryMetadataRowsBySpecs(
+  const { results, hasSuccessfulQuery, failureMessage } = await queryMetadataRowsBySpecs(
     conn,
     dbName,
     querySpecs,
@@ -942,7 +957,7 @@ const loadStarRocksMaterializedViews = async (
     });
   });
 
-  return { views, supported: hasSuccessfulQuery };
+  return { views, supported: hasSuccessfulQuery, failureMessage };
 };
 
 const loadDatabaseTriggers = async (
@@ -955,11 +970,10 @@ const loadDatabaseTriggers = async (
     tableName: string;
     objectStatus?: string;
   }>;
-  supported: boolean;
-}> => {
+} & MetadataLoadState> => {
   const dialect = getMetadataDialect(conn as SavedConnection);
   const querySpecs = buildTriggersMetadataQuerySpecs(dialect, dbName);
-  const { results, hasSuccessfulQuery } = await queryMetadataRowsBySpecs(
+  const { results, hasSuccessfulQuery, failureMessage } = await queryMetadataRowsBySpecs(
     conn,
     dbName,
     querySpecs,
@@ -1036,7 +1050,7 @@ const loadDatabaseTriggers = async (
       });
     });
   });
-  return { triggers, supported: hasSuccessfulQuery };
+  return { triggers, supported: hasSuccessfulQuery, failureMessage };
 };
 
 const loadFunctions = async (
@@ -1049,11 +1063,10 @@ const loadFunctions = async (
     routineType: string;
     objectStatus?: string;
   }>;
-  supported: boolean;
-}> => {
+} & MetadataLoadState> => {
   const dialect = getMetadataDialect(conn as SavedConnection);
   const querySpecs = buildFunctionsMetadataQuerySpecs(dialect, dbName);
-  const { results, hasSuccessfulQuery } = await queryMetadataRowsBySpecs(
+  const { results, hasSuccessfulQuery, failureMessage } = await queryMetadataRowsBySpecs(
     conn,
     dbName,
     querySpecs,
@@ -1105,7 +1118,7 @@ const loadFunctions = async (
       });
     });
   });
-  return { routines, supported: hasSuccessfulQuery };
+  return { routines, supported: hasSuccessfulQuery, failureMessage };
 };
 
 const loadSequences = async (
@@ -1117,11 +1130,10 @@ const loadSequences = async (
     sequenceName: string;
     schemaName: string;
   }>;
-  supported: boolean;
-}> => {
+} & MetadataLoadState> => {
   const dialect = getMetadataDialect(conn as SavedConnection);
   const querySpecs = buildSequencesMetadataQuerySpecs(dialect, dbName);
-  const { results, hasSuccessfulQuery } = await queryMetadataRowsBySpecs(
+  const { results, hasSuccessfulQuery, failureMessage } = await queryMetadataRowsBySpecs(
     conn,
     dbName,
     querySpecs,
@@ -1166,7 +1178,7 @@ const loadSequences = async (
       });
     });
   });
-  return { sequences, supported: hasSuccessfulQuery };
+  return { sequences, supported: hasSuccessfulQuery, failureMessage };
 };
 
 const loadPackages = async (
@@ -1178,11 +1190,10 @@ const loadPackages = async (
     packageName: string;
     schemaName: string;
   }>;
-  supported: boolean;
-}> => {
+} & MetadataLoadState> => {
   const dialect = getMetadataDialect(conn as SavedConnection);
   const querySpecs = buildPackagesMetadataQuerySpecs(dialect, dbName);
-  const { results, hasSuccessfulQuery } = await queryMetadataRowsBySpecs(
+  const { results, hasSuccessfulQuery, failureMessage } = await queryMetadataRowsBySpecs(
     conn,
     dbName,
     querySpecs,
@@ -1226,7 +1237,7 @@ const loadPackages = async (
       });
     });
   });
-  return { packages, supported: hasSuccessfulQuery };
+  return { packages, supported: hasSuccessfulQuery, failureMessage };
 };
 
 const loadDatabaseEvents = async (
@@ -1240,11 +1251,10 @@ const loadDatabaseEvents = async (
     eventType: string;
     status: string;
   }>;
-  supported: boolean;
-}> => {
+} & MetadataLoadState> => {
   const dialect = getMetadataDialect(conn as SavedConnection);
   const querySpecs = buildEventsMetadataQuerySpecs(dialect, dbName);
-  const { results, hasSuccessfulQuery } = await queryMetadataRowsBySpecs(
+  const { results, hasSuccessfulQuery, failureMessage } = await queryMetadataRowsBySpecs(
     conn,
     dbName,
     querySpecs,
@@ -1295,16 +1305,16 @@ const loadDatabaseEvents = async (
     });
   });
 
-  return { events, supported: hasSuccessfulQuery };
+  return { events, supported: hasSuccessfulQuery, failureMessage };
 };
 
 const loadSchemas = async (
   conn: any,
   dbName: string,
-): Promise<{ schemas: string[]; supported: boolean }> => {
+): Promise<{ schemas: string[] } & MetadataLoadState> => {
   const dialect = getMetadataDialect(conn as SavedConnection);
   const querySpecs = buildSchemasMetadataQuerySpecs(dialect, dbName);
-  const { results, hasSuccessfulQuery } = await queryMetadataRowsBySpecs(
+  const { results, hasSuccessfulQuery, failureMessage } = await queryMetadataRowsBySpecs(
     conn,
     dbName,
     querySpecs,
@@ -1331,7 +1341,7 @@ const loadSchemas = async (
     });
   });
 
-  return { schemas, supported: hasSuccessfulQuery };
+  return { schemas, supported: hasSuccessfulQuery, failureMessage };
 };
 
 export {

--- a/frontend/src/components/sidebar/useSidebarTreeLoaders.partitions.test.tsx
+++ b/frontend/src/components/sidebar/useSidebarTreeLoaders.partitions.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { message } from 'antd';
 
 import type { SavedConnection } from '../../types';
 import { buildSidebarDatabasePinKey } from '../../store';
@@ -37,6 +38,7 @@ const deferred = <T,>(): Deferred<T> => {
 };
 
 vi.mock('antd', () => ({
+  Button: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
   message: {
     error: vi.fn(),
     info: vi.fn(),
@@ -506,5 +508,98 @@ describe('useSidebarTreeLoaders PostgreSQL partitions', () => {
     expect(mocks.replaceTreeNodeChildren).toHaveBeenCalledTimes(2);
     const refreshedChildren = mocks.replaceTreeNodeChildren.mock.calls[1][1];
     expect(findTableNode(refreshedChildren).dataRef).toMatchObject({ rowCount: 9, tableSize: 2048 });
+  });
+
+  it('warns and exposes a retry action when extension metadata is incomplete', async () => {
+    const connection = {
+      id: 'conn-mysql',
+      name: 'MySQL',
+      dbName: 'app',
+      config: { type: 'mysql', host: '127.0.0.1', port: 3306, user: 'root', database: 'app' },
+    } as SavedConnection & { dbName: string };
+    mocks.storeState.connections = [connection];
+    mocks.dbGetTables.mockResolvedValue({ success: true, data: [{ Table: 'users' }] });
+    mocks.dbQuery.mockResolvedValue({ success: false, message: 'metadata permission denied', data: [] });
+
+    let loaders: ReturnType<typeof useSidebarTreeLoaders> | undefined;
+    const Harness = () => {
+      loaders = useSidebarTreeLoaders({
+        savedQueries: [], tableSortPreference: {}, tableAccessCount: {}, pinnedSidebarTables: [], pinnedSidebarDatabases: [],
+        isV2Ui: true, loadingNodesRef: { current: new Set<string>() }, setConnectionStates: vi.fn(), setLoadedKeys: vi.fn(),
+        replaceTreeNodeChildren: mocks.replaceTreeNodeChildren, buildRuntimeConfig: (conn) => conn.config,
+        buildJVMRuntimeConfig: (conn) => conn.config, buildJVMDiagnosticTreeNodes: () => [], resolveSavedQueryDisplayName: (name) => String(name || ''),
+      });
+      return null;
+    };
+
+    act(() => { renderer = create(<Harness />); });
+    await act(async () => {
+      await loaders?.loadTables({ key: 'conn-mysql-app', dataRef: connection });
+    });
+
+    expect(message.warning).toHaveBeenCalledWith(expect.objectContaining({
+      key: 'db-conn-mysql-app-metadata-partial',
+      content: expect.anything(),
+    }));
+
+    const warningContent = (message.warning as any).mock.calls[0][0].content as React.ReactElement<any>;
+    const retryButton = React.Children.toArray(warningContent.props.children)
+      .find((child: any) => React.isValidElement(child) && typeof (child as React.ReactElement<any>).props.onClick === 'function') as React.ReactElement<any>;
+    expect(retryButton).toBeDefined();
+    await act(async () => {
+      retryButton.props.onClick();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(mocks.dbGetTables).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows a retry action and clears loaded state when base table metadata fails', async () => {
+    const connection = {
+      id: 'conn-mysql',
+      name: 'MySQL',
+      dbName: 'app',
+      config: { type: 'mysql', host: '127.0.0.1', port: 3306, user: 'root', database: 'app' },
+    } as SavedConnection & { dbName: string };
+    mocks.storeState.connections = [connection];
+    mocks.dbGetTables
+      .mockResolvedValueOnce({ success: false, message: 'table metadata permission denied' })
+      .mockResolvedValueOnce({ success: true, data: [{ Table: 'users' }] });
+    const setLoadedKeys = vi.fn();
+
+    let loaders: ReturnType<typeof useSidebarTreeLoaders> | undefined;
+    const Harness = () => {
+      loaders = useSidebarTreeLoaders({
+        savedQueries: [], tableSortPreference: {}, tableAccessCount: {}, pinnedSidebarTables: [], pinnedSidebarDatabases: [],
+        isV2Ui: true, loadingNodesRef: { current: new Set<string>() }, setConnectionStates: vi.fn(), setLoadedKeys,
+        replaceTreeNodeChildren: mocks.replaceTreeNodeChildren, buildRuntimeConfig: (conn) => conn.config,
+        buildJVMRuntimeConfig: (conn) => conn.config, buildJVMDiagnosticTreeNodes: () => [], resolveSavedQueryDisplayName: (name) => String(name || ''),
+      });
+      return null;
+    };
+
+    act(() => { renderer = create(<Harness />); });
+    const node = { key: 'conn-mysql-app', dataRef: connection };
+    await act(async () => {
+      await loaders?.loadTables(node);
+    });
+
+    expect(setLoadedKeys).toHaveBeenCalled();
+    expect(message.error).toHaveBeenCalledWith(expect.objectContaining({
+      key: 'db-conn-mysql-app-tables',
+      content: expect.anything(),
+    }));
+    const errorContent = (message.error as any).mock.calls[0][0].content as React.ReactElement<any>;
+    const retryButton = React.Children.toArray(errorContent.props.children)
+      .find((child: any) => React.isValidElement(child) && typeof (child as React.ReactElement<any>).props.onClick === 'function') as React.ReactElement<any>;
+    expect(retryButton).toBeDefined();
+    await act(async () => {
+      retryButton.props.onClick();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.dbGetTables).toHaveBeenCalledTimes(2);
+    expect(mocks.replaceTreeNodeChildren).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/sidebar/useSidebarTreeLoaders.tsx
+++ b/frontend/src/components/sidebar/useSidebarTreeLoaders.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { message } from 'antd';
+import { Button, message } from 'antd';
 import {
   AppstoreOutlined,
   CloudOutlined,
@@ -841,6 +841,27 @@ export const useSidebarTreeLoaders = ({
       loadingNodesRef.current.add(loadKey);
       setConnectionStates(prev => ({ ...prev, [key as string]: 'loading' }));
       let shouldMarkDatabaseSuccess = false;
+      const showTableLoadFailure = (error: unknown) => {
+          const errorMessage = String(error || t('sidebar.message.load_table_list_failed', { error: 'unknown error' }));
+          setConnectionStates(prev => ({ ...prev, [key as string]: 'error' }));
+          setLoadedKeys(prev => prev.filter(loadedKey => loadedKey !== node.key));
+          message.error({
+              key: `db-${key}-tables`,
+              duration: 10,
+              content: (
+                  <span>
+                      {errorMessage}
+                      <Button
+                          type="link"
+                          size="small"
+                          onClick={() => void loadTables(node, { ensureFresh: true })}
+                      >
+                          {t('common.retry')}
+                      </Button>
+                  </span>
+              ),
+          });
+      };
       
       const dbQueries = savedQueries.filter(q => q.connectionId === conn.id && q.dbName === dbName);
       const queriesNode: TreeNode = {
@@ -1173,6 +1194,38 @@ export const useSidebarTreeLoaders = ({
                         }),
                     });
                 }
+            }
+
+            const metadataFailures = [
+                { label: t('sidebar.object_group.views'), message: viewsResult.failureMessage },
+                { label: t('sidebar.object_group.materialized_views'), message: materializedViewsResult.failureMessage },
+                { label: t('sidebar.object_group.triggers'), message: triggersResult.failureMessage },
+                { label: t('sidebar.object_group.routines'), message: routinesResult.failureMessage },
+                { label: t('sidebar.object_group.sequences'), message: sequencesResult.failureMessage },
+                { label: t('sidebar.object_group.packages'), message: packagesResult.failureMessage },
+                { label: t('sidebar.object_group.events'), message: eventsResult.failureMessage },
+            ].filter((failure) => failure.message);
+            if (metadataFailures.length > 0) {
+                const warningKey = `db-${key}-metadata-partial`;
+                message.warning({
+                    key: warningKey,
+                    duration: 10,
+                    content: (
+                        <span>
+                            {t('sidebar.message.object_metadata_partial', {
+                                objects: metadataFailures.map((failure) => failure.label).join(t('sidebar.punctuation.list_separator')),
+                                error: metadataFailures.map((failure) => failure.message).join('; '),
+                            })}
+                            <Button
+                                type="link"
+                                size="small"
+                                onClick={() => void loadTables(node, { ensureFresh: true })}
+                            >
+                                {t('common.retry')}
+                            </Button>
+                        </span>
+                    ),
+                });
             }
 
 	            const currentStoreState = useStore.getState();
@@ -1535,15 +1588,10 @@ export const useSidebarTreeLoaders = ({
 	                }
 	            }
 	          } else {
-	            setConnectionStates(prev => ({ ...prev, [key as string]: 'error' }));
-	            message.error({ content: res.message, key: `db-${key}-tables` });
+	            showTableLoadFailure(res.message);
           }
 	      } catch (e: any) {
-	          setConnectionStates(prev => ({ ...prev, [key as string]: 'error' }));
-	          message.error({
-	              content: t('sidebar.message.load_table_list_failed', { error: e?.message || String(e) }),
-	              key: `db-${key}-tables`,
-	          });
+	          showTableLoadFailure(t('sidebar.message.load_table_list_failed', { error: e?.message || String(e) }));
 	      } finally {
 	          loadingNodesRef.current.delete(loadKey);
               if (shouldMarkDatabaseSuccess) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -2113,6 +2113,10 @@ export namespace connection {
 	    data: any;
 	    fields?: string[];
 	    messages?: string[];
+	    partial?: boolean;
+	    warnings?: string[];
+	    failedObjectTypes?: string[];
+	    retryable?: boolean;
 	    queryId?: string;
 	    cancellationState?: string;
 	    transactionId?: string;
@@ -2129,6 +2133,10 @@ export namespace connection {
 	        this.data = source["data"];
 	        this.fields = source["fields"];
 	        this.messages = source["messages"];
+	        this.partial = source["partial"];
+	        this.warnings = source["warnings"];
+	        this.failedObjectTypes = source["failedObjectTypes"];
+	        this.retryable = source["retryable"];
 	        this.queryId = source["queryId"];
 	        this.cancellationState = source["cancellationState"];
 	        this.transactionId = source["transactionId"];

--- a/internal/app/methods_db_metadata_retry_test.go
+++ b/internal/app/methods_db_metadata_retry_test.go
@@ -10,6 +10,7 @@ import (
 
 	"GoNavi-Wails/internal/connection"
 	"GoNavi-Wails/internal/db"
+	"GoNavi-Wails/internal/redis"
 	"GoNavi-Wails/internal/secretstore"
 )
 
@@ -30,6 +31,7 @@ type fakeMetadataRetryDB struct {
 	allColumns       []connection.ColumnDefinitionWithTable
 	indexes          []connection.IndexDefinition
 	createStatement  string
+	tablesErr        error
 	columnsErr       error
 	indexesErr       error
 	queryResults     []fakeMetadataQueryResult
@@ -102,6 +104,9 @@ func (f *fakeMetadataRetryDB) GetDatabases() ([]string, error) { return nil, nil
 func (f *fakeMetadataRetryDB) GetTables(dbName string) ([]string, error) {
 	f.tableCalls++
 	f.tableSchema = dbName
+	if f.tablesErr != nil {
+		return nil, f.tablesErr
+	}
 	return f.tables, nil
 }
 func (f *fakeMetadataRetryDB) GetCreateStatement(dbName, tableName string) (string, error) {
@@ -341,6 +346,72 @@ func TestDBGetSchemaMetadataReusesOceanBaseOracleBaseConnectionForSelectedSchema
 	}
 	if !strings.Contains(strings.Join(dbInst.queries, "\n"), "FROM all_views WHERE OWNER = 'CRH_AC'") {
 		t.Fatalf("expected explicit CRH_AC owner view query, got %v", dbInst.queries)
+	}
+}
+
+func TestDBGetObjectsMarksExtensionMetadataFailuresPartial(t *testing.T) {
+	dbInst := &fakeMetadataRetryDB{
+		tables:   []string{"CRH_AC.ORDERS"},
+		queryErr: errors.New("metadata permission denied"),
+	}
+	fixture := newOceanBaseOracleMetadataFixture(t, dbInst)
+
+	result := fixture.app.DBGetObjects(fixture.config, "CRH_AC")
+	if !result.Success || !result.Partial || !result.Retryable {
+		t.Fatalf("expected retryable partial object metadata result, got %#v", result)
+	}
+	if !strings.Contains(strings.Join(result.FailedObjectTypes, ","), "view") {
+		t.Fatalf("expected failed view metadata to be identified, got %#v", result.FailedObjectTypes)
+	}
+	if !strings.Contains(strings.Join(result.Warnings, "\n"), "metadata permission denied") {
+		t.Fatalf("expected query error summary in warnings, got %#v", result.Warnings)
+	}
+	objects, ok := result.Data.([]connection.DatabaseObject)
+	if !ok || len(objects) != 1 || objects[0].Name != "ORDERS" || objects[0].Type != "table" {
+		t.Fatalf("expected discovered table to be retained, got %#v", result.Data)
+	}
+}
+
+func TestDBGetObjectsFailsWhenBaseTableMetadataFails(t *testing.T) {
+	dbInst := &fakeMetadataRetryDB{tablesErr: errors.New("table metadata permission denied")}
+	fixture := newOceanBaseOracleMetadataFixture(t, dbInst)
+
+	result := fixture.app.DBGetObjects(fixture.config, "CRH_AC")
+	if result.Success || !result.Partial || !result.Retryable {
+		t.Fatalf("expected retryable base metadata failure, got %#v", result)
+	}
+	if len(result.FailedObjectTypes) != 1 || result.FailedObjectTypes[0] != "table" {
+		t.Fatalf("expected table failure type, got %#v", result.FailedObjectTypes)
+	}
+	if !strings.Contains(result.Message, "table metadata permission denied") {
+		t.Fatalf("expected base error summary, got %q", result.Message)
+	}
+}
+
+func TestDBGetObjectsMarksRedisKeyMetadataFailuresPartial(t *testing.T) {
+	originalNewRedisClientFunc := newRedisClientFunc
+	t.Cleanup(func() {
+		newRedisClientFunc = originalNewRedisClientFunc
+		CloseAllRedisClients()
+	})
+	CloseAllRedisClients()
+	newRedisClientFunc = func() redis.RedisClient {
+		return &capturingRedisClient{scanErr: errors.New("key scan denied")}
+	}
+
+	result := NewApp().DBGetObjects(connection.ConnectionConfig{
+		Type: "redis",
+		Host: "redis.local",
+		Port: 6379,
+	}, "0")
+	if result.Success || !result.Partial || !result.Retryable {
+		t.Fatalf("expected retryable Redis key metadata failure, got %#v", result)
+	}
+	if len(result.FailedObjectTypes) != 1 || result.FailedObjectTypes[0] != "key" {
+		t.Fatalf("expected key failure type, got %#v", result.FailedObjectTypes)
+	}
+	if !strings.Contains(result.Message, "key scan denied") {
+		t.Fatalf("expected key scan error summary, got %q", result.Message)
 	}
 }
 

--- a/internal/app/methods_db_objects.go
+++ b/internal/app/methods_db_objects.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -22,11 +23,11 @@ func (a *App) DBGetObjects(config connection.ConnectionConfig, dbName string) co
 	if strings.EqualFold(strings.TrimSpace(runConfig.Type), "redis") {
 		keys := a.DBGetTables(config, dbName)
 		if !keys.Success {
-			return keys
+			return failedObjectMetadataResult("key", errors.New(strings.TrimSpace(keys.Message)))
 		}
 		names, err := decodeStringRows(keys.Data, "Table", "table", "name")
 		if err != nil {
-			return connection.QueryResult{Success: false, Message: err.Error()}
+			return failedObjectMetadataResult("key", err)
 		}
 		return connection.QueryResult{Success: true, Data: buildNamedObjects(dbName, "key", names)}
 	}
@@ -34,31 +35,81 @@ func (a *App) DBGetObjects(config connection.ConnectionConfig, dbName string) co
 	dbInst, err := a.getDatabase(runConfig)
 	if err != nil {
 		logger.Error(err, "DBGetObjects 获取连接失败：%s", formatConnSummary(runConfig))
-		return connection.QueryResult{Success: false, Message: err.Error()}
+		return failedObjectMetadataResult(tableObjectTypeForDB(dbType), err)
 	}
 
 	objects := make([]connection.DatabaseObject, 0, 128)
 	tableType := tableObjectTypeForDB(dbType)
-	if tables, tableErr := dbInst.GetTables(dbName); tableErr == nil {
-		objects = append(objects, buildNamedObjects(dbName, tableType, tables)...)
-	} else {
+	tables, tableErr := dbInst.GetTables(dbName)
+	if tableErr != nil {
 		logger.Warnf("DBGetObjects 获取基础对象失败：%s err=%v", formatConnSummary(runConfig), tableErr)
+		return failedObjectMetadataResult(tableType, tableErr)
+	}
+	objects = append(objects, buildNamedObjects(dbName, tableType, tables)...)
+
+	warnings := make([]string, 0)
+	failedObjectTypes := make([]string, 0)
+	appendMetadataObjects := func(objectType string, metadataObjects []connection.DatabaseObject, metadataErr error) {
+		objects = append(objects, metadataObjects...)
+		if metadataErr == nil {
+			return
+		}
+		warning := objectMetadataWarning(objectType, metadataErr)
+		logger.Warnf("DBGetObjects %s 元数据不完整：%s err=%v", objectType, formatConnSummary(runConfig), metadataErr)
+		warnings = append(warnings, warning)
+		failedObjectTypes = append(failedObjectTypes, objectType)
 	}
 
 	if dbType == "rabbitmq" {
-		objects = append(objects, listObjectsByQueries(dbInst, runConfig, dbName, "exchange", buildMessageExchangeMetadataQueries(dbType))...)
+		metadataObjects, metadataErr := listObjectsByQueries(dbInst, runConfig, dbName, "exchange", buildMessageExchangeMetadataQueries(dbType))
+		appendMetadataObjects("exchange", metadataObjects, metadataErr)
 	}
 
-	viewLookup := listViewNameLookup(dbInst, runConfig, dbName)
-	objects = append(objects, buildNamedObjects(dbName, "view", mapValuesSorted(viewLookup))...)
-	objects = append(objects, listObjectsByQueries(dbInst, runConfig, dbName, "materialized_view", buildMaterializedViewMetadataQueries(dbType, dbName))...)
-	objects = append(objects, listObjectsByQueries(dbInst, runConfig, dbName, "trigger", buildObjectTriggerMetadataQueries(dbType, dbName))...)
-	objects = append(objects, listRoutineObjects(dbInst, runConfig, dbName, buildObjectRoutineMetadataQueries(dbType, dbName))...)
-	objects = append(objects, listObjectsByQueries(dbInst, runConfig, dbName, "sequence", buildObjectSequenceMetadataQueries(dbType, dbName))...)
-	objects = append(objects, listObjectsByQueries(dbInst, runConfig, dbName, "package", buildObjectPackageMetadataQueries(dbType, dbName))...)
-	objects = append(objects, listObjectsByQueries(dbInst, runConfig, dbName, "event", buildObjectEventMetadataQueries(dbType, dbName))...)
+	viewLookup, viewErr := listViewNameLookupWithStatus(dbInst, runConfig, dbName)
+	appendMetadataObjects("view", buildNamedObjects(dbName, "view", mapValuesSorted(viewLookup)), viewErr)
+	metadataObjects, metadataErr := listObjectsByQueries(dbInst, runConfig, dbName, "materialized_view", buildMaterializedViewMetadataQueries(dbType, dbName))
+	appendMetadataObjects("materialized_view", metadataObjects, metadataErr)
+	metadataObjects, metadataErr = listObjectsByQueries(dbInst, runConfig, dbName, "trigger", buildObjectTriggerMetadataQueries(dbType, dbName))
+	appendMetadataObjects("trigger", metadataObjects, metadataErr)
+	metadataObjects, metadataErr = listRoutineObjects(dbInst, runConfig, dbName, buildObjectRoutineMetadataQueries(dbType, dbName))
+	appendMetadataObjects("routine", metadataObjects, metadataErr)
+	metadataObjects, metadataErr = listObjectsByQueries(dbInst, runConfig, dbName, "sequence", buildObjectSequenceMetadataQueries(dbType, dbName))
+	appendMetadataObjects("sequence", metadataObjects, metadataErr)
+	metadataObjects, metadataErr = listObjectsByQueries(dbInst, runConfig, dbName, "package", buildObjectPackageMetadataQueries(dbType, dbName))
+	appendMetadataObjects("package", metadataObjects, metadataErr)
+	metadataObjects, metadataErr = listObjectsByQueries(dbInst, runConfig, dbName, "event", buildObjectEventMetadataQueries(dbType, dbName))
+	appendMetadataObjects("event", metadataObjects, metadataErr)
 
-	return connection.QueryResult{Success: true, Data: dedupeSortDatabaseObjects(objects)}
+	partial := len(failedObjectTypes) > 0
+	result := connection.QueryResult{
+		Success:           true,
+		Data:              dedupeSortDatabaseObjects(objects),
+		Partial:           partial,
+		Warnings:          warnings,
+		FailedObjectTypes: failedObjectTypes,
+		Retryable:         partial,
+	}
+	if partial {
+		result.Message = "对象元数据不完整，可重试"
+	}
+	return result
+}
+
+func objectMetadataWarning(objectType string, err error) string {
+	return fmt.Sprintf("读取 %s 对象元数据失败: %v", strings.TrimSpace(objectType), err)
+}
+
+func failedObjectMetadataResult(objectType string, err error) connection.QueryResult {
+	warning := objectMetadataWarning(objectType, err)
+	return connection.QueryResult{
+		Success:           false,
+		Partial:           true,
+		Message:           warning,
+		Data:              []connection.DatabaseObject{},
+		Warnings:          []string{warning},
+		FailedObjectTypes: []string{objectType},
+		Retryable:         true,
+	}
 }
 
 func tableObjectTypeForDB(dbType string) string {
@@ -92,13 +143,19 @@ func buildNamedObjects(dbName string, objectType string, names []string) []conne
 	return objects
 }
 
-func listObjectsByQueries(dbInst db.Database, config connection.ConnectionConfig, dbName string, objectType string, specs []objectMetadataQuerySpec) []connection.DatabaseObject {
+func listObjectsByQueries(dbInst db.Database, config connection.ConnectionConfig, dbName string, objectType string, specs []objectMetadataQuerySpec) ([]connection.DatabaseObject, error) {
 	objects := make([]connection.DatabaseObject, 0)
+	querySucceeded := false
+	var firstErr error
 	for _, spec := range normalizeObjectMetadataQuerySpecs(specs) {
 		rows, _, err := queryDataForExport(dbInst, config, spec.sql)
 		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
 			continue
 		}
+		querySucceeded = true
 		for _, row := range rows {
 			object := databaseObjectFromRow(dbName, objectType, spec.inferredType, row)
 			if object.Name == "" {
@@ -107,16 +164,25 @@ func listObjectsByQueries(dbInst db.Database, config connection.ConnectionConfig
 			objects = append(objects, object)
 		}
 	}
-	return objects
+	if !querySucceeded && firstErr != nil {
+		return objects, firstErr
+	}
+	return objects, nil
 }
 
-func listRoutineObjects(dbInst db.Database, config connection.ConnectionConfig, dbName string, specs []objectMetadataQuerySpec) []connection.DatabaseObject {
+func listRoutineObjects(dbInst db.Database, config connection.ConnectionConfig, dbName string, specs []objectMetadataQuerySpec) ([]connection.DatabaseObject, error) {
 	objects := make([]connection.DatabaseObject, 0)
+	querySucceeded := false
+	var firstErr error
 	for _, spec := range normalizeObjectMetadataQuerySpecs(specs) {
 		rows, _, err := queryDataForExport(dbInst, config, spec.sql)
 		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
 			continue
 		}
+		querySucceeded = true
 		for _, row := range rows {
 			rawType := rowStringCI(row, "routine_type", "object_type", "type")
 			if rawType == "" {
@@ -133,7 +199,10 @@ func listRoutineObjects(dbInst db.Database, config connection.ConnectionConfig, 
 			objects = append(objects, object)
 		}
 	}
-	return objects
+	if !querySucceeded && firstErr != nil {
+		return objects, firstErr
+	}
+	return objects, nil
 }
 
 func databaseObjectFromRow(dbName string, objectType string, rawType string, row map[string]interface{}) connection.DatabaseObject {

--- a/internal/app/methods_file.go
+++ b/internal/app/methods_file.go
@@ -6203,7 +6203,14 @@ func normalizeExportObjectKeyByParts(schemaName, objectName string) string {
 }
 
 func listViewNameLookup(dbInst db.Database, config connection.ConnectionConfig, dbName string) map[string]string {
+	viewLookup, _ := listViewNameLookupWithStatus(dbInst, config, dbName)
+	return viewLookup
+}
+
+func listViewNameLookupWithStatus(dbInst db.Database, config connection.ConnectionConfig, dbName string) (map[string]string, error) {
 	viewLookup := make(map[string]string)
+	var firstErr error
+	querySucceeded := false
 	queries := buildListViewQueries(config, dbName)
 	for _, query := range queries {
 		if strings.TrimSpace(query) == "" {
@@ -6211,8 +6218,12 @@ func listViewNameLookup(dbInst db.Database, config connection.ConnectionConfig, 
 		}
 		rows, _, err := queryDataForExport(dbInst, config, query)
 		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
 			continue
 		}
+		querySucceeded = true
 		for _, row := range rows {
 			tableType := strings.ToUpper(exportRowValueCI(row, "table_type", "type"))
 			if tableType != "" && tableType != "VIEW" {
@@ -6239,7 +6250,10 @@ func listViewNameLookup(dbInst db.Database, config connection.ConnectionConfig, 
 			}
 		}
 	}
-	return viewLookup
+	if !querySucceeded && firstErr != nil {
+		return viewLookup, firstErr
+	}
+	return viewLookup, nil
 }
 
 func buildListViewQueries(config connection.ConnectionConfig, dbName string) []string {

--- a/internal/app/methods_redis_test.go
+++ b/internal/app/methods_redis_test.go
@@ -31,6 +31,7 @@ type capturingRedisClient struct {
 	listCalls          int
 	closed             int
 	closeErr           error
+	scanErr            error
 }
 
 func (c *capturingRedisClient) Connect(config connection.ConnectionConfig) error {
@@ -46,6 +47,9 @@ func (c *capturingRedisClient) Close() error {
 func (c *capturingRedisClient) Ping() error { return nil }
 
 func (c *capturingRedisClient) ScanKeys(pattern string, cursor uint64, count int64) (*redislib.RedisScanResult, error) {
+	if c.scanErr != nil {
+		return nil, c.scanErr
+	}
 	return &redislib.RedisScanResult{}, nil
 }
 

--- a/internal/connection/types.go
+++ b/internal/connection/types.go
@@ -200,6 +200,10 @@ type QueryResult struct {
 	Data               interface{} `json:"data"`
 	Fields             []string    `json:"fields,omitempty"`
 	Messages           []string    `json:"messages,omitempty"`
+	Partial            bool        `json:"partial,omitempty"`
+	Warnings           []string    `json:"warnings,omitempty"`
+	FailedObjectTypes  []string    `json:"failedObjectTypes,omitempty"`
+	Retryable          bool        `json:"retryable,omitempty"`
 	QueryID            string      `json:"queryId,omitempty"` // Unique ID for query cancellation
 	CancellationState  string      `json:"cancellationState,omitempty"`
 	TransactionID      string      `json:"transactionId,omitempty"`

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -85,6 +85,40 @@ func TestExecuteSQLCallToolReturnsSelectResultContent(t *testing.T) {
 	}
 }
 
+func TestGetObjectsCallToolRetainsStructuredBaseMetadataFailure(t *testing.T) {
+	backend := &fakeBackend{
+		editableConnection: connection.SavedConnectionView{
+			ID:     "mysql-main",
+			Config: connection.ConnectionConfig{Type: "mysql", Database: "app"},
+		},
+		objectsResult: connection.QueryResult{
+			Success:           false,
+			Partial:           true,
+			Retryable:         true,
+			Message:           "读取 table 对象元数据失败: permission denied",
+			Warnings:          []string{"读取 table 对象元数据失败: permission denied"},
+			FailedObjectTypes: []string{"table"},
+		},
+	}
+
+	result := callServerTool(t, NewServer(backend), "get_objects", map[string]any{
+		"connectionId": "mysql-main",
+		"dbName":       "app",
+	})
+	if !result.IsError {
+		t.Fatalf("expected base metadata failure tool result, got %#v", result)
+	}
+	structured, err := json.Marshal(result.StructuredContent)
+	if err != nil {
+		t.Fatalf("failed to marshal structuredContent: %v", err)
+	}
+	for _, expected := range []string{`"partial":true`, `"retryable":true`, `"failedObjectTypes":["table"]`, `"warnings":["读取 table 对象元数据失败: permission denied"]`} {
+		if !strings.Contains(string(structured), expected) {
+			t.Fatalf("expected structured base metadata failure to contain %s, got %s", expected, string(structured))
+		}
+	}
+}
+
 func listServerToolNames(t *testing.T, server *mcp.Server) map[string]bool {
 	t.Helper()
 

--- a/internal/mcpserver/service.go
+++ b/internal/mcpserver/service.go
@@ -99,9 +99,14 @@ type getViewsResult struct {
 }
 
 type getObjectsResult struct {
-	ConnectionID string                      `json:"connectionId"`
-	DBName       string                      `json:"dbName,omitempty"`
-	Objects      []connection.DatabaseObject `json:"objects"`
+	ConnectionID      string                      `json:"connectionId"`
+	DBName            string                      `json:"dbName,omitempty"`
+	Objects           []connection.DatabaseObject `json:"objects"`
+	Message           string                      `json:"message,omitempty"`
+	Partial           bool                        `json:"partial,omitempty"`
+	Warnings          []string                    `json:"warnings,omitempty"`
+	FailedObjectTypes []string                    `json:"failedObjectTypes,omitempty"`
+	Retryable         bool                        `json:"retryable,omitempty"`
 }
 
 type getAllColumnsResult struct {
@@ -308,7 +313,24 @@ func (s *Service) GetObjects(ctx context.Context, req *mcp.CallToolRequest, args
 	dbName := effectiveDBName(args.DBName, view.Config)
 	queryResult := s.backend.DBGetObjects(view.Config, dbName)
 	if !queryResult.Success {
-		return toolError("获取数据库对象列表失败: %s", strings.TrimSpace(queryResult.Message)), getObjectsResult{}, nil
+		output := getObjectsResult{
+			ConnectionID:      view.ID,
+			DBName:            dbName,
+			Objects:           []connection.DatabaseObject{},
+			Message:           strings.TrimSpace(queryResult.Message),
+			Partial:           queryResult.Partial,
+			Warnings:          objectMetadataWarnings(queryResult),
+			FailedObjectTypes: queryResult.FailedObjectTypes,
+			Retryable:         queryResult.Retryable,
+		}
+		if queryResult.Retryable {
+			failedTypes := strings.Join(queryResult.FailedObjectTypes, ", ")
+			if failedTypes != "" {
+				return toolError("获取数据库对象列表失败（失败类别: %s，可重试）: %s", failedTypes, strings.TrimSpace(queryResult.Message)), output, nil
+			}
+			return toolError("获取数据库对象列表失败（可重试）: %s", strings.TrimSpace(queryResult.Message)), output, nil
+		}
+		return toolError("获取数据库对象列表失败: %s", strings.TrimSpace(queryResult.Message)), output, nil
 	}
 
 	objects, err := decodeDatabaseObjects(queryResult.Data)
@@ -317,10 +339,25 @@ func (s *Service) GetObjects(ctx context.Context, req *mcp.CallToolRequest, args
 	}
 
 	return successResult(), getObjectsResult{
-		ConnectionID: view.ID,
-		DBName:       dbName,
-		Objects:      filterDatabaseObjects(objects, args.ObjectTypes),
+		ConnectionID:      view.ID,
+		DBName:            dbName,
+		Objects:           filterDatabaseObjects(objects, args.ObjectTypes),
+		Message:           strings.TrimSpace(queryResult.Message),
+		Partial:           queryResult.Partial,
+		Warnings:          objectMetadataWarnings(queryResult),
+		FailedObjectTypes: queryResult.FailedObjectTypes,
+		Retryable:         queryResult.Retryable,
 	}, nil
+}
+
+func objectMetadataWarnings(result connection.QueryResult) []string {
+	if len(result.Warnings) > 0 {
+		return result.Warnings
+	}
+	if message := strings.TrimSpace(result.Message); message != "" {
+		return []string{message}
+	}
+	return nil
 }
 
 func (s *Service) GetAllColumns(ctx context.Context, req *mcp.CallToolRequest, args databaseArgs) (*mcp.CallToolResult, getAllColumnsResult, error) {

--- a/internal/mcpserver/service_test.go
+++ b/internal/mcpserver/service_test.go
@@ -358,6 +358,56 @@ func TestGetObjectsReturnsDatabaseObjectsAndFiltersByType(t *testing.T) {
 	}
 }
 
+func TestGetObjectsPreservesPartialMetadataWarnings(t *testing.T) {
+	backend := &fakeBackend{
+		editableConnection: connection.SavedConnectionView{
+			ID:     "mysql-main",
+			Config: connection.ConnectionConfig{Type: "mysql", Database: "app"},
+		},
+		objectsResult: connection.QueryResult{
+			Success:           true,
+			Partial:           true,
+			Retryable:         true,
+			Warnings:          []string{"读取 view 对象元数据失败: permission denied"},
+			FailedObjectTypes: []string{"view"},
+			Data:              []connection.DatabaseObject{{Database: "app", Name: "users", Type: "table"}},
+		},
+	}
+
+	result, out, err := NewService(backend).GetObjects(context.Background(), nil, objectsArgs{ConnectionID: "mysql-main", DBName: "app"})
+	if err != nil || result == nil || result.IsError {
+		t.Fatalf("expected partial metadata success, result=%#v err=%v", result, err)
+	}
+	if !out.Partial || !out.Retryable || len(out.Warnings) != 1 || len(out.FailedObjectTypes) != 1 || out.FailedObjectTypes[0] != "view" {
+		t.Fatalf("partial metadata details were lost: %#v", out)
+	}
+}
+
+func TestGetObjectsMarksBaseMetadataFailureRetryable(t *testing.T) {
+	backend := &fakeBackend{
+		editableConnection: connection.SavedConnectionView{ID: "mysql-main", Config: connection.ConnectionConfig{Type: "mysql", Database: "app"}},
+		objectsResult: connection.QueryResult{
+			Success:           false,
+			Partial:           true,
+			Retryable:         true,
+			Message:           "读取 table 对象元数据失败: permission denied",
+			FailedObjectTypes: []string{"table"},
+		},
+	}
+
+	result, out, err := NewService(backend).GetObjects(context.Background(), nil, objectsArgs{ConnectionID: "mysql-main", DBName: "app"})
+	if err != nil || result == nil || !result.IsError {
+		t.Fatalf("expected retryable tool error, result=%#v err=%v", result, err)
+	}
+	text := firstTextContent(result)
+	if !strings.Contains(text, "table") || !strings.Contains(text, "可重试") {
+		t.Fatalf("expected failure category and retry guidance, got %q", text)
+	}
+	if !out.Partial || !out.Retryable || len(out.Warnings) != 1 || len(out.FailedObjectTypes) != 1 || out.FailedObjectTypes[0] != "table" {
+		t.Fatalf("expected structured retry metadata, got %#v", out)
+	}
+}
+
 func TestGetIndexesReturnsIndexDefinitions(t *testing.T) {
 	backend := &fakeBackend{
 		editableConnection: connection.SavedConnectionView{

--- a/shared/i18n/de-DE.json
+++ b/shared/i18n/de-DE.json
@@ -7743,6 +7743,7 @@
   "sidebar.message.load_database_list_failed": "Datenbanken konnten nicht geladen werden: {{error}}",
   "sidebar.message.load_jvm_resources_failed": "JVM-Ressourcen konnten nicht geladen werden: {{error}}",
   "sidebar.message.load_table_list_failed": "Tabellen konnten nicht geladen werden: {{error}}",
+  "sidebar.message.object_metadata_partial": "Einige Datenbankobjektmetadaten konnten nicht geladen werden ({{objects}}): {{error}}",
   "sidebar.message.load_tables_failed": "Objekte konnten nicht geladen werden: {{error}}",
   "sidebar.message.locate_connection_not_found_for_object": "Die Verbindung für das aktuelle Objekt wurde nicht gefunden",
   "sidebar.message.locate_connection_not_in_tree": "Die aktuelle Verbindung wurde im linken Baum nicht gefunden",

--- a/shared/i18n/en-US.json
+++ b/shared/i18n/en-US.json
@@ -7743,6 +7743,7 @@
   "sidebar.message.load_database_list_failed": "Failed to load databases: {{error}}",
   "sidebar.message.load_jvm_resources_failed": "Failed to load JVM resources: {{error}}",
   "sidebar.message.load_table_list_failed": "Failed to load tables: {{error}}",
+  "sidebar.message.object_metadata_partial": "Some database object metadata could not be loaded ({{objects}}): {{error}}",
   "sidebar.message.load_tables_failed": "Failed to load objects: {{error}}",
   "sidebar.message.locate_connection_not_found_for_object": "The connection for the current object was not found",
   "sidebar.message.locate_connection_not_in_tree": "Current connection was not found in the left tree",

--- a/shared/i18n/ja-JP.json
+++ b/shared/i18n/ja-JP.json
@@ -7743,6 +7743,7 @@
   "sidebar.message.load_database_list_failed": "データベースの読み込みに失敗しました: {{error}}",
   "sidebar.message.load_jvm_resources_failed": "JVM リソースの読み込みに失敗しました: {{error}}",
   "sidebar.message.load_table_list_failed": "テーブルの読み込みに失敗しました: {{error}}",
+  "sidebar.message.object_metadata_partial": "一部のデータベースオブジェクトメタデータを読み込めませんでした（{{objects}}）：{{error}}",
   "sidebar.message.load_tables_failed": "オブジェクトの読み込みに失敗しました: {{error}}",
   "sidebar.message.locate_connection_not_found_for_object": "現在のオブジェクトに対応する接続が見つかりません",
   "sidebar.message.locate_connection_not_in_tree": "左側ツリーで現在の接続が見つかりません",

--- a/shared/i18n/ru-RU.json
+++ b/shared/i18n/ru-RU.json
@@ -7743,6 +7743,7 @@
   "sidebar.message.load_database_list_failed": "Не удалось загрузить базы данных: {{error}}",
   "sidebar.message.load_jvm_resources_failed": "Не удалось загрузить ресурсы JVM: {{error}}",
   "sidebar.message.load_table_list_failed": "Не удалось загрузить таблицы: {{error}}",
+  "sidebar.message.object_metadata_partial": "Не удалось загрузить часть метаданных объектов базы данных ({{objects}}): {{error}}",
   "sidebar.message.load_tables_failed": "Не удалось загрузить объекты: {{error}}",
   "sidebar.message.locate_connection_not_found_for_object": "Подключение для текущего объекта не найдено",
   "sidebar.message.locate_connection_not_in_tree": "Текущее подключение не найдено в левом дереве",

--- a/shared/i18n/zh-CN.json
+++ b/shared/i18n/zh-CN.json
@@ -7743,6 +7743,7 @@
   "sidebar.message.load_database_list_failed": "加载数据库失败：{{error}}",
   "sidebar.message.load_jvm_resources_failed": "加载 JVM 资源失败：{{error}}",
   "sidebar.message.load_table_list_failed": "加载表失败：{{error}}",
+  "sidebar.message.object_metadata_partial": "部分数据库对象元数据加载失败（{{objects}}）：{{error}}",
   "sidebar.message.load_tables_failed": "加载对象失败：{{error}}",
   "sidebar.message.locate_connection_not_found_for_object": "未找到当前对象对应的连接",
   "sidebar.message.locate_connection_not_in_tree": "未在左侧树找到当前连接",

--- a/shared/i18n/zh-TW.json
+++ b/shared/i18n/zh-TW.json
@@ -7743,6 +7743,7 @@
   "sidebar.message.load_database_list_failed": "載入資料庫失敗：{{error}}",
   "sidebar.message.load_jvm_resources_failed": "載入 JVM 資源失敗：{{error}}",
   "sidebar.message.load_table_list_failed": "載入資料表失敗：{{error}}",
+  "sidebar.message.object_metadata_partial": "部分資料庫物件中繼資料載入失敗（{{objects}}）：{{error}}",
   "sidebar.message.load_tables_failed": "載入物件失敗：{{error}}",
   "sidebar.message.locate_connection_not_found_for_object": "找不到目前物件對應的連線",
   "sidebar.message.locate_connection_not_in_tree": "未在左側樹找到目前連線",


### PR DESCRIPTION
## Summary
- mark base and extension object metadata failures as partial and retryable
- preserve structured failure metadata through MCP, including Redis keys
- show sidebar metadata warnings with direct retry actions

## Validation
- targeted Go app and MCP tests
- MCP in-memory transport structured-content test
- sidebar and i18n Vitest tests
- frontend production build

Closes #969