### PR TITLE
🐛 fix(sidebar): 修复连接树光标与选中背景 (#985)

### DIFF
--- a/frontend/src/v2-theme.css
+++ b/frontend/src/v2-theme.css
@@ -3200,6 +3200,18 @@ body[data-ui-version="v2"] .gn-v2-explorer-tree-shell .ant-tree-node-content-wra
   background: var(--gn-bg-hover) !important;
 }
 
+body[data-ui-version="v2"] .gn-v2-explorer-tree-shell .ant-tree-treenode.ant-tree-treenode-draggable {
+  cursor: pointer !important;
+}
+
+body[data-ui-version="v2"] .gn-v2-explorer-tree-shell .ant-tree-treenode.ant-tree-treenode-draggable:hover {
+  background: var(--gn-bg-hover) !important;
+}
+
+body[data-ui-version="v2"] .gn-v2-explorer-tree-shell .ant-tree-treenode.ant-tree-treenode-draggable.ant-tree-treenode-selected {
+  background: color-mix(in srgb, var(--gn-accent) 10%, var(--gn-bg-selected)) !important;
+}
+
 body[data-ui-version="v2"] .gn-v2-explorer-tree-shell .ant-tree-node-content-wrapper.ant-tree-node-selected {
   background: color-mix(in srgb, var(--gn-accent) 10%, var(--gn-bg-selected)) !important;
   color: var(--gn-fg-1) !important;


### PR DESCRIPTION
## 背景

Issue #985 中，连接行之间的空白区域会显示五指拖拽光标，选中连接时空白区域的反馈也不完整。预期是连接行及其可点击空白区域显示单指光标和明确的悬浮/选中背景，同时保留原有拖拽能力。

Fixes #985

## 变更点

- 将光标、悬浮背景和选中背景规则限定在新版侧边栏资源树的可拖拽行。
- 保持现有 Tree 的 draggable 配置、拖拽事件和连接选择逻辑不变。

## 影响范围

- 影响新版侧边栏中连接/分组行的光标和行背景视觉反馈。
- 旧版侧边栏、其他 rc-tree 组件、连接选择、展开折叠、右键菜单和拖拽处理逻辑不受影响。

## 验证

- `npm --prefix frontend test -- src/components/Sidebar.locate-toolbar.test.tsx src/components/Sidebar.v2-metadata.test.tsx src/components/sidebar/oracleObjectCompilation.test.ts`：101 个测试通过。
- `npm --prefix frontend run build`：构建通过，仅有既有 chunk 体积警告。
- 浏览器 CSS 探针：资源树容器外的拖拽节点为 `auto`，新版侧边栏容器内为 `pointer`。
- 用户自测：通过