### PR TITLE
fix(redis): report truncated cursor scans

### DIFF
--- a/frontend/src/components/DataSyncModal.table-metadata.test.tsx
+++ b/frontend/src/components/DataSyncModal.table-metadata.test.tsx
@@ -1,0 +1,231 @@
+import React from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DataSyncModal from './DataSyncModal';
+
+const mocks = vi.hoisted(() => ({
+  dbGetDatabases: vi.fn(),
+  dbGetTables: vi.fn(),
+  dataSyncCapability: vi.fn(),
+  message: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+  transfer: vi.fn(),
+  storeState: {
+    connections: [
+      {
+        id: 'source',
+        name: 'Source Redis',
+        config: { type: 'redis', host: 'source.local', port: 6379, database: '0' },
+      },
+      {
+        id: 'target',
+        name: 'Target Redis',
+        config: { type: 'redis', host: 'target.local', port: 6379, database: '0' },
+      },
+    ],
+    theme: 'light',
+    appearance: {},
+  },
+}));
+
+vi.mock('../store', () => ({
+  useStore: (selector: (state: typeof mocks.storeState) => unknown) => selector(mocks.storeState),
+}));
+
+vi.mock('../../wailsjs/go/app/App', () => ({
+  DBGetDatabases: mocks.dbGetDatabases,
+  DBGetTables: mocks.dbGetTables,
+  DataSync: vi.fn(),
+  DataSyncAnalyze: vi.fn(),
+  DataSyncCapability: mocks.dataSyncCapability,
+  DataSyncPreview: vi.fn(),
+}));
+
+vi.mock('../../wailsjs/runtime/runtime', () => ({
+  EventsOn: vi.fn(() => () => undefined),
+}));
+
+vi.mock('./dataSyncBackgroundTask', () => ({
+  useDataSyncBackgroundTask: () => ({
+    taskKey: '',
+    jobId: '',
+    status: 'idle',
+    startedAt: 0,
+    finishedAt: 0,
+    progress: { percent: 0, current: 0, total: 0, table: '', stage: '' },
+    logs: [],
+    result: null,
+  }),
+  startDataSyncBackgroundTask: vi.fn(),
+  finishDataSyncBackgroundTask: vi.fn(),
+  failDataSyncBackgroundTask: vi.fn(),
+  resolveDataSyncTaskLogLevel: vi.fn(() => 'info'),
+}));
+
+vi.mock('antd', async () => {
+  const React = await import('react');
+  const Form = Object.assign(
+    ({ children }: { children?: React.ReactNode }) => React.createElement('form', null, children),
+    { Item: ({ children }: { children?: React.ReactNode }) => React.createElement('div', null, children) },
+  );
+  const Select = Object.assign(
+    ({ children, value, onChange, disabled }: any) => React.createElement(
+      'select',
+      {
+        value: value ?? '',
+        disabled,
+        onChange: (event: any) => onChange?.(event.target.value),
+      },
+      children,
+    ),
+    {
+      Option: ({ children, value, disabled }: any) => React.createElement(
+        'option',
+        { value, disabled },
+        children,
+      ),
+    },
+  );
+  const Input = Object.assign(
+    ({ value, onChange, placeholder }: any) => React.createElement('input', { value, onChange, placeholder }),
+    { TextArea: ({ value, onChange }: any) => React.createElement('textarea', { value, onChange }) },
+  );
+  const Steps = Object.assign(
+    ({ current, children }: any) => React.createElement('div', { 'data-testid': 'steps', 'data-current': current }, children),
+    { Step: () => null },
+  );
+  const Typography = {
+    Title: ({ children }: { children?: React.ReactNode }) => React.createElement('h2', null, children),
+    Text: ({ children }: { children?: React.ReactNode }) => React.createElement('span', null, children),
+  };
+  const modalRef = () => ({ update: vi.fn() });
+  const Modal = Object.assign(
+    ({ children, open }: any) => (open ? React.createElement('div', null, children) : null),
+    {
+      info: modalRef,
+      success: modalRef,
+      error: modalRef,
+      warning: modalRef,
+      confirm: modalRef,
+      destroyAll: vi.fn(),
+      useModal: () => [{ info: modalRef, success: modalRef, error: modalRef, warning: modalRef, confirm: modalRef }, null],
+    },
+  );
+
+  return {
+    Form,
+    Select,
+    Input,
+    Button: ({ children, disabled, loading, onClick }: any) => React.createElement(
+      'button',
+      { disabled: Boolean(disabled || loading), onClick },
+      children,
+    ),
+    Steps,
+    Transfer: (props: any) => {
+      mocks.transfer(props);
+      return React.createElement('div', { 'data-testid': 'transfer' });
+    },
+    Card: ({ children, title }: any) => React.createElement('section', null, title, children),
+    Alert: ({ message: alertMessage, description }: any) => React.createElement('div', null, alertMessage, description),
+    Divider: ({ children }: any) => React.createElement('div', null, children),
+    Typography,
+    Progress: () => React.createElement('div'),
+    Checkbox: ({ children, checked, disabled, onChange }: any) => React.createElement(
+      'label',
+      null,
+      React.createElement('input', {
+        type: 'checkbox',
+        checked,
+        disabled,
+        onChange,
+      }),
+      children,
+    ),
+    Table: () => React.createElement('div'),
+    Drawer: ({ children, open }: any) => (open ? React.createElement('aside', null, children) : null),
+    Tabs: () => React.createElement('div'),
+    Modal,
+    theme: { useToken: () => ({ token: { colorPrimary: '#1677ff' } }) },
+    message: mocks.message,
+  };
+});
+
+vi.mock('@ant-design/icons', () => ({
+  DatabaseOutlined: () => null,
+  RocketOutlined: () => null,
+  SwapOutlined: () => null,
+  TableOutlined: () => null,
+}));
+
+const textContent = (node: any): string => {
+  if (node === null || node === undefined) return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(textContent).join('');
+  return textContent(node.children || []);
+};
+
+describe('DataSyncModal table metadata completeness', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.dbGetDatabases.mockResolvedValue({ success: true, data: [{ Database: '0' }] });
+    mocks.dataSyncCapability.mockResolvedValue({
+      sourceType: 'redis',
+      targetType: 'redis',
+      planner: 'redis',
+      canExecute: true,
+      supportsAutoCreate: false,
+      supportsAutoAddColumns: false,
+      requiresExistingTarget: true,
+      supportLevel: 'full',
+    });
+  });
+
+  it('warns and remains on configuration when table metadata is truncated', async () => {
+    mocks.dbGetTables.mockResolvedValue({
+      success: true,
+      partial: true,
+      truncated: true,
+      message: 'Redis key scan truncated after 2 keys: cursor loop detected',
+      data: [{ Table: 'orders' }, { Table: 'users' }],
+    });
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<DataSyncModal open embedded onClose={vi.fn()} />);
+      await Promise.resolve();
+    });
+
+    const [sourceConnection, targetConnection] = renderer.root.findAllByType('select');
+    await act(async () => {
+      sourceConnection.props.onChange({ target: { value: 'source' } });
+      await Promise.resolve();
+      targetConnection.props.onChange({ target: { value: 'target' } });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const nextButton = renderer.root
+      .findAllByType('button')
+      .find((button) => textContent(button).trim() === 'Next');
+    expect(nextButton).toBeTruthy();
+    expect(nextButton?.props.disabled).toBe(false);
+
+    await act(async () => {
+      nextButton?.props.onClick();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.dbGetTables).toHaveBeenCalledTimes(1);
+    expect(mocks.message.warning).toHaveBeenCalledWith(
+      expect.stringContaining('Redis key scan truncated after 2 keys: cursor loop detected'),
+    );
+    expect(renderer.root.findByProps({ 'data-testid': 'steps' }).props['data-current']).toBe(0);
+    expect(mocks.transfer).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/DataSyncModal.tsx
+++ b/frontend/src/components/DataSyncModal.tsx
@@ -50,6 +50,7 @@ import {
 import { resolveSqlDialect } from "../utils/sqlDialect";
 import { quoteIdentPart, quoteQualifiedIdent } from "../utils/sql";
 import { normalizeTableNamesFromMetadataRows } from "../utils/tableMetadataRows";
+import { getTableMetadataIssueDetail, isTableMetadataIncomplete } from "../utils/tableMetadataResult";
 import {
   formatLocalDateTimeLiteral,
   normalizeTemporalLiteralText,
@@ -960,7 +961,7 @@ const DataSyncModal: React.FC<{
         ) {
           return;
         }
-        if (res.success) {
+        if (res.success && !isTableMetadataIncomplete(res)) {
           const tables = normalizeTableNamesFromMetadataRows(res.data);
           const nextTables = (
             isSourceQueryMode && targetSupportsSchemaSelection && targetSchema
@@ -977,10 +978,12 @@ const DataSyncModal: React.FC<{
           });
           setCurrentStep(1);
         } else {
-          message.error(
-            res.message
+          const detail = getTableMetadataIssueDetail(res);
+          const notify = res.success ? message.warning : message.error;
+          notify(
+            detail
               ? tr("data_sync.message.fetch_tables_failed_detail", {
-                  detail: res.message,
+                  detail,
                 })
               : tr("data_sync.message.fetch_tables_failed"),
           );

--- a/frontend/src/components/FindInDatabaseModal.test.tsx
+++ b/frontend/src/components/FindInDatabaseModal.test.tsx
@@ -186,4 +186,32 @@ describe("FindInDatabaseModal i18n", () => {
 
     expect(mocks.message.error).toHaveBeenCalledWith("Failed to get table list: driver raw detail");
   });
+
+  it("warns and stops before searching an incomplete table list", async () => {
+    mocks.dbGetTables.mockResolvedValue({
+      success: true,
+      partial: true,
+      truncated: true,
+      message: "Redis key scan truncated after 2 keys: cursor loop detected",
+      data: [{ Table: "orders" }, { Table: "users" }],
+    });
+    const renderer = renderFindModal();
+
+    const input = renderer.root.findByType("input");
+    await act(async () => {
+      input.props.onChange({ target: { value: "alice" } });
+    });
+    const searchButton = renderer.root.findAllByType("button").find((button) => textContent(button).includes("Search"));
+
+    await act(async () => {
+      searchButton?.props.onClick();
+      await Promise.resolve();
+    });
+
+    expect(mocks.message.warning).toHaveBeenCalledWith(
+      "Failed to get table list: Redis key scan truncated after 2 keys: cursor loop detected",
+    );
+    expect(mocks.dbGetAllColumns).not.toHaveBeenCalled();
+    expect(mocks.dbQuery).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/components/FindInDatabaseModal.tsx
+++ b/frontend/src/components/FindInDatabaseModal.tsx
@@ -10,6 +10,7 @@ import { buildRpcConnectionConfig } from '../utils/connectionRpcConfig';
 import { isMacLikePlatform } from '../utils/appearance';
 import { useI18n } from '../i18n/provider';
 import { normalizeTableNamesFromMetadataRows } from '../utils/tableMetadataRows';
+import { getTableMetadataIssueDetail, isTableMetadataIncomplete } from '../utils/tableMetadataResult';
 
 interface FindInDatabaseModalProps {
     open: boolean;
@@ -113,8 +114,10 @@ const FindInDatabaseModal: React.FC<FindInDatabaseModalProps> = ({ open, onClose
 
         try {
             const tablesRes = await DBGetTables(buildRpcConnectionConfig(config) as any, dbName);
-            if (!tablesRes.success) {
-                message.error(t('find_in_database.message.get_tables_failed', { detail: tablesRes.message }));
+            if (!tablesRes.success || isTableMetadataIncomplete(tablesRes)) {
+                const detail = getTableMetadataIssueDetail(tablesRes);
+                const notify = tablesRes.success ? message.warning : message.error;
+                notify(t('find_in_database.message.get_tables_failed', { detail }));
                 setSearching(false);
                 return;
             }

--- a/frontend/src/components/sidebar/useSidebarTreeLoaders.partitions.test.tsx
+++ b/frontend/src/components/sidebar/useSidebarTreeLoaders.partitions.test.tsx
@@ -602,4 +602,43 @@ describe('useSidebarTreeLoaders PostgreSQL partitions', () => {
     expect(mocks.dbGetTables).toHaveBeenCalledTimes(2);
     expect(mocks.replaceTreeNodeChildren).toHaveBeenCalledTimes(1);
   });
+
+  it('warns when table metadata scanning is truncated', async () => {
+    const connection = {
+      id: 'conn-redis',
+      name: 'Redis',
+      dbName: '0',
+      config: { type: 'redis', host: '127.0.0.1', port: 6379, database: '0' },
+    } as SavedConnection & { dbName: string };
+    mocks.storeState.connections = [connection];
+    mocks.dbGetTables.mockResolvedValue({
+      success: true,
+      data: [{ Table: 'orders' }],
+      partial: true,
+      truncated: true,
+      scannedCount: 1,
+      message: 'Redis key scan truncated after 1 keys: invalid cursor',
+    });
+
+    let loaders: ReturnType<typeof useSidebarTreeLoaders> | undefined;
+    const Harness = () => {
+      loaders = useSidebarTreeLoaders({
+        savedQueries: [], tableSortPreference: {}, tableAccessCount: {}, pinnedSidebarTables: [], pinnedSidebarDatabases: [],
+        isV2Ui: true, loadingNodesRef: { current: new Set<string>() }, setConnectionStates: vi.fn(), setLoadedKeys: vi.fn(),
+        replaceTreeNodeChildren: mocks.replaceTreeNodeChildren, buildRuntimeConfig: (conn) => conn.config,
+        buildJVMRuntimeConfig: (conn) => conn.config, buildJVMDiagnosticTreeNodes: () => [], resolveSavedQueryDisplayName: (name) => String(name || ''),
+      });
+      return null;
+    };
+
+    act(() => { renderer = create(<Harness />); });
+    await act(async () => {
+      await loaders?.loadTables({ key: 'conn-redis-0', dataRef: connection });
+    });
+
+    expect(message.warning).toHaveBeenCalledWith(expect.objectContaining({
+      key: 'db-conn-redis-0-tables-partial',
+      content: expect.anything(),
+    }));
+  });
 });

--- a/frontend/src/components/sidebar/useSidebarTreeLoaders.tsx
+++ b/frontend/src/components/sidebar/useSidebarTreeLoaders.tsx
@@ -892,6 +892,29 @@ export const useSidebarTreeLoaders = ({
 	          const res = await DBGetTables(buildRpcConnectionConfig(config) as any, conn.dbName);
 	          if (res.success) {
                 const tableRows: any[] = Array.isArray(res.data) ? res.data : [];
+                if (res.partial || res.truncated) {
+                    const warningDetail = String(
+                        res.message
+                        || (Array.isArray(res.warnings) ? res.warnings.join('; ') : '')
+                        || t('sidebar.message.load_table_list_failed', { error: 'metadata scan was truncated' }),
+                    );
+                    message.warning({
+                        key: `db-${key}-tables-partial`,
+                        duration: 10,
+                        content: (
+                            <span>
+                                {warningDetail}
+                                <Button
+                                    type="link"
+                                    size="small"
+                                    onClick={() => void loadTables(node, { ensureFresh: true })}
+                                >
+                                    {t('common.retry')}
+                                </Button>
+                            </span>
+                        ),
+                    });
+                }
                 const tableStatusSql = buildSidebarTableStatusSQL(conn as SavedConnection, conn.dbName);
                 const tableStatsResult = tableStatusSql
                     ? await DBQuery(buildRpcConnectionConfig(config) as any, conn.dbName, tableStatusSql).catch(() => ({ success: false, data: [] as any[] }))

--- a/frontend/src/utils/tableMetadataResult.test.ts
+++ b/frontend/src/utils/tableMetadataResult.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { getTableMetadataIssueDetail, isTableMetadataIncomplete } from './tableMetadataResult';
+
+describe('table metadata result helpers', () => {
+  it('treats either partial or truncated metadata as incomplete', () => {
+    expect(isTableMetadataIncomplete({ partial: true })).toBe(true);
+    expect(isTableMetadataIncomplete({ truncated: true })).toBe(true);
+    expect(isTableMetadataIncomplete({})).toBe(false);
+  });
+
+  it('uses the backend message before warning details', () => {
+    expect(getTableMetadataIssueDetail({
+      message: 'Redis key scan truncated',
+      warnings: ['cursor loop detected'],
+    })).toBe('Redis key scan truncated');
+    expect(getTableMetadataIssueDetail({ warnings: ['cursor loop detected'] })).toBe('cursor loop detected');
+  });
+});

--- a/frontend/src/utils/tableMetadataResult.ts
+++ b/frontend/src/utils/tableMetadataResult.ts
@@ -1,0 +1,23 @@
+type TableMetadataResult = {
+  partial?: boolean;
+  truncated?: boolean;
+  message?: unknown;
+  warnings?: unknown;
+};
+
+export const isTableMetadataIncomplete = (result: TableMetadataResult): boolean =>
+  Boolean(result.partial || result.truncated);
+
+export const getTableMetadataIssueDetail = (result: TableMetadataResult): string => {
+  const message = String(result.message || '').trim();
+  if (message) return message;
+
+  if (Array.isArray(result.warnings)) {
+    const warning = result.warnings
+      .map((item) => String(item || '').trim())
+      .find(Boolean);
+    if (warning) return warning;
+  }
+
+  return '';
+};

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -2117,6 +2117,8 @@ export namespace connection {
 	    warnings?: string[];
 	    failedObjectTypes?: string[];
 	    retryable?: boolean;
+	    truncated?: boolean;
+	    scannedCount?: number;
 	    queryId?: string;
 	    cancellationState?: string;
 	    transactionId?: string;
@@ -2137,6 +2139,8 @@ export namespace connection {
 	        this.warnings = source["warnings"];
 	        this.failedObjectTypes = source["failedObjectTypes"];
 	        this.retryable = source["retryable"];
+	        this.truncated = source["truncated"];
+	        this.scannedCount = source["scannedCount"];
 	        this.queryId = source["queryId"];
 	        this.cancellationState = source["cancellationState"];
 	        this.transactionId = source["transactionId"];

--- a/internal/app/methods_db.go
+++ b/internal/app/methods_db.go
@@ -2362,6 +2362,7 @@ func (a *App) DBGetTables(config connection.ConnectionConfig, dbName string) con
 		cursor := uint64(0)
 		tables := make([]string, 0, 128)
 		seen := make(map[string]struct{}, 128)
+		seenCursors := map[uint64]struct{}{cursor: {}}
 		for {
 			result, err := client.ScanKeys("*", cursor, 1000)
 			if err != nil {
@@ -2387,9 +2388,10 @@ func (a *App) DBGetTables(config connection.ConnectionConfig, dbName string) con
 			if err != nil {
 				return buildRedisTablesPartialResult(tables, fmt.Sprintf("invalid cursor %q: %v", rawCursor, err))
 			}
-			if next == cursor {
-				return buildRedisTablesPartialResult(tables, fmt.Sprintf("cursor did not advance (cursor=%d)", cursor))
+			if _, exists := seenCursors[next]; exists {
+				return buildRedisTablesPartialResult(tables, fmt.Sprintf("cursor loop detected (cursor=%d next=%d)", cursor, next))
 			}
+			seenCursors[next] = struct{}{}
 			cursor = next
 		}
 		resData := make([]map[string]string, 0, len(tables))

--- a/internal/app/methods_db.go
+++ b/internal/app/methods_db.go
@@ -2379,12 +2379,16 @@ func (a *App) DBGetTables(config connection.ConnectionConfig, dbName string) con
 				seen[key] = struct{}{}
 				tables = append(tables, key)
 			}
-			if strings.TrimSpace(result.Cursor) == "" || strings.TrimSpace(result.Cursor) == "0" {
+			rawCursor := strings.TrimSpace(result.Cursor)
+			if rawCursor == "0" {
 				break
 			}
-			next, err := strconv.ParseUint(strings.TrimSpace(result.Cursor), 10, 64)
-			if err != nil || next == cursor {
-				break
+			next, err := strconv.ParseUint(rawCursor, 10, 64)
+			if err != nil {
+				return buildRedisTablesPartialResult(tables, fmt.Sprintf("invalid cursor %q: %v", rawCursor, err))
+			}
+			if next == cursor {
+				return buildRedisTablesPartialResult(tables, fmt.Sprintf("cursor did not advance (cursor=%d)", cursor))
 			}
 			cursor = next
 		}
@@ -2392,7 +2396,7 @@ func (a *App) DBGetTables(config connection.ConnectionConfig, dbName string) con
 		for _, name := range tables {
 			resData = append(resData, map[string]string{"Table": name})
 		}
-		return connection.QueryResult{Success: true, Data: resData}
+		return connection.QueryResult{Success: true, Data: resData, ScannedCount: len(tables)}
 	}
 
 	dbInst, err := a.getDatabase(runConfig)
@@ -2466,6 +2470,25 @@ func (a *App) DBGetTables(config connection.ConnectionConfig, dbName string) con
 	}
 
 	return connection.QueryResult{Success: true, Data: resData}
+}
+
+func buildRedisTablesPartialResult(tables []string, reason string) connection.QueryResult {
+	warning := fmt.Sprintf("Redis key scan truncated after %d keys: %s", len(tables), strings.TrimSpace(reason))
+	resData := make([]map[string]string, 0, len(tables))
+	for _, name := range tables {
+		resData = append(resData, map[string]string{"Table": name})
+	}
+	return connection.QueryResult{
+		Success:           true,
+		Data:              resData,
+		Message:           warning,
+		Partial:           true,
+		Warnings:          []string{warning},
+		Retryable:         true,
+		Truncated:         true,
+		ScannedCount:      len(tables),
+		FailedObjectTypes: []string{"key"},
+	}
 }
 
 func (a *App) DBRefreshTableStats(config connection.ConnectionConfig, dbName string, rawTables []string) connection.QueryResult {

--- a/internal/app/methods_db_metadata_retry_test.go
+++ b/internal/app/methods_db_metadata_retry_test.go
@@ -423,6 +423,7 @@ func TestDBGetTablesRedisCursorState(t *testing.T) {
 		wantPartial   bool
 		wantTruncated bool
 		wantWarning   string
+		wantScanCalls int
 	}{
 		{
 			name: "invalid cursor",
@@ -444,7 +445,21 @@ func TestDBGetTablesRedisCursorState(t *testing.T) {
 			wantKeys:      2,
 			wantPartial:   true,
 			wantTruncated: true,
-			wantWarning:   "cursor did not advance",
+			wantWarning:   "cursor loop detected",
+			wantScanCalls: 2,
+		},
+		{
+			name: "cursor loop",
+			scanResults: []*redis.RedisScanResult{
+				{Keys: []redis.RedisKeyInfo{{Key: "orders"}}, Cursor: "7"},
+				{Keys: []redis.RedisKeyInfo{{Key: "users"}}, Cursor: "8"},
+				{Keys: []redis.RedisKeyInfo{{Key: "products"}}, Cursor: "7"},
+			},
+			wantKeys:      3,
+			wantPartial:   true,
+			wantTruncated: true,
+			wantWarning:   "cursor loop detected",
+			wantScanCalls: 3,
 		},
 		{
 			name: "normal zero cursor",
@@ -464,8 +479,9 @@ func TestDBGetTablesRedisCursorState(t *testing.T) {
 				CloseAllRedisClients()
 			})
 			CloseAllRedisClients()
+			client := &capturingRedisClient{scanResults: tc.scanResults}
 			newRedisClientFunc = func() redis.RedisClient {
-				return &capturingRedisClient{scanResults: tc.scanResults}
+				return client
 			}
 
 			result := NewApp().DBGetTables(connection.ConnectionConfig{
@@ -488,6 +504,9 @@ func TestDBGetTablesRedisCursorState(t *testing.T) {
 			}
 			if tc.wantWarning != "" && !strings.Contains(strings.Join(result.Warnings, "\n"), tc.wantWarning) {
 				t.Fatalf("expected warning containing %q, got %#v", tc.wantWarning, result.Warnings)
+			}
+			if tc.wantScanCalls > 0 && client.scanCalls != tc.wantScanCalls {
+				t.Fatalf("expected %d scan calls, got %d", tc.wantScanCalls, client.scanCalls)
 			}
 		})
 	}

--- a/internal/app/methods_db_metadata_retry_test.go
+++ b/internal/app/methods_db_metadata_retry_test.go
@@ -415,6 +415,114 @@ func TestDBGetObjectsMarksRedisKeyMetadataFailuresPartial(t *testing.T) {
 	}
 }
 
+func TestDBGetTablesRedisCursorState(t *testing.T) {
+	testCases := []struct {
+		name          string
+		scanResults   []*redis.RedisScanResult
+		wantKeys      int
+		wantPartial   bool
+		wantTruncated bool
+		wantWarning   string
+	}{
+		{
+			name: "invalid cursor",
+			scanResults: []*redis.RedisScanResult{{
+				Keys:   []redis.RedisKeyInfo{{Key: "orders"}},
+				Cursor: "not-a-cursor",
+			}},
+			wantKeys:      1,
+			wantPartial:   true,
+			wantTruncated: true,
+			wantWarning:   "invalid cursor",
+		},
+		{
+			name: "repeated cursor",
+			scanResults: []*redis.RedisScanResult{
+				{Keys: []redis.RedisKeyInfo{{Key: "orders"}}, Cursor: "7"},
+				{Keys: []redis.RedisKeyInfo{{Key: "users"}}, Cursor: "7"},
+			},
+			wantKeys:      2,
+			wantPartial:   true,
+			wantTruncated: true,
+			wantWarning:   "cursor did not advance",
+		},
+		{
+			name: "normal zero cursor",
+			scanResults: []*redis.RedisScanResult{{
+				Keys:   []redis.RedisKeyInfo{{Key: "orders"}},
+				Cursor: "0",
+			}},
+			wantKeys: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			originalNewRedisClientFunc := newRedisClientFunc
+			t.Cleanup(func() {
+				newRedisClientFunc = originalNewRedisClientFunc
+				CloseAllRedisClients()
+			})
+			CloseAllRedisClients()
+			newRedisClientFunc = func() redis.RedisClient {
+				return &capturingRedisClient{scanResults: tc.scanResults}
+			}
+
+			result := NewApp().DBGetTables(connection.ConnectionConfig{
+				Type: "redis",
+				Host: "redis-" + tc.name + ".local",
+				Port: 6379,
+			}, "0")
+			if !result.Success {
+				t.Fatalf("expected scan result, got failure: %#v", result)
+			}
+			rows, ok := result.Data.([]map[string]string)
+			if !ok || len(rows) != tc.wantKeys {
+				t.Fatalf("expected %d scanned keys, got %#v", tc.wantKeys, result.Data)
+			}
+			if result.Partial != tc.wantPartial || result.Truncated != tc.wantTruncated {
+				t.Fatalf("unexpected cursor state: %#v", result)
+			}
+			if result.ScannedCount != tc.wantKeys {
+				t.Fatalf("expected scannedCount=%d, got %d", tc.wantKeys, result.ScannedCount)
+			}
+			if tc.wantWarning != "" && !strings.Contains(strings.Join(result.Warnings, "\n"), tc.wantWarning) {
+				t.Fatalf("expected warning containing %q, got %#v", tc.wantWarning, result.Warnings)
+			}
+		})
+	}
+}
+
+func TestDBGetObjectsPreservesRedisCursorTruncation(t *testing.T) {
+	originalNewRedisClientFunc := newRedisClientFunc
+	t.Cleanup(func() {
+		newRedisClientFunc = originalNewRedisClientFunc
+		CloseAllRedisClients()
+	})
+	CloseAllRedisClients()
+	newRedisClientFunc = func() redis.RedisClient {
+		return &capturingRedisClient{scanResults: []*redis.RedisScanResult{{
+			Keys:   []redis.RedisKeyInfo{{Key: "orders"}},
+			Cursor: "invalid",
+		}}}
+	}
+
+	result := NewApp().DBGetObjects(connection.ConnectionConfig{
+		Type: "redis",
+		Host: "redis-object-cursor.local",
+		Port: 6379,
+	}, "0")
+	if !result.Success || !result.Partial || !result.Truncated || !result.Retryable {
+		t.Fatalf("expected partial Redis object result, got %#v", result)
+	}
+	if len(result.FailedObjectTypes) != 1 || result.FailedObjectTypes[0] != "key" {
+		t.Fatalf("expected key failure type, got %#v", result.FailedObjectTypes)
+	}
+	if result.ScannedCount != 1 || !strings.Contains(result.Message, "invalid cursor") {
+		t.Fatalf("expected cursor warning and count, got %#v", result)
+	}
+}
+
 func TestDBGetColumnsRetriesAfterCachedConnectionRefresh(t *testing.T) {
 	originalNewDatabaseFunc := newDatabaseFunc
 	originalResolveDialConfigWithProxyFunc := resolveDialConfigWithProxyFunc

--- a/internal/app/methods_db_objects.go
+++ b/internal/app/methods_db_objects.go
@@ -29,7 +29,17 @@ func (a *App) DBGetObjects(config connection.ConnectionConfig, dbName string) co
 		if err != nil {
 			return failedObjectMetadataResult("key", err)
 		}
-		return connection.QueryResult{Success: true, Data: buildNamedObjects(dbName, "key", names)}
+		return connection.QueryResult{
+			Success:           true,
+			Data:              buildNamedObjects(dbName, "key", names),
+			Message:           keys.Message,
+			Partial:           keys.Partial,
+			Warnings:          keys.Warnings,
+			FailedObjectTypes: keys.FailedObjectTypes,
+			Retryable:         keys.Retryable,
+			Truncated:         keys.Truncated,
+			ScannedCount:      keys.ScannedCount,
+		}
 	}
 
 	dbInst, err := a.getDatabase(runConfig)

--- a/internal/app/methods_redis_test.go
+++ b/internal/app/methods_redis_test.go
@@ -32,6 +32,8 @@ type capturingRedisClient struct {
 	closed             int
 	closeErr           error
 	scanErr            error
+	scanResults        []*redislib.RedisScanResult
+	scanCalls          int
 }
 
 func (c *capturingRedisClient) Connect(config connection.ConnectionConfig) error {
@@ -47,8 +49,16 @@ func (c *capturingRedisClient) Close() error {
 func (c *capturingRedisClient) Ping() error { return nil }
 
 func (c *capturingRedisClient) ScanKeys(pattern string, cursor uint64, count int64) (*redislib.RedisScanResult, error) {
+	c.scanCalls++
 	if c.scanErr != nil {
 		return nil, c.scanErr
+	}
+	if len(c.scanResults) > 0 {
+		index := c.scanCalls - 1
+		if index >= len(c.scanResults) {
+			index = len(c.scanResults) - 1
+		}
+		return c.scanResults[index], nil
 	}
 	return &redislib.RedisScanResult{}, nil
 }

--- a/internal/connection/types.go
+++ b/internal/connection/types.go
@@ -204,6 +204,8 @@ type QueryResult struct {
 	Warnings           []string    `json:"warnings,omitempty"`
 	FailedObjectTypes  []string    `json:"failedObjectTypes,omitempty"`
 	Retryable          bool        `json:"retryable,omitempty"`
+	Truncated          bool        `json:"truncated,omitempty"`
+	ScannedCount       int         `json:"scannedCount,omitempty"`
 	QueryID            string      `json:"queryId,omitempty"` // Unique ID for query cancellation
 	CancellationState  string      `json:"cancellationState,omitempty"`
 	TransactionID      string      `json:"transactionId,omitempty"`

--- a/internal/mcpserver/service.go
+++ b/internal/mcpserver/service.go
@@ -107,6 +107,8 @@ type getObjectsResult struct {
 	Warnings          []string                    `json:"warnings,omitempty"`
 	FailedObjectTypes []string                    `json:"failedObjectTypes,omitempty"`
 	Retryable         bool                        `json:"retryable,omitempty"`
+	Truncated         bool                        `json:"truncated,omitempty"`
+	ScannedCount      int                         `json:"scannedCount,omitempty"`
 }
 
 type getAllColumnsResult struct {
@@ -322,6 +324,8 @@ func (s *Service) GetObjects(ctx context.Context, req *mcp.CallToolRequest, args
 			Warnings:          objectMetadataWarnings(queryResult),
 			FailedObjectTypes: queryResult.FailedObjectTypes,
 			Retryable:         queryResult.Retryable,
+			Truncated:         queryResult.Truncated,
+			ScannedCount:      queryResult.ScannedCount,
 		}
 		if queryResult.Retryable {
 			failedTypes := strings.Join(queryResult.FailedObjectTypes, ", ")
@@ -347,6 +351,8 @@ func (s *Service) GetObjects(ctx context.Context, req *mcp.CallToolRequest, args
 		Warnings:          objectMetadataWarnings(queryResult),
 		FailedObjectTypes: queryResult.FailedObjectTypes,
 		Retryable:         queryResult.Retryable,
+		Truncated:         queryResult.Truncated,
+		ScannedCount:      queryResult.ScannedCount,
 	}, nil
 }
 

--- a/internal/mcpserver/service.go
+++ b/internal/mcpserver/service.go
@@ -90,6 +90,12 @@ type getTablesResult struct {
 	DBName       string   `json:"dbName,omitempty"`
 	Tables       []string `json:"tables"`
 	Views        []string `json:"views"`
+	Message      string   `json:"message,omitempty"`
+	Partial      bool     `json:"partial,omitempty"`
+	Warnings     []string `json:"warnings,omitempty"`
+	Retryable    bool     `json:"retryable,omitempty"`
+	Truncated    bool     `json:"truncated,omitempty"`
+	ScannedCount int      `json:"scannedCount,omitempty"`
 }
 
 type getViewsResult struct {
@@ -273,6 +279,12 @@ func (s *Service) GetTables(ctx context.Context, req *mcp.CallToolRequest, args 
 		DBName:       dbName,
 		Tables:       ensureNonNilStrings(tables),
 		Views:        ensureNonNilStrings(views),
+		Message:      strings.TrimSpace(queryResult.Message),
+		Partial:      queryResult.Partial,
+		Warnings:     objectMetadataWarnings(queryResult),
+		Retryable:    queryResult.Retryable,
+		Truncated:    queryResult.Truncated,
+		ScannedCount: queryResult.ScannedCount,
 	}, nil
 }
 

--- a/internal/mcpserver/service_test.go
+++ b/internal/mcpserver/service_test.go
@@ -315,6 +315,39 @@ func TestGetTablesIncludesViewsInDedicatedField(t *testing.T) {
 	}
 }
 
+func TestGetTablesPreservesPartialMetadataWarnings(t *testing.T) {
+	backend := &fakeBackend{
+		editableConnection: connection.SavedConnectionView{
+			ID:     "redis-main",
+			Config: connection.ConnectionConfig{Type: "redis", Database: "0"},
+		},
+		tablesResult: connection.QueryResult{
+			Success:      true,
+			Message:      "Redis key scan truncated after 2 keys: cursor loop detected",
+			Partial:      true,
+			Truncated:    true,
+			Retryable:    true,
+			ScannedCount: 2,
+			Warnings:     []string{"Redis key scan truncated after 2 keys: cursor loop detected"},
+			Data:         []map[string]string{{"Table": "orders"}, {"Table": "users"}},
+		},
+	}
+
+	result, out, err := NewService(backend).GetTables(context.Background(), nil, databaseArgs{
+		ConnectionID: "redis-main",
+		DBName:       "0",
+	})
+	if err != nil || result == nil || result.IsError {
+		t.Fatalf("expected partial table metadata success, result=%#v err=%v", result, err)
+	}
+	if !out.Partial || !out.Truncated || !out.Retryable || out.ScannedCount != 2 || len(out.Warnings) != 1 {
+		t.Fatalf("partial table metadata details were lost: %#v", out)
+	}
+	if out.Message != backend.tablesResult.Message || out.Warnings[0] != backend.tablesResult.Warnings[0] {
+		t.Fatalf("expected table metadata message and warnings to propagate, got %#v", out)
+	}
+}
+
 func TestGetObjectsReturnsDatabaseObjectsAndFiltersByType(t *testing.T) {
 	backend := &fakeBackend{
 		editableConnection: connection.SavedConnectionView{

--- a/internal/mcpserver/service_test.go
+++ b/internal/mcpserver/service_test.go
@@ -368,6 +368,8 @@ func TestGetObjectsPreservesPartialMetadataWarnings(t *testing.T) {
 			Success:           true,
 			Partial:           true,
 			Retryable:         true,
+			Truncated:         true,
+			ScannedCount:      1,
 			Warnings:          []string{"读取 view 对象元数据失败: permission denied"},
 			FailedObjectTypes: []string{"view"},
 			Data:              []connection.DatabaseObject{{Database: "app", Name: "users", Type: "table"}},
@@ -378,7 +380,7 @@ func TestGetObjectsPreservesPartialMetadataWarnings(t *testing.T) {
 	if err != nil || result == nil || result.IsError {
 		t.Fatalf("expected partial metadata success, result=%#v err=%v", result, err)
 	}
-	if !out.Partial || !out.Retryable || len(out.Warnings) != 1 || len(out.FailedObjectTypes) != 1 || out.FailedObjectTypes[0] != "view" {
+	if !out.Partial || !out.Retryable || !out.Truncated || out.ScannedCount != 1 || len(out.Warnings) != 1 || len(out.FailedObjectTypes) != 1 || out.FailedObjectTypes[0] != "view" {
 		t.Fatalf("partial metadata details were lost: %#v", out)
 	}
 }


### PR DESCRIPTION
## Summary
- mark invalid and repeated Redis cursors as partial/truncated instead of silent success
- include truncation reason and scanned key count
- propagate cursor status through object metadata and MCP responses
- show sidebar warning with retry action

## Validation
- Redis invalid, repeated, and zero cursor tests
- Redis object and MCP metadata propagation tests
- sidebar/i18n Vitest tests
- frontend production build

Closes #970