### PR TITLE
🐛 fix(metadata): 统一 PG 类元数据 schema 解析

### DIFF
--- a/internal/app/methods_db.go
+++ b/internal/app/methods_db.go
@@ -3472,7 +3472,7 @@ func (a *App) DBGetForeignKeys(config connection.ConnectionConfig, dbName string
 		return connection.QueryResult{Success: false, Message: err.Error()}
 	}
 
-	schemaName, pureTableName := normalizeSchemaAndTable(config, dbName, tableName)
+	schemaName, pureTableName := normalizeMetadataSchemaAndTable(config, dbName, tableName)
 	fks, err := dbInst.GetForeignKeys(schemaName, pureTableName)
 	if err != nil {
 		return connection.QueryResult{Success: false, Message: err.Error()}
@@ -3512,7 +3512,7 @@ func (a *App) DBGetTriggers(config connection.ConnectionConfig, dbName string, t
 		return connection.QueryResult{Success: false, Message: err.Error()}
 	}
 
-	schemaName, pureTableName := normalizeSchemaAndTable(config, dbName, tableName)
+	schemaName, pureTableName := normalizeMetadataSchemaAndTable(config, dbName, tableName)
 	triggers, err := dbInst.GetTriggers(schemaName, pureTableName)
 	if err != nil {
 		return connection.QueryResult{Success: false, Message: err.Error()}

--- a/internal/app/methods_db_metadata_retry_test.go
+++ b/internal/app/methods_db_metadata_retry_test.go
@@ -539,6 +539,80 @@ func TestDBGetIndexesUsesSearchPathForPostgresPureTableMetadata(t *testing.T) {
 	}
 }
 
+func TestDBGetForeignKeysAndTriggersUseSearchPathForPostgresPureTableMetadata(t *testing.T) {
+	originalNewDatabaseFunc := newDatabaseFunc
+	originalResolveDialConfigWithProxyFunc := resolveDialConfigWithProxyFunc
+	t.Cleanup(func() {
+		newDatabaseFunc = originalNewDatabaseFunc
+		resolveDialConfigWithProxyFunc = originalResolveDialConfigWithProxyFunc
+	})
+
+	dbInst := &fakeMetadataRetryDB{}
+	newDatabaseFunc = func(dbType string) (db.Database, error) {
+		return dbInst, nil
+	}
+	resolveDialConfigWithProxyFunc = func(raw connection.ConnectionConfig) (connection.ConnectionConfig, error) {
+		return raw, nil
+	}
+
+	app := NewAppWithSecretStore(secretstore.NewUnavailableStore("test"))
+	config := connection.ConnectionConfig{
+		Type:     "postgres",
+		Host:     "127.0.0.1",
+		Port:     5432,
+		User:     "postgres",
+		Database: "demo_db",
+	}
+
+	if result := app.DBGetForeignKeys(config, "demo_db", "users"); !result.Success {
+		t.Fatalf("expected DBGetForeignKeys success, got failure: %s", result.Message)
+	}
+	if dbInst.foreignKeySchema != "" || dbInst.foreignKeyTable != "users" {
+		t.Fatalf("expected postgres pure table foreign-key metadata to pass empty schema/users, got %q.%q", dbInst.foreignKeySchema, dbInst.foreignKeyTable)
+	}
+
+	if result := app.DBGetTriggers(config, "demo_db", "users"); !result.Success {
+		t.Fatalf("expected DBGetTriggers success, got failure: %s", result.Message)
+	}
+	if dbInst.triggerSchema != "" || dbInst.triggerTable != "users" {
+		t.Fatalf("expected postgres pure table trigger metadata to pass empty schema/users, got %q.%q", dbInst.triggerSchema, dbInst.triggerTable)
+	}
+}
+
+func TestDBGetForeignKeysAndTriggersKeepExplicitPostgresSchema(t *testing.T) {
+	originalNewDatabaseFunc := newDatabaseFunc
+	originalResolveDialConfigWithProxyFunc := resolveDialConfigWithProxyFunc
+	t.Cleanup(func() {
+		newDatabaseFunc = originalNewDatabaseFunc
+		resolveDialConfigWithProxyFunc = originalResolveDialConfigWithProxyFunc
+	})
+
+	dbInst := &fakeMetadataRetryDB{}
+	newDatabaseFunc = func(dbType string) (db.Database, error) {
+		return dbInst, nil
+	}
+	resolveDialConfigWithProxyFunc = func(raw connection.ConnectionConfig) (connection.ConnectionConfig, error) {
+		return raw, nil
+	}
+
+	app := NewAppWithSecretStore(secretstore.NewUnavailableStore("test"))
+	config := connection.ConnectionConfig{Type: "postgres", Host: "127.0.0.1", Port: 5432, User: "postgres", Database: "demo_db"}
+
+	if result := app.DBGetForeignKeys(config, "demo_db", "public.users"); !result.Success {
+		t.Fatalf("expected DBGetForeignKeys success, got failure: %s", result.Message)
+	}
+	if dbInst.foreignKeySchema != "public" || dbInst.foreignKeyTable != "users" {
+		t.Fatalf("expected explicit postgres foreign-key metadata to pass public/users, got %q.%q", dbInst.foreignKeySchema, dbInst.foreignKeyTable)
+	}
+
+	if result := app.DBGetTriggers(config, "demo_db", "public.users"); !result.Success {
+		t.Fatalf("expected DBGetTriggers success, got failure: %s", result.Message)
+	}
+	if dbInst.triggerSchema != "public" || dbInst.triggerTable != "users" {
+		t.Fatalf("expected explicit postgres trigger metadata to pass public/users, got %q.%q", dbInst.triggerSchema, dbInst.triggerTable)
+	}
+}
+
 func TestDBGetColumnsKeepsCurrentDatabaseForKingbaseQualifiedTableMetadata(t *testing.T) {
 	installFakeOptionalDriverRuntime(t)
 	originalNewDatabaseFunc := newDatabaseFunc

--- a/internal/db/highgo_impl.go
+++ b/internal/db/highgo_impl.go
@@ -337,37 +337,12 @@ func (h *HighGoDB) GetIndexes(dbName, tableName string) ([]connection.IndexDefin
 }
 
 func (h *HighGoDB) GetForeignKeys(dbName, tableName string) ([]connection.ForeignKeyDefinition, error) {
-	schema := strings.TrimSpace(dbName)
-	if schema == "" {
-		schema = "public"
-	}
-	table := strings.TrimSpace(tableName)
+	schema, table := normalizePGLikeMetadataTable(dbName, tableName)
 	if table == "" {
 		return nil, localizedDatabaseRuntimeError("db.backend.error.table_name_required", nil)
 	}
 
-	esc := func(s string) string { return strings.ReplaceAll(s, "'", "''") }
-
-	query := fmt.Sprintf(`
-SELECT
-	tc.constraint_name AS constraint_name,
-	kcu.column_name AS column_name,
-	ccu.table_schema AS foreign_table_schema,
-	ccu.table_name AS foreign_table_name,
-	ccu.column_name AS foreign_column_name
-FROM information_schema.table_constraints AS tc
-JOIN information_schema.key_column_usage AS kcu
-  ON tc.constraint_name = kcu.constraint_name
-  AND tc.table_schema = kcu.table_schema
-JOIN information_schema.constraint_column_usage AS ccu
-  ON ccu.constraint_name = tc.constraint_name
-  AND ccu.table_schema = tc.table_schema
-WHERE tc.constraint_type = 'FOREIGN KEY'
-  AND tc.table_name = '%s'
-  AND tc.table_schema = '%s'
-ORDER BY tc.constraint_name, kcu.ordinal_position`, esc(table), esc(schema))
-
-	data, _, err := h.Query(query)
+	data, _, err := h.Query(buildPGLikeForeignKeysMetadataQuery(schema, table))
 	if err != nil {
 		return nil, err
 	}
@@ -397,25 +372,12 @@ ORDER BY tc.constraint_name, kcu.ordinal_position`, esc(table), esc(schema))
 }
 
 func (h *HighGoDB) GetTriggers(dbName, tableName string) ([]connection.TriggerDefinition, error) {
-	schema := strings.TrimSpace(dbName)
-	if schema == "" {
-		schema = "public"
-	}
-	table := strings.TrimSpace(tableName)
+	schema, table := normalizePGLikeMetadataTable(dbName, tableName)
 	if table == "" {
 		return nil, localizedDatabaseRuntimeError("db.backend.error.table_name_required", nil)
 	}
 
-	esc := func(s string) string { return strings.ReplaceAll(s, "'", "''") }
-
-	query := fmt.Sprintf(`
-SELECT trigger_name, action_timing, event_manipulation, action_statement
-FROM information_schema.triggers
-WHERE event_object_table = '%s'
-  AND event_object_schema = '%s'
-ORDER BY trigger_name, event_manipulation`, esc(table), esc(schema))
-
-	data, _, err := h.Query(query)
+	data, _, err := h.Query(buildPGLikeTriggersMetadataQuery(schema, table))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/kingbase_impl.go
+++ b/internal/db/kingbase_impl.go
@@ -532,79 +532,27 @@ func (k *KingbaseDB) GetIndexes(dbName, tableName string) ([]connection.IndexDef
 }
 
 func (k *KingbaseDB) GetForeignKeys(dbName, tableName string) ([]connection.ForeignKeyDefinition, error) {
-	// 解析 schema.table 格式
-	schema := strings.TrimSpace(dbName)
-	table := strings.TrimSpace(tableName)
-
-	// 如果 tableName 包含 schema (格式: schema.table)
-	if parts := strings.SplitN(table, ".", 2); len(parts) == 2 {
-		parsedSchema := strings.TrimSpace(parts[0])
-		parsedTable := strings.TrimSpace(parts[1])
-		if parsedSchema != "" && parsedTable != "" {
-			schema = parsedSchema
-			table = parsedTable
-		}
-	}
-
+	schema, table := normalizePGLikeMetadataTable(dbName, tableName)
 	if table == "" {
 		return nil, localizedDatabaseRuntimeError("db.backend.error.table_name_required", nil)
 	}
 
-	// 转义函数:处理单引号,移除双引号
-	esc := func(s string) string {
-		s = strings.Trim(s, "\"")
-		return strings.ReplaceAll(s, "'", "''")
-	}
-
-	// 构建查询：如果没有指定schema,使用current_schema()
-	var query string
-	if schema != "" {
-		query = fmt.Sprintf(`
-			SELECT
-				tc.constraint_name,
-				kcu.column_name,
-				ccu.table_name AS foreign_table_name,
-				ccu.column_name AS foreign_column_name
-			FROM
-				information_schema.table_constraints AS tc
-				JOIN information_schema.key_column_usage AS kcu
-				  ON tc.constraint_name = kcu.constraint_name
-				  AND tc.table_schema = kcu.table_schema
-				JOIN information_schema.constraint_column_usage AS ccu
-				  ON ccu.constraint_name = tc.constraint_name
-				  AND ccu.table_schema = tc.table_schema
-			WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_name='%s' AND tc.table_schema='%s'`,
-			esc(table), esc(schema))
-	} else {
-		query = fmt.Sprintf(`
-			SELECT
-				tc.constraint_name,
-				kcu.column_name,
-				ccu.table_name AS foreign_table_name,
-				ccu.column_name AS foreign_column_name
-			FROM
-				information_schema.table_constraints AS tc
-				JOIN information_schema.key_column_usage AS kcu
-				  ON tc.constraint_name = kcu.constraint_name
-				  AND tc.table_schema = kcu.table_schema
-				JOIN information_schema.constraint_column_usage AS ccu
-				  ON ccu.constraint_name = tc.constraint_name
-				  AND ccu.table_schema = tc.table_schema
-			WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_name='%s' AND tc.table_schema=current_schema()`,
-			esc(table))
-	}
-
-	data, _, err := k.Query(query)
+	data, _, err := k.Query(buildPGLikeForeignKeysMetadataQuery(schema, table))
 	if err != nil {
 		return nil, err
 	}
 
 	var fks []connection.ForeignKeyDefinition
 	for _, row := range data {
+		refSchema := strings.TrimSpace(fmt.Sprintf("%v", row["foreign_table_schema"]))
+		refTable := fmt.Sprintf("%v", row["foreign_table_name"])
+		if refSchema != "" {
+			refTable = refSchema + "." + refTable
+		}
 		fk := connection.ForeignKeyDefinition{
 			Name:           fmt.Sprintf("%v", row["constraint_name"]),
 			ColumnName:     fmt.Sprintf("%v", row["column_name"]),
-			RefTableName:   fmt.Sprintf("%v", row["foreign_table_name"]),
+			RefTableName:   refTable,
 			RefColumnName:  fmt.Sprintf("%v", row["foreign_column_name"]),
 			ConstraintName: fmt.Sprintf("%v", row["constraint_name"]),
 		}
@@ -694,45 +642,12 @@ func (k *KingbaseDB) GetDatabaseForeignKeys(_ string) (map[string][]connection.F
 }
 
 func (k *KingbaseDB) GetTriggers(dbName, tableName string) ([]connection.TriggerDefinition, error) {
-	// 解析 schema.table 格式
-	schema := strings.TrimSpace(dbName)
-	table := strings.TrimSpace(tableName)
-
-	// 如果 tableName 包含 schema (格式: schema.table)
-	if parts := strings.SplitN(table, ".", 2); len(parts) == 2 {
-		parsedSchema := strings.TrimSpace(parts[0])
-		parsedTable := strings.TrimSpace(parts[1])
-		if parsedSchema != "" && parsedTable != "" {
-			schema = parsedSchema
-			table = parsedTable
-		}
-	}
-
+	schema, table := normalizePGLikeMetadataTable(dbName, tableName)
 	if table == "" {
 		return nil, localizedDatabaseRuntimeError("db.backend.error.table_name_required", nil)
 	}
 
-	// 转义函数:处理单引号,移除双引号
-	esc := func(s string) string {
-		s = strings.Trim(s, "\"")
-		return strings.ReplaceAll(s, "'", "''")
-	}
-
-	// 构建查询：如果指定了schema,也加上schema条件
-	var query string
-	if schema != "" {
-		query = fmt.Sprintf(`SELECT trigger_name, action_timing, event_manipulation
-			FROM information_schema.triggers
-			WHERE event_object_table = '%s' AND event_object_schema = '%s'`,
-			esc(table), esc(schema))
-	} else {
-		query = fmt.Sprintf(`SELECT trigger_name, action_timing, event_manipulation
-			FROM information_schema.triggers
-			WHERE event_object_table = '%s' AND event_object_schema = current_schema()`,
-			esc(table))
-	}
-
-	data, _, err := k.Query(query)
+	data, _, err := k.Query(buildPGLikeTriggersMetadataQuery(schema, table))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/pg_metadata.go
+++ b/internal/db/pg_metadata.go
@@ -28,14 +28,22 @@ func escapePGLikeMetadataLiteral(raw string) string {
 }
 
 func buildPGLikeVisibleRelationPredicate(alias string, schemaName string) string {
+	return buildPGLikeVisibleRelationPredicateWithNamespace(alias, "n", schemaName)
+}
+
+func buildPGLikeVisibleRelationPredicateWithNamespace(alias string, namespaceAlias string, schemaName string) string {
 	relAlias := strings.TrimSpace(alias)
 	if relAlias == "" {
 		relAlias = "c"
 	}
+	nsAlias := strings.TrimSpace(namespaceAlias)
+	if nsAlias == "" {
+		nsAlias = "n"
+	}
 	if strings.TrimSpace(schemaName) == "" {
 		return fmt.Sprintf("pg_catalog.pg_table_is_visible(%s.oid)", relAlias)
 	}
-	return fmt.Sprintf("n.nspname = '%s'", escapePGLikeMetadataLiteral(schemaName))
+	return fmt.Sprintf("%s.nspname = '%s'", nsAlias, escapePGLikeMetadataLiteral(schemaName))
 }
 
 func buildPGLikeColumnsMetadataQuery(schemaName, tableName string) string {
@@ -91,6 +99,42 @@ WHERE t.relkind IN ('r', 'p')
     SELECT 1 FROM unnest(ix.indkey) AS expr_key(attnum) WHERE expr_key.attnum <= 0
   )
 ORDER BY i.relname, x.ordinality`, escapePGLikeMetadataLiteral(tableName), buildPGLikeVisibleRelationPredicate("t", schemaName))
+}
+
+func buildPGLikeForeignKeysMetadataQuery(schemaName, tableName string) string {
+	return fmt.Sprintf(`
+SELECT
+	tc.constraint_name AS constraint_name,
+	kcu.column_name AS column_name,
+	ccu.table_schema AS foreign_table_schema,
+	ccu.table_name AS foreign_table_name,
+	ccu.column_name AS foreign_column_name
+FROM information_schema.table_constraints AS tc
+JOIN information_schema.key_column_usage AS kcu
+  ON tc.constraint_name = kcu.constraint_name
+  AND tc.constraint_catalog = kcu.constraint_catalog
+  AND tc.constraint_schema = kcu.constraint_schema
+JOIN information_schema.constraint_column_usage AS ccu
+  ON ccu.constraint_name = tc.constraint_name
+  AND ccu.constraint_catalog = tc.constraint_catalog
+  AND ccu.constraint_schema = tc.constraint_schema
+JOIN pg_catalog.pg_namespace AS n ON n.nspname = tc.table_schema
+JOIN pg_catalog.pg_class AS c ON c.relnamespace = n.oid AND c.relname = tc.table_name
+WHERE tc.constraint_type = 'FOREIGN KEY'
+  AND tc.table_name = '%s'
+  AND %s
+ORDER BY tc.constraint_name, kcu.ordinal_position`, escapePGLikeMetadataLiteral(tableName), buildPGLikeVisibleRelationPredicate("c", schemaName))
+}
+
+func buildPGLikeTriggersMetadataQuery(schemaName, tableName string) string {
+	return fmt.Sprintf(`
+SELECT t.trigger_name, t.action_timing, t.event_manipulation, t.action_statement
+FROM information_schema.triggers AS t
+JOIN pg_catalog.pg_namespace AS n ON n.nspname = t.event_object_schema
+JOIN pg_catalog.pg_class AS c ON c.relnamespace = n.oid AND c.relname = t.event_object_table
+WHERE t.event_object_table = '%s'
+  AND %s
+ORDER BY t.trigger_name, t.event_manipulation`, escapePGLikeMetadataLiteral(tableName), buildPGLikeVisibleRelationPredicate("c", schemaName))
 }
 
 func buildPGLikeColumnDefinitions(data []map[string]interface{}) []connection.ColumnDefinition {

--- a/internal/db/pg_metadata_test.go
+++ b/internal/db/pg_metadata_test.go
@@ -23,6 +23,25 @@ func TestBuildPGLikeMetadataQueriesUseVisibleRelationForPureTable(t *testing.T) 
 	if strings.Contains(indexQuery, "n.nspname = 'public'") || strings.Contains(indexQuery, "current_schema()") {
 		t.Fatalf("pure table index metadata should not force public/current_schema, got %s", indexQuery)
 	}
+
+	foreignKeyQuery := buildPGLikeForeignKeysMetadataQuery("", "users")
+	if !strings.Contains(foreignKeyQuery, "pg_catalog.pg_table_is_visible(c.oid)") {
+		t.Fatalf("expected visible relation predicate for foreign-key metadata, got %s", foreignKeyQuery)
+	}
+	if strings.Contains(foreignKeyQuery, "n.nspname = 'public'") || strings.Contains(foreignKeyQuery, "current_schema()") {
+		t.Fatalf("pure table foreign-key metadata should not force public/current_schema, got %s", foreignKeyQuery)
+	}
+	if !strings.Contains(foreignKeyQuery, "ccu.constraint_catalog = tc.constraint_catalog") || !strings.Contains(foreignKeyQuery, "ccu.constraint_schema = tc.constraint_schema") || strings.Contains(foreignKeyQuery, "ccu.table_schema = tc.table_schema") {
+		t.Fatalf("foreign-key metadata should join constraint usage by constraint schema to preserve cross-schema references, got %s", foreignKeyQuery)
+	}
+
+	triggerQuery := buildPGLikeTriggersMetadataQuery("", "users")
+	if !strings.Contains(triggerQuery, "pg_catalog.pg_table_is_visible(c.oid)") {
+		t.Fatalf("expected visible relation predicate for trigger metadata, got %s", triggerQuery)
+	}
+	if strings.Contains(triggerQuery, "n.nspname = 'public'") || strings.Contains(triggerQuery, "current_schema()") {
+		t.Fatalf("pure table trigger metadata should not force public/current_schema, got %s", triggerQuery)
+	}
 }
 
 func TestBuildPGLikeMetadataQueriesKeepExplicitSchema(t *testing.T) {
@@ -34,6 +53,22 @@ func TestBuildPGLikeMetadataQueriesKeepExplicitSchema(t *testing.T) {
 	}
 	if strings.Contains(columnQuery, "pg_catalog.pg_table_is_visible") {
 		t.Fatalf("explicit schema metadata should not use visibility predicate, got %s", columnQuery)
+	}
+
+	foreignKeyQuery := buildPGLikeForeignKeysMetadataQuery("audit", "users")
+	if !strings.Contains(foreignKeyQuery, "n.nspname = 'audit'") {
+		t.Fatalf("expected explicit schema predicate for foreign-key metadata, got %s", foreignKeyQuery)
+	}
+	if strings.Contains(foreignKeyQuery, "pg_catalog.pg_table_is_visible") {
+		t.Fatalf("explicit schema foreign-key metadata should not use visibility predicate, got %s", foreignKeyQuery)
+	}
+
+	triggerQuery := buildPGLikeTriggersMetadataQuery("audit", "users")
+	if !strings.Contains(triggerQuery, "n.nspname = 'audit'") {
+		t.Fatalf("expected explicit schema predicate for trigger metadata, got %s", triggerQuery)
+	}
+	if strings.Contains(triggerQuery, "pg_catalog.pg_table_is_visible") {
+		t.Fatalf("explicit schema trigger metadata should not use visibility predicate, got %s", triggerQuery)
 	}
 }
 

--- a/internal/db/postgres_impl.go
+++ b/internal/db/postgres_impl.go
@@ -435,37 +435,12 @@ func (p *PostgresDB) GetIndexes(dbName, tableName string) ([]connection.IndexDef
 }
 
 func (p *PostgresDB) GetForeignKeys(dbName, tableName string) ([]connection.ForeignKeyDefinition, error) {
-	schema := strings.TrimSpace(dbName)
-	if schema == "" {
-		schema = "public"
-	}
-	table := strings.TrimSpace(tableName)
+	schema, table := normalizePGLikeMetadataTable(dbName, tableName)
 	if table == "" {
 		return nil, localizedDatabaseRuntimeError("db.backend.error.table_name_required", nil)
 	}
 
-	esc := func(s string) string { return strings.ReplaceAll(s, "'", "''") }
-
-	query := fmt.Sprintf(`
-SELECT
-	tc.constraint_name AS constraint_name,
-	kcu.column_name AS column_name,
-	ccu.table_schema AS foreign_table_schema,
-	ccu.table_name AS foreign_table_name,
-	ccu.column_name AS foreign_column_name
-FROM information_schema.table_constraints AS tc
-JOIN information_schema.key_column_usage AS kcu
-  ON tc.constraint_name = kcu.constraint_name
-  AND tc.table_schema = kcu.table_schema
-JOIN information_schema.constraint_column_usage AS ccu
-  ON ccu.constraint_name = tc.constraint_name
-  AND ccu.table_schema = tc.table_schema
-WHERE tc.constraint_type = 'FOREIGN KEY'
-  AND tc.table_name = '%s'
-  AND tc.table_schema = '%s'
-ORDER BY tc.constraint_name, kcu.ordinal_position`, esc(table), esc(schema))
-
-	data, _, err := p.Query(query)
+	data, _, err := p.Query(buildPGLikeForeignKeysMetadataQuery(schema, table))
 	if err != nil {
 		return nil, err
 	}
@@ -495,25 +470,12 @@ ORDER BY tc.constraint_name, kcu.ordinal_position`, esc(table), esc(schema))
 }
 
 func (p *PostgresDB) GetTriggers(dbName, tableName string) ([]connection.TriggerDefinition, error) {
-	schema := strings.TrimSpace(dbName)
-	if schema == "" {
-		schema = "public"
-	}
-	table := strings.TrimSpace(tableName)
+	schema, table := normalizePGLikeMetadataTable(dbName, tableName)
 	if table == "" {
 		return nil, localizedDatabaseRuntimeError("db.backend.error.table_name_required", nil)
 	}
 
-	esc := func(s string) string { return strings.ReplaceAll(s, "'", "''") }
-
-	query := fmt.Sprintf(`
-SELECT trigger_name, action_timing, event_manipulation, action_statement
-FROM information_schema.triggers
-WHERE event_object_table = '%s'
-  AND event_object_schema = '%s'
-ORDER BY trigger_name, event_manipulation`, esc(table), esc(schema))
-
-	data, _, err := p.Query(query)
+	data, _, err := p.Query(buildPGLikeTriggersMetadataQuery(schema, table))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/vastbase_impl.go
+++ b/internal/db/vastbase_impl.go
@@ -272,37 +272,12 @@ func (v *VastbaseDB) GetIndexes(dbName, tableName string) ([]connection.IndexDef
 }
 
 func (v *VastbaseDB) GetForeignKeys(dbName, tableName string) ([]connection.ForeignKeyDefinition, error) {
-	schema := strings.TrimSpace(dbName)
-	if schema == "" {
-		schema = "public"
-	}
-	table := strings.TrimSpace(tableName)
+	schema, table := normalizePGLikeMetadataTable(dbName, tableName)
 	if table == "" {
 		return nil, localizedDatabaseRuntimeError("db.backend.error.table_name_required", nil)
 	}
 
-	esc := func(s string) string { return strings.ReplaceAll(s, "'", "''") }
-
-	query := fmt.Sprintf(`
-SELECT
-	tc.constraint_name AS constraint_name,
-	kcu.column_name AS column_name,
-	ccu.table_schema AS foreign_table_schema,
-	ccu.table_name AS foreign_table_name,
-	ccu.column_name AS foreign_column_name
-FROM information_schema.table_constraints AS tc
-JOIN information_schema.key_column_usage AS kcu
-  ON tc.constraint_name = kcu.constraint_name
-  AND tc.table_schema = kcu.table_schema
-JOIN information_schema.constraint_column_usage AS ccu
-  ON ccu.constraint_name = tc.constraint_name
-  AND ccu.table_schema = tc.table_schema
-WHERE tc.constraint_type = 'FOREIGN KEY'
-  AND tc.table_name = '%s'
-  AND tc.table_schema = '%s'
-ORDER BY tc.constraint_name, kcu.ordinal_position`, esc(table), esc(schema))
-
-	data, _, err := v.Query(query)
+	data, _, err := v.Query(buildPGLikeForeignKeysMetadataQuery(schema, table))
 	if err != nil {
 		return nil, err
 	}
@@ -332,25 +307,12 @@ ORDER BY tc.constraint_name, kcu.ordinal_position`, esc(table), esc(schema))
 }
 
 func (v *VastbaseDB) GetTriggers(dbName, tableName string) ([]connection.TriggerDefinition, error) {
-	schema := strings.TrimSpace(dbName)
-	if schema == "" {
-		schema = "public"
-	}
-	table := strings.TrimSpace(tableName)
+	schema, table := normalizePGLikeMetadataTable(dbName, tableName)
 	if table == "" {
 		return nil, localizedDatabaseRuntimeError("db.backend.error.table_name_required", nil)
 	}
 
-	esc := func(s string) string { return strings.ReplaceAll(s, "'", "''") }
-
-	query := fmt.Sprintf(`
-SELECT trigger_name, action_timing, event_manipulation, action_statement
-FROM information_schema.triggers
-WHERE event_object_table = '%s'
-  AND event_object_schema = '%s'
-ORDER BY trigger_name, event_manipulation`, esc(table), esc(schema))
-
-	data, _, err := v.Query(query)
+	data, _, err := v.Query(buildPGLikeTriggersMetadataQuery(schema, table))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## 背景\n修复 PostgreSQL 类数据库在非 public search_path 下，列/索引与外键/触发器元数据解析到不同 schema 的问题。\n\n## 变更\n- 统一外键、触发器入口使用元数据 schema 归一化。\n- PG-like 元数据查询对裸表名使用可见关系解析，显式 schema 保持精确匹配。\n- 覆盖 PostgreSQL、OpenGauss、GaussDB、HighGo、Kingbase、Vastbase。\n- 修复跨 schema 外键约束关联条件，并补充回归测试。\n\n## 验证\n- go test ./internal/app ./internal/db -run 'Test(DBGet(ForeignKeysAndTriggers|Indexes|Columns).*(Postgres|SearchPath)|BuildPGLikeMetadata)' -count=1\n- go test ./internal/db -count=1\n- git diff --cached --check\n\nCloses #966