### PR TITLE
🐛 fix(dameng): 转义元数据名称中的单引号

### DIFF
--- a/internal/db/dameng_impl.go
+++ b/internal/db/dameng_impl.go
@@ -258,9 +258,10 @@ func (d *DamengDB) GetDatabases() ([]string, error) {
 func (d *DamengDB) GetTables(dbName string) ([]string, error) {
 	// 始终返回 OWNER.TABLE_NAME，与 Oracle 实现对齐，避免下游 SQL 缺少 schema 前缀（refs issue #445）
 	// 列别名用双引号包裹强制大写，避免不同驱动版本返回不一致 case 导致 row map 取值失败
+	escapedDBName := escapeDamengMetadataLiteral(dbName)
 	var query string
-	if dbName != "" {
-		query = fmt.Sprintf(`SELECT owner AS "OWNER", table_name AS "TABLE_NAME" FROM all_tables WHERE owner = '%s' ORDER BY table_name`, strings.ToUpper(dbName))
+	if escapedDBName != "" {
+		query = fmt.Sprintf(`SELECT owner AS "OWNER", table_name AS "TABLE_NAME" FROM all_tables WHERE owner = '%s' ORDER BY table_name`, escapedDBName)
 	} else {
 		query = `SELECT USER AS "OWNER", table_name AS "TABLE_NAME" FROM user_tables ORDER BY table_name`
 	}
@@ -291,11 +292,13 @@ func (d *DamengDB) GetCreateStatement(dbName, tableName string) (string, error) 
 	// We'll try a common DM approach.
 	// SELECT DBMS_METADATA.GET_DDL('TABLE', 'TABLE_NAME', 'OWNER') FROM DUAL;
 
+	escapedDBName := escapeDamengMetadataLiteral(dbName)
+	escapedTableName := escapeDamengMetadataLiteral(tableName)
 	query := fmt.Sprintf("SELECT DBMS_METADATA.GET_DDL('TABLE', '%s', '%s') as ddl FROM DUAL",
-		strings.ToUpper(tableName), strings.ToUpper(dbName))
+		escapedTableName, escapedDBName)
 
-	if dbName == "" {
-		query = fmt.Sprintf("SELECT DBMS_METADATA.GET_DDL('TABLE', '%s') as ddl FROM DUAL", strings.ToUpper(tableName))
+	if escapedDBName == "" {
+		query = fmt.Sprintf("SELECT DBMS_METADATA.GET_DDL('TABLE', '%s') as ddl FROM DUAL", escapedTableName)
 	}
 
 	data, _, err := d.Query(query)
@@ -382,7 +385,7 @@ func (d *DamengDB) GetTriggers(dbName, tableName string) ([]connection.TriggerDe
 	query := fmt.Sprintf(`SELECT trigger_name, trigger_type, triggering_event 
 		FROM all_triggers 
 		WHERE table_owner = '%s' AND table_name = '%s'`,
-		strings.ToUpper(dbName), strings.ToUpper(tableName))
+		escapeDamengMetadataLiteral(dbName), escapeDamengMetadataLiteral(tableName))
 
 	data, _, err := d.Query(query)
 	if err != nil {
@@ -526,7 +529,7 @@ func (d *DamengDB) GetAllColumns(dbName string) ([]connection.ColumnDefinitionWi
 		FROM all_tab_columns c
 		LEFT JOIN all_col_comments cc
 		  ON cc.owner = c.owner AND cc.table_name = c.table_name AND cc.column_name = c.column_name
-		WHERE c.owner = '%s'`, strings.ReplaceAll(strings.ToUpper(dbName), "'", "''"))
+		WHERE c.owner = '%s'`, escapeDamengMetadataLiteral(dbName))
 
 	data, _, err := d.Query(query)
 	if err != nil {

--- a/internal/db/dameng_metadata.go
+++ b/internal/db/dameng_metadata.go
@@ -9,6 +9,12 @@ import (
 	"GoNavi-Wails/internal/logger"
 )
 
+// escapeDamengMetadataLiteral normalizes a schema/table value and escapes it
+// for use as a SQL string literal in Dameng metadata queries.
+func escapeDamengMetadataLiteral(value string) string {
+	return strings.ReplaceAll(strings.ToUpper(strings.TrimSpace(value)), "'", "''")
+}
+
 var damengDatabaseQueries = []string{
 	// 优先使用达梦原生系统表（SYSDBA 保留：作为默认管理员 schema，大多数用户在此创建业务表）
 	"SELECT DISTINCT OBJECT_NAME AS DATABASE_NAME FROM SYS.SYSOBJECTS WHERE TYPE$ = 'SCH' AND OBJECT_NAME NOT IN ('SYS','SYSAUDITOR','SYSSSO','CTISYS','__RECYCLE_USER__') ORDER BY OBJECT_NAME",
@@ -106,8 +112,8 @@ func getDamengRowString(row map[string]interface{}, keys ...string) string {
 }
 
 func buildDamengColumnsQuery(dbName, tableName string) string {
-	upperTableName := strings.ToUpper(strings.TrimSpace(tableName))
-	upperDBName := strings.ToUpper(strings.TrimSpace(dbName))
+	upperTableName := escapeDamengMetadataLiteral(tableName)
+	upperDBName := escapeDamengMetadataLiteral(dbName)
 
 	// 注意：达梦中 COMMENT 为保留字，不能使用 AS comment 作为列别名（Error -2007 语法分析出错）。
 	if upperDBName == "" {
@@ -153,8 +159,8 @@ func buildDamengColumnsQuery(dbName, tableName string) string {
 // compatible ALL_COL_COMMENTS/USER_COL_COMMENTS views but return empty comment
 // values when those views are joined with the column dictionary.
 func buildDamengColumnCommentsQuery(dbName, tableName string) string {
-	upperTableName := strings.ReplaceAll(strings.ToUpper(strings.TrimSpace(tableName)), "'", "''")
-	upperDBName := strings.ReplaceAll(strings.ToUpper(strings.TrimSpace(dbName)), "'", "''")
+	upperTableName := escapeDamengMetadataLiteral(tableName)
+	upperDBName := escapeDamengMetadataLiteral(dbName)
 
 	schemaPredicate := "SCHNAME = USER"
 	if upperDBName != "" {
@@ -168,8 +174,8 @@ func buildDamengColumnCommentsQuery(dbName, tableName string) string {
 }
 
 func buildDamengTableCommentQuery(dbName, tableName string) string {
-	upperTableName := strings.ReplaceAll(strings.ToUpper(strings.TrimSpace(tableName)), "'", "''")
-	upperDBName := strings.ReplaceAll(strings.ToUpper(strings.TrimSpace(dbName)), "'", "''")
+	upperTableName := escapeDamengMetadataLiteral(tableName)
+	upperDBName := escapeDamengMetadataLiteral(dbName)
 	if upperDBName == "" {
 		return fmt.Sprintf(`SELECT comments AS "TABLE_COMMENT"
 			FROM user_tab_comments
@@ -208,8 +214,8 @@ func appendDamengTableCommentDDL(ddl, dbName, tableName, comment string) string 
 // records both IDENTITY and AUTO_INCREMENT columns. It intentionally remains a
 // separate query so restricted accounts can still load base column metadata.
 func buildDamengAutoIncrementColumnsQuery(dbName, tableName string) string {
-	upperDBName := strings.ToUpper(strings.TrimSpace(dbName))
-	upperTableName := strings.ToUpper(strings.TrimSpace(tableName))
+	upperDBName := escapeDamengMetadataLiteral(dbName)
+	upperTableName := escapeDamengMetadataLiteral(tableName)
 
 	schemaPredicate := "s.NAME = USER"
 	if upperDBName != "" {
@@ -245,8 +251,8 @@ func applyDamengAutoIncrementColumns(columns []connection.ColumnDefinition, data
 }
 
 func buildDamengIndexesQuery(dbName, tableName string) string {
-	upperDBName := strings.ReplaceAll(strings.ToUpper(strings.TrimSpace(dbName)), "'", "''")
-	upperTableName := strings.ReplaceAll(strings.ToUpper(strings.TrimSpace(tableName)), "'", "''")
+	upperDBName := escapeDamengMetadataLiteral(dbName)
+	upperTableName := escapeDamengMetadataLiteral(tableName)
 
 	if upperDBName == "" {
 		return fmt.Sprintf(`SELECT c.index_name, c.column_name, i.uniqueness, c.column_position, i.index_type
@@ -298,8 +304,8 @@ func buildDamengIndexDefinitions(data []map[string]interface{}) []connection.Ind
 }
 
 func buildDamengForeignKeysQuery(dbName, tableName string) string {
-	upperDBName := strings.ToUpper(strings.TrimSpace(dbName))
-	upperTableName := strings.ToUpper(strings.TrimSpace(tableName))
+	upperDBName := escapeDamengMetadataLiteral(dbName)
+	upperTableName := escapeDamengMetadataLiteral(tableName)
 	if upperDBName == "" {
 		return fmt.Sprintf(`SELECT a.constraint_name, a.column_name, c_pk.table_name r_table_name, b.column_name r_column_name
 		FROM (

--- a/internal/db/dameng_metadata_entry_test.go
+++ b/internal/db/dameng_metadata_entry_test.go
@@ -1,0 +1,163 @@
+//go:build gonavi_full_drivers || gonavi_dameng_driver
+
+package db
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+type damengMetadataCapture struct {
+	queries []string
+}
+
+type damengMetadataConnector struct {
+	capture *damengMetadataCapture
+}
+
+func (c damengMetadataConnector) Connect(context.Context) (driver.Conn, error) {
+	return damengMetadataConn{capture: c.capture}, nil
+}
+
+func (damengMetadataConnector) Driver() driver.Driver { return damengMetadataDriver{} }
+
+type damengMetadataDriver struct{}
+
+func (damengMetadataDriver) Open(string) (driver.Conn, error) {
+	return nil, errors.New("use sql.OpenDB with the test connector")
+}
+
+type damengMetadataConn struct {
+	capture *damengMetadataCapture
+}
+
+func (c damengMetadataConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepared statements are not supported by this test driver")
+}
+
+func (damengMetadataConn) Close() error { return nil }
+
+func (damengMetadataConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("transactions are not supported by this test driver")
+}
+
+func (c damengMetadataConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	c.capture.queries = append(c.capture.queries, query)
+	switch {
+	case strings.Contains(query, "all_tables"):
+		return &damengMetadataRows{columns: []string{"OWNER", "TABLE_NAME"}, values: [][]driver.Value{{"SALES'OPS", "ORDER'ITEMS"}}}, nil
+	case strings.Contains(query, "DBMS_METADATA.GET_DDL"):
+		return &damengMetadataRows{columns: []string{"DDL"}, values: [][]driver.Value{{"CREATE TABLE TEST"}}}, nil
+	case strings.Contains(query, "all_triggers"):
+		return &damengMetadataRows{columns: []string{"TRIGGER_NAME", "TRIGGER_TYPE", "TRIGGERING_EVENT"}}, nil
+	case strings.Contains(query, "all_tab_comments"):
+		return &damengMetadataRows{columns: []string{"TABLE_COMMENT"}}, nil
+	default:
+		return &damengMetadataRows{columns: []string{"TABLE_NAME", "COLUMN_NAME", "DATA_TYPE", "COL_COMMENT"}}, nil
+	}
+}
+
+type damengMetadataRows struct {
+	columns []string
+	values  [][]driver.Value
+	index   int
+}
+
+func (r *damengMetadataRows) Columns() []string { return r.columns }
+func (r *damengMetadataRows) Close() error      { return nil }
+func (r *damengMetadataRows) Next(dest []driver.Value) error {
+	if r.index >= len(r.values) {
+		return io.EOF
+	}
+	copy(dest, r.values[r.index])
+	r.index++
+	return nil
+}
+
+func openDamengMetadataCaptureDB(t *testing.T, capture *damengMetadataCapture) *sql.DB {
+	t.Helper()
+	db := sql.OpenDB(damengMetadataConnector{capture: capture})
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestDamengMetadataEntrypointsEscapeLiterals(t *testing.T) {
+	t.Parallel()
+
+	const schema = "Sales'Ops"
+	const table = "Order'Items"
+	const escapedSchema = "SALES''OPS"
+	const escapedTable = "ORDER''ITEMS"
+
+	tests := []struct {
+		name string
+		call func(*DamengDB) error
+		want []string
+	}{
+		{
+			name: "tables",
+			call: func(db *DamengDB) error { _, err := db.GetTables(schema); return err },
+			want: []string{escapedSchema},
+		},
+		{
+			name: "create statement",
+			call: func(db *DamengDB) error { _, err := db.GetCreateStatement(schema, table); return err },
+			want: []string{escapedSchema, escapedTable},
+		},
+		{
+			name: "triggers",
+			call: func(db *DamengDB) error { _, err := db.GetTriggers(schema, table); return err },
+			want: []string{escapedSchema, escapedTable},
+		},
+		{
+			name: "all columns",
+			call: func(db *DamengDB) error { _, err := db.GetAllColumns(schema); return err },
+			want: []string{escapedSchema},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			capture := &damengMetadataCapture{}
+			db := &DamengDB{conn: openDamengMetadataCaptureDB(t, capture)}
+			if err := test.call(db); err != nil {
+				t.Fatalf("metadata entrypoint returned error: %v", err)
+			}
+			if len(capture.queries) == 0 {
+				t.Fatal("metadata entrypoint did not execute a query")
+			}
+			query := capture.queries[0]
+			for _, want := range test.want {
+				if !strings.Contains(query, want) {
+					t.Fatalf("query should contain escaped literal %q, got: %s", want, query)
+				}
+			}
+		})
+	}
+}
+
+func TestDamengMetadataEntrypointsTreatWhitespaceSchemaAsEmpty(t *testing.T) {
+	t.Parallel()
+
+	capture := &damengMetadataCapture{}
+	db := &DamengDB{conn: openDamengMetadataCaptureDB(t, capture)}
+	if _, err := db.GetTables("  "); err != nil {
+		t.Fatalf("GetTables returned error: %v", err)
+	}
+	if len(capture.queries) != 1 || !strings.Contains(capture.queries[0], "FROM user_tables") {
+		t.Fatalf("whitespace schema should use current-schema table query, got: %v", capture.queries)
+	}
+
+	capture.queries = nil
+	if _, err := db.GetCreateStatement("  ", "orders"); err != nil {
+		t.Fatalf("GetCreateStatement returned error: %v", err)
+	}
+	if len(capture.queries) < 1 || strings.Contains(capture.queries[0], ", ''") || !strings.Contains(capture.queries[0], "GET_DDL('TABLE', 'ORDERS')") {
+		t.Fatalf("whitespace schema should use current-schema DDL query, got: %v", capture.queries)
+	}
+}

--- a/internal/db/dameng_metadata_test.go
+++ b/internal/db/dameng_metadata_test.go
@@ -7,6 +7,21 @@ import (
 	"testing"
 )
 
+func TestEscapeDamengMetadataLiteral_NormalizesAndEscapes(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		" Sales'Ops ": "SALES''OPS",
+		"orders":      "ORDERS",
+		"MiXeD":       "MIXED",
+		"":            "",
+	}
+	for input, want := range tests {
+		if got := escapeDamengMetadataLiteral(input); got != want {
+			t.Fatalf("escapeDamengMetadataLiteral(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
 func TestCollectDamengDatabaseNames_UsesCurrentSchemaFallback(t *testing.T) {
 	t.Parallel()
 
@@ -143,6 +158,32 @@ func TestBuildDamengColumnsQuery_IncludesColumnCommentsJoin(t *testing.T) {
 	}
 	if strings.Contains(strings.ToLower(allQuery), " as comment") {
 		t.Fatalf("dameng forbids AS comment alias (reserved word), got: %s", allQuery)
+	}
+}
+
+func TestDamengMetadataQueriesEscapeSchemaAndTableLiterals(t *testing.T) {
+	t.Parallel()
+
+	const schema = "Sales'Ops"
+	const table = "Order'Items"
+	wantSchema := "SALES''OPS"
+	wantTable := "ORDER''ITEMS"
+
+	queries := []string{
+		buildDamengColumnsQuery(schema, table),
+		buildDamengColumnCommentsQuery(schema, table),
+		buildDamengTableCommentQuery(schema, table),
+		buildDamengAutoIncrementColumnsQuery(schema, table),
+		buildDamengIndexesQuery(schema, table),
+		buildDamengForeignKeysQuery(schema, table),
+	}
+	for i, query := range queries {
+		if !strings.Contains(query, wantSchema) || !strings.Contains(query, wantTable) {
+			t.Fatalf("metadata query %d should escape normalized schema/table literals, got: %s", i, query)
+		}
+		if strings.Contains(query, "'SALES'OPS'") || strings.Contains(query, "'ORDER'ITEMS'") {
+			t.Fatalf("metadata query %d contains an unescaped apostrophe, got: %s", i, query)
+		}
 	}
 }
 


### PR DESCRIPTION
## 背景：达梦元数据查询直接拼接 schema/table SQL 字面量，名称含单引号时查询失败或返回空结果。 ## 变更：新增统一 Dameng metadata literal helper，覆盖表、DDL、触发器、字段、全字段、自增、注释、索引和外键查询；空白 schema 统一走当前 schema 分支；增加 builder 和实际入口 query-capture 回归测试。 ## 验证：go test ./internal/db -run Dameng -count=1；go test ./internal/db -count=1；go test -tags gonavi_dameng_driver ./internal/db -run Dameng -count=1；go test -tags gonavi_dameng_driver ./internal/db -count=1；git diff --check。 Closes #965