### PR TITLE
fix(elasticsearch): honor rollover alias write index

### DIFF
--- a/internal/db/elasticsearch_impl.go
+++ b/internal/db/elasticsearch_impl.go
@@ -928,10 +928,13 @@ func (e *ElasticsearchDB) esBulkActionMeta(action, indexName string, docID strin
 	return map[string]interface{}{action: meta}
 }
 
-// resolveWriteIndex 解析别名对应的实际可写索引名。
-// 如果 indexOrAlias 是直接索引名，原样返回。
-// 如果是别名，返回该别名下最新的索引名（按名称倒序）。
+// resolveWriteIndex 解析别名 metadata 中唯一标记为 is_write_index 的索引。
+// 直接索引名通过 GetAlias 的 404 判定；别名缺失或冲突时拒绝写入。
 func (e *ElasticsearchDB) resolveWriteIndex(indexOrAlias string) (string, error) {
+	indexOrAlias = strings.TrimSpace(indexOrAlias)
+	if indexOrAlias == "" {
+		return "", fmt.Errorf("未指定索引或别名")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -940,41 +943,47 @@ func (e *ElasticsearchDB) resolveWriteIndex(indexOrAlias string) (string, error)
 		e.client.Indices.GetAlias.WithIndex(indexOrAlias),
 	)
 	if err != nil {
-		return indexOrAlias, nil // 网络错误时回退到原名
+		return "", fmt.Errorf("读取别名 metadata 失败：%w", err)
 	}
 	defer res.Body.Close()
 
 	if res.IsError() {
-		// 404 表示不是别名而是直接索引名
-		return indexOrAlias, nil
+		if res.StatusCode == http.StatusNotFound {
+			// 404 表示不是别名，按直接索引名处理。
+			_, _ = io.Copy(io.Discard, res.Body)
+			return indexOrAlias, nil
+		}
+		body, _ := io.ReadAll(res.Body)
+		return "", fmt.Errorf("读取别名 metadata 失败（HTTP %d）：%s", res.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		return indexOrAlias, nil
+		return "", fmt.Errorf("读取别名 metadata 失败：%w", err)
 	}
 
-	var aliasMap map[string]interface{}
+	type aliasConfig struct {
+		IsWriteIndex *bool `json:"is_write_index"`
+	}
+	type indexAliasMetadata struct {
+		Aliases map[string]aliasConfig `json:"aliases"`
+	}
+	var aliasMap map[string]indexAliasMetadata
 	if err := json.Unmarshal(body, &aliasMap); err != nil {
-		return indexOrAlias, nil
+		return "", fmt.Errorf("解析别名 metadata 失败：%w", err)
 	}
 
-	// aliasMap 的 key 是实际索引名，如果没有 key 或只有一个，直接用
-	var indices []string
-	for name := range aliasMap {
-		indices = append(indices, name)
+	writeIndexes := make([]string, 0, 1)
+	for indexName, metadata := range aliasMap {
+		config, ok := metadata.Aliases[indexOrAlias]
+		if ok && config.IsWriteIndex != nil && *config.IsWriteIndex {
+			writeIndexes = append(writeIndexes, indexName)
+		}
 	}
-
-	if len(indices) == 0 {
-		return indexOrAlias, nil
+	if len(writeIndexes) != 1 {
+		return "", fmt.Errorf("别名 %q 必须且只能有一个 is_write_index=true 索引，实际 %d 个", indexOrAlias, len(writeIndexes))
 	}
-	if len(indices) == 1 {
-		return indices[0], nil
-	}
-
-	// 多个索引对应同一别名时，取名称最新的（ES 通常用日期后缀，倒序取第一个）
-	sort.Sort(sort.Reverse(sort.StringSlice(indices)))
-	return indices[0], nil
+	return writeIndexes[0], nil
 }
 
 // isESMetaField 判断字段名是否为 ES 元字段（不应写入文档 _source）。
@@ -1000,9 +1009,9 @@ func (e *ElasticsearchDB) ApplyChanges(tableName string, changes connection.Chan
 	var bulkBody bytes.Buffer
 
 	// 如果目标是别名（非直接索引），解析出实际的可写索引名。
-	writeIndexName := indexName
-	if resolved, err := e.resolveWriteIndex(indexName); err == nil && resolved != "" {
-		writeIndexName = resolved
+	writeIndexName, err := e.resolveWriteIndex(indexName)
+	if err != nil {
+		return fmt.Errorf("解析写入索引失败：%w", err)
 	}
 
 	// resolveWriteIndex 确定写操作的目标索引。

--- a/internal/db/elasticsearch_impl.go
+++ b/internal/db/elasticsearch_impl.go
@@ -940,7 +940,7 @@ func (e *ElasticsearchDB) resolveWriteIndex(indexOrAlias string) (string, error)
 
 	res, err := e.client.Indices.GetAlias(
 		e.client.Indices.GetAlias.WithContext(ctx),
-		e.client.Indices.GetAlias.WithIndex(indexOrAlias),
+		e.client.Indices.GetAlias.WithName(indexOrAlias),
 	)
 	if err != nil {
 		return "", fmt.Errorf("读取别名 metadata 失败：%w", err)
@@ -949,7 +949,7 @@ func (e *ElasticsearchDB) resolveWriteIndex(indexOrAlias string) (string, error)
 
 	if res.IsError() {
 		if res.StatusCode == http.StatusNotFound {
-			// 404 表示不是别名，按直接索引名处理。
+			// Alias API 的 404 表示该名称不是别名，按直接索引名处理。
 			_, _ = io.Copy(io.Discard, res.Body)
 			return indexOrAlias, nil
 		}

--- a/internal/db/elasticsearch_impl_test.go
+++ b/internal/db/elasticsearch_impl_test.go
@@ -85,12 +85,17 @@ func TestBuildESClientConfigSeparatesConnectionAndRequestTimeout(t *testing.T) {
 func TestElasticsearchApplyChangesResolvesWriteAliasMetadata(t *testing.T) {
 	testCases := []struct {
 		name          string
+		target        string
+		aliasPath     string
+		aliasStatus   int
 		aliasResponse map[string]interface{}
 		wantIndex     string
 		wantErr       string
 	}{
 		{
-			name: "unique write index",
+			name:      "unique write index",
+			target:    "events",
+			aliasPath: "/_alias/events",
 			aliasResponse: map[string]interface{}{
 				"events-000001": map[string]interface{}{"aliases": map[string]interface{}{
 					"events": map[string]interface{}{"is_write_index": false},
@@ -102,7 +107,9 @@ func TestElasticsearchApplyChangesResolvesWriteAliasMetadata(t *testing.T) {
 			wantIndex: "events-000002",
 		},
 		{
-			name: "missing write index",
+			name:      "missing write index",
+			target:    "events",
+			aliasPath: "/_alias/events",
 			aliasResponse: map[string]interface{}{
 				"events-000001": map[string]interface{}{"aliases": map[string]interface{}{
 					"events": map[string]interface{}{},
@@ -114,7 +121,9 @@ func TestElasticsearchApplyChangesResolvesWriteAliasMetadata(t *testing.T) {
 			wantErr: "is_write_index=true",
 		},
 		{
-			name: "conflicting write indexes",
+			name:      "conflicting write indexes",
+			target:    "events",
+			aliasPath: "/_alias/events",
 			aliasResponse: map[string]interface{}{
 				"events-000001": map[string]interface{}{"aliases": map[string]interface{}{
 					"events": map[string]interface{}{"is_write_index": true},
@@ -125,6 +134,13 @@ func TestElasticsearchApplyChangesResolvesWriteAliasMetadata(t *testing.T) {
 			},
 			wantErr: "is_write_index=true",
 		},
+		{
+			name:        "direct index",
+			target:      "events-000002",
+			aliasPath:   "/_alias/events-000002",
+			aliasStatus: http.StatusNotFound,
+			wantIndex:   "events-000002",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -133,7 +149,16 @@ func TestElasticsearchApplyChangesResolvesWriteAliasMetadata(t *testing.T) {
 			var bulkIndex string
 			server := newMockESServer(t, func(w http.ResponseWriter, r *http.Request) {
 				switch {
-				case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/_alias"):
+				case r.Method == http.MethodGet:
+					if r.URL.Path != tc.aliasPath {
+						t.Errorf("unexpected alias metadata path: got %q want %q", r.URL.Path, tc.aliasPath)
+						w.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+					if tc.aliasStatus != 0 {
+						w.WriteHeader(tc.aliasStatus)
+						return
+					}
 					writeJSON(w, tc.aliasResponse)
 				case r.Method == http.MethodPost && r.URL.Path == "/_bulk":
 					bulkCalls.Add(1)
@@ -156,8 +181,8 @@ func TestElasticsearchApplyChangesResolvesWriteAliasMetadata(t *testing.T) {
 				}
 			})
 
-			db := newTestESDB(t, server.URL, "events")
-			err := db.ApplyChanges("events", connection.ChangeSet{
+			db := newTestESDB(t, server.URL, tc.target)
+			err := db.ApplyChanges(tc.target, connection.ChangeSet{
 				Inserts: []map[string]interface{}{{"message": "hello"}},
 			})
 			if tc.wantErr != "" {

--- a/internal/db/elasticsearch_impl_test.go
+++ b/internal/db/elasticsearch_impl_test.go
@@ -82,6 +82,103 @@ func TestBuildESClientConfigSeparatesConnectionAndRequestTimeout(t *testing.T) {
 	}
 }
 
+func TestElasticsearchApplyChangesResolvesWriteAliasMetadata(t *testing.T) {
+	testCases := []struct {
+		name          string
+		aliasResponse map[string]interface{}
+		wantIndex     string
+		wantErr       string
+	}{
+		{
+			name: "unique write index",
+			aliasResponse: map[string]interface{}{
+				"events-000001": map[string]interface{}{"aliases": map[string]interface{}{
+					"events": map[string]interface{}{"is_write_index": false},
+				}},
+				"events-000002": map[string]interface{}{"aliases": map[string]interface{}{
+					"events": map[string]interface{}{"is_write_index": true},
+				}},
+			},
+			wantIndex: "events-000002",
+		},
+		{
+			name: "missing write index",
+			aliasResponse: map[string]interface{}{
+				"events-000001": map[string]interface{}{"aliases": map[string]interface{}{
+					"events": map[string]interface{}{},
+				}},
+				"events-000002": map[string]interface{}{"aliases": map[string]interface{}{
+					"events": map[string]interface{}{"is_write_index": false},
+				}},
+			},
+			wantErr: "is_write_index=true",
+		},
+		{
+			name: "conflicting write indexes",
+			aliasResponse: map[string]interface{}{
+				"events-000001": map[string]interface{}{"aliases": map[string]interface{}{
+					"events": map[string]interface{}{"is_write_index": true},
+				}},
+				"events-000002": map[string]interface{}{"aliases": map[string]interface{}{
+					"events": map[string]interface{}{"is_write_index": true},
+				}},
+			},
+			wantErr: "is_write_index=true",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var bulkCalls atomic.Int32
+			var bulkIndex string
+			server := newMockESServer(t, func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/_alias"):
+					writeJSON(w, tc.aliasResponse)
+				case r.Method == http.MethodPost && r.URL.Path == "/_bulk":
+					bulkCalls.Add(1)
+					body, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Errorf("读取 bulk 请求失败：%v", err)
+						w.WriteHeader(http.StatusBadRequest)
+						return
+					}
+					var action map[string]map[string]interface{}
+					if err := json.Unmarshal([]byte(strings.SplitN(strings.TrimSpace(string(body)), "\n", 2)[0]), &action); err != nil {
+						t.Errorf("解析 bulk action 失败：%v", err)
+						w.WriteHeader(http.StatusBadRequest)
+						return
+					}
+					bulkIndex, _ = action["index"]["_index"].(string)
+					writeJSON(w, map[string]interface{}{"errors": false, "items": []interface{}{map[string]interface{}{"index": map[string]interface{}{"status": 201}}}})
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			})
+
+			db := newTestESDB(t, server.URL, "events")
+			err := db.ApplyChanges("events", connection.ChangeSet{
+				Inserts: []map[string]interface{}{{"message": "hello"}},
+			})
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+				}
+				if bulkCalls.Load() != 0 {
+					t.Fatalf("bulk must not run after alias validation failure, calls=%d", bulkCalls.Load())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ApplyChanges returned error: %v", err)
+			}
+			if bulkCalls.Load() != 1 || bulkIndex != tc.wantIndex {
+				t.Fatalf("expected one bulk write to %q, calls=%d index=%q", tc.wantIndex, bulkCalls.Load(), bulkIndex)
+			}
+		})
+	}
+}
+
 // buildMockESMappingResponse 构造模拟的 mapping 响应 JSON。
 func buildMockESMappingResponse(indexName string, fields map[string]string) map[string]interface{} {
 	properties := make(map[string]interface{})


### PR DESCRIPTION
## Summary
- resolve rollover aliases using exactly one `is_write_index=true` target
- reject missing, conflicting, malformed, or failed alias metadata instead of guessing/falling back
- verify bulk writes target the metadata-selected index

## Validation
- httptest coverage for unique, missing, and conflicting write indexes
- full `internal/db` regression with Elasticsearch driver tag

Closes #967