### PR TITLE
🐛 fix(query-editor): 修复 Kingbase Schema 表补全范围 (#983)

### DIFF
--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -145,6 +145,7 @@ import {
     extractQueryEditorCurrentSchema,
     QUERY_EDITOR_CURRENT_SCHEMA_SQL,
     resolveLoadedQueryEditorSchema,
+    shouldIncludeQueryEditorSchemaObject,
     supportsQueryEditorSchemaSelection,
 } from './queryEditor/queryEditorSchemaContext';
 import { useSqlEditorTransactionController } from './useSqlEditorTransactionController';
@@ -1014,7 +1015,7 @@ const resolveQueryEditorAiConnectionHost = (connection: any): string => {
 
 // HMR 重载时释放旧注册避免补全和 hover 内容重复
 const _g = globalThis as any;
-const SQL_COMPLETION_PROVIDER_VERSION = '20260803-prefix-retrigger-v2';
+const SQL_COMPLETION_PROVIDER_VERSION = '20260817-schema-context-v3';
 const QUERY_EDITOR_MONACO_LANGUAGE_IDS = ['sql', 'mysql'] as const;
 if (!_g.__gonaviSqlCompletionState) {
     _g.__gonaviSqlCompletionState = { registered: false, version: '', disposables: [] as any[] };
@@ -1029,6 +1030,7 @@ let sqlCompletionDisposables = _g.__gonaviSqlCompletionState.disposables;
 // 每个 QueryEditor 实例在成为活跃 Tab 时更新这些变量，确保 provider 始终使用正确的上下文。
 let sharedCurrentDb = '';
 let sharedCurrentConnectionId = '';
+let sharedCurrentSchema = '';
 let sharedConnections: any[] = [];
 let sharedTablesData: CompletionTableMeta[] = [];
 let sharedAllColumnsData: CompletionColumnMeta[] = [];
@@ -1320,6 +1322,7 @@ const resetSharedQueryEditorMetadata = () => {
     sharedQueryEditorMetadataContextKey = '';
     sharedQueryEditorMetadataConnectionConfig = null;
     sharedCurrentDb = '';
+    sharedCurrentSchema = '';
     sharedTablesData = [];
     sharedAllColumnsData = [];
     sharedVisibleDbs = [];
@@ -2327,6 +2330,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
           sharedQueryEditorMetadataConnectionConfig = targetConnectionConfig;
           sharedCurrentDb = normalizedDbName;
           sharedCurrentConnectionId = normalizedConnectionId;
+          sharedCurrentSchema = '';
           sharedConnections = connections;
           sharedVisibleDbs = visibleDbsRef.current;
           sharedActiveEditorModelUri = String(editorRef.current?.getModel?.()?.uri?.toString?.() || '');
@@ -2867,6 +2871,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
       }
       sharedCurrentDb = currentDb;
       sharedCurrentConnectionId = currentConnectionId;
+      sharedCurrentSchema = currentSchema;
       sharedConnections = connections;
       sharedTablesData = tablesRef.current;
       sharedAllColumnsData = allColumnsRef.current;
@@ -2880,7 +2885,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
       sharedPackagesData = packagesRef.current;
       sharedColumnsCacheData = columnsCacheRef.current;
       sharedActiveEditorModelUri = String(editorRef.current?.getModel?.()?.uri?.toString?.() || '');
-  }, [isActive, currentDb, currentConnectionId, connections, tab.id]);
+  }, [isActive, currentDb, currentConnectionId, currentSchema, connections, tab.id]);
 
   useEffect(() => {
       connectionsRef.current = connections;
@@ -6286,6 +6291,11 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                       : applyQueryEditorCompletionFragmentCase(ident, fragment)
               );
               const getActiveCompletionDbName = () => String(sharedCurrentDb || currentDbRef.current || currentDb || tab.dbName || '').trim();
+              const getActiveCompletionSchemaName = () => (
+                  isPostgresSchemaDialect(activeDialect)
+                      ? String(sharedCurrentSchema || '').trim()
+                      : ''
+              );
               const dialectKeywords = resolveSqlKeywords(activeDialect);
               const dialectFunctions = resolveSqlFunctions(activeDialect);
 
@@ -7022,6 +7032,13 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
               }
               if (expectsTableName && currentDatabase) {
                   completionTables = findCompletionTablesByDatabase(completionTables, currentDatabase);
+              }
+              const currentCompletionSchema = getActiveCompletionSchemaName();
+              if (expectsTableName && currentCompletionSchema) {
+                  completionTables = completionTables.filter((table) => {
+                      const parsed = splitSchemaAndTable(table.tableName || '', table.dbName);
+                      return shouldIncludeQueryEditorSchemaObject(currentCompletionSchema, parsed.schema);
+                  });
               }
 
               const referencedColumns: CompletionColumnMeta[] = [];

--- a/frontend/src/components/queryEditor/queryEditorSchemaContext.test.ts
+++ b/frontend/src/components/queryEditor/queryEditorSchemaContext.test.ts
@@ -5,16 +5,25 @@ import {
   extractQueryEditorCurrentSchema,
   quotePostgresSearchPathIdentifier,
   resolveLoadedQueryEditorSchema,
+  shouldIncludeQueryEditorSchemaObject,
   supportsQueryEditorSchemaSelection,
 } from './queryEditorSchemaContext';
 
 describe('queryEditorSchemaContext', () => {
-  it.each(['postgres', 'postgresql', 'pg'])('enables schema selection for %s', (dbType) => {
+  it.each(['postgres', 'postgresql', 'pg', 'kingbase', 'highgo', 'vastbase', 'opengauss', 'gaussdb'])('enables schema selection for %s', (dbType) => {
     expect(supportsQueryEditorSchemaSelection(dbType)).toBe(true);
   });
 
-  it.each(['mysql', 'kingbase', 'custom'])('does not enable PostgreSQL search_path for %s', (dbType) => {
+  it.each(['mysql', 'custom'])('does not enable query editor schema selection for %s', (dbType) => {
     expect(supportsQueryEditorSchemaSelection(dbType)).toBe(false);
+  });
+
+  it('keeps unqualified metadata but excludes objects from other selected schemas', () => {
+    expect(shouldIncludeQueryEditorSchemaObject('advert_statis', 'advert_statis')).toBe(true);
+    expect(shouldIncludeQueryEditorSchemaObject('advert_statis', '')).toBe(true);
+    expect(shouldIncludeQueryEditorSchemaObject('', 'advert_dev')).toBe(true);
+    expect(shouldIncludeQueryEditorSchemaObject('advert_statis', 'advert_dev')).toBe(false);
+    expect(shouldIncludeQueryEditorSchemaObject('Foo', 'foo')).toBe(false);
   });
 
   it('extracts the current schema from PostgreSQL metadata rows', () => {

--- a/frontend/src/components/queryEditor/queryEditorSchemaContext.ts
+++ b/frontend/src/components/queryEditor/queryEditorSchemaContext.ts
@@ -1,13 +1,22 @@
 import type { ConnectionConfig } from '../../types';
-import { normalizeDriverType } from '../../utils/connectionDriverType';
+import { isPostgresSchemaDialect } from '../../utils/connectionDriverType';
 
 export const QUERY_EDITOR_CURRENT_SCHEMA_SQL = 'SELECT current_schema() AS schema_name';
 
 const normalizeSchemaName = (value: unknown): string => String(value ?? '').trim();
 
 export const supportsQueryEditorSchemaSelection = (dbType: string): boolean => (
-  normalizeDriverType(dbType) === 'postgres'
+  isPostgresSchemaDialect(dbType)
 );
+
+export const shouldIncludeQueryEditorSchemaObject = (
+  selectedSchema: string,
+  objectSchema: string,
+): boolean => {
+  const selected = normalizeSchemaName(selectedSchema);
+  const object = normalizeSchemaName(objectSchema);
+  return !selected || !object || selected === object;
+};
 
 export const extractQueryEditorCurrentSchema = (rows: unknown): string => {
   if (!Array.isArray(rows) || rows.length === 0 || !rows[0] || typeof rows[0] !== 'object') return '';


### PR DESCRIPTION
## 背景

Kingbase 多 Schema 查询时，选择 `advert_statis` 后，未限定 Schema 的表补全仍会混入 `advert_dev`、`advert_test11` 等其他 Schema 的全限定表名。预期是未写 `schema.` 时遵循当前选择的 Schema，同时保留用户明确输入其他 Schema 时的补全能力。

Fixes #983

## 变更点

- 复用 PG 兼容方言能力，维护当前活跃查询 Tab 的 Schema 上下文。
- 过滤未限定表来源补全，仅保留当前 Schema 或无 Schema 元数据的对象；显式限定 Schema 的补全路径保持不变。
- 更新 Monaco completion provider 版本，避免开发热更新继续使用旧 provider。
- 增加 Kingbase 及其他 PG 兼容方言、跨 Schema 排除和大小写区分测试。

## 影响范围

- 影响查询编辑器中 PG 兼容数据库的 Schema 选择和未限定表补全；Kingbase 为本 Issue 的主要场景。
- 非 PG 兼容数据库、SQL 执行、SQL 保存、列补全及显式 `schema.table` 补全路径保持原有行为。

## 验证

- `npm --prefix frontend test -- src/components/queryEditor/queryEditorSchemaContext.test.ts`：18/18 通过。
- `npm --prefix frontend run build`：通过。
- 用户自测：Kingbase 场景通过。