### PR TITLE
[Bug] 修复查询扫描错误被静默跳过

### DIFF
--- a/internal/db/scan_rows.go
+++ b/internal/db/scan_rows.go
@@ -41,6 +41,12 @@ type queryRowScanner struct {
 	valuePtrs   []interface{}
 }
 
+type queryRowsScanner interface {
+	scanCurrentPreviewRow(*sql.Rows) (map[string]interface{}, error)
+	scanCurrentRow(*sql.Rows) (map[string]interface{}, error)
+	scanCurrentRowValues(*sql.Rows) ([]interface{}, error)
+}
+
 func scanRowsForDialect(rows *sql.Rows, dialect string) ([]map[string]interface{}, []string, error) {
 	return scanRowsForDialectWithPreview(rows, dialect, true)
 }
@@ -62,17 +68,26 @@ func scanRowsForDialectWithPreview(rows *sql.Rows, dialect string, boundOracleLa
 	}
 
 	scanner := newQueryRowScanner(columns, colTypes, dialect)
+	return scanRowsWithScanner(rows, columns, scanner, boundOracleLargeObjects)
+}
+
+func scanRowsWithScanner(rows *sql.Rows, columns []string, scanner queryRowsScanner, boundOracleLargeObjects bool) ([]map[string]interface{}, []string, error) {
 	resultData := make([]map[string]interface{}, 0)
 
+	var rowNumber int64
 	for rows.Next() {
-		var entry map[string]interface{}
+		rowNumber++
+		var (
+			entry map[string]interface{}
+			err   error
+		)
 		if boundOracleLargeObjects {
 			entry, err = scanner.scanCurrentPreviewRow(rows)
 		} else {
 			entry, err = scanner.scanCurrentRow(rows)
 		}
 		if err != nil {
-			continue
+			return resultData, columns, newQueryRowScanError(rowNumber, columns, err)
 		}
 		resultData = append(resultData, entry)
 	}
@@ -100,6 +115,10 @@ func streamRowsForDialect(rows *sql.Rows, dialect string, consumer QueryStreamCo
 	}
 
 	scanner := newQueryRowScanner(columns, colTypes, dialect)
+	return streamRowsWithScanner(rows, columns, consumer, scanner)
+}
+
+func streamRowsWithScanner(rows *sql.Rows, columns []string, consumer QueryStreamConsumer, scanner queryRowsScanner) error {
 	if err := consumer.SetColumns(columns); err != nil {
 		return err
 	}
@@ -110,11 +129,13 @@ func streamRowsForDialect(rows *sql.Rows, dialect string, consumer QueryStreamCo
 	// 主进程的 in-process 流式查询调用，所以一处加 GC 即可覆盖两端。
 	var processedRows int64
 
+	var rowNumber int64
 	for rows.Next() {
+		rowNumber++
 		if useValueConsumer {
 			values, err := scanner.scanCurrentRowValues(rows)
 			if err != nil {
-				continue
+				return newQueryRowScanError(rowNumber, columns, err)
 			}
 			if err := valueConsumer.ConsumeRowValues(values); err != nil {
 				return err
@@ -122,7 +143,7 @@ func streamRowsForDialect(rows *sql.Rows, dialect string, consumer QueryStreamCo
 		} else {
 			entry, err := scanner.scanCurrentRow(rows)
 			if err != nil {
-				continue
+				return newQueryRowScanError(rowNumber, columns, err)
 			}
 			if err := consumer.ConsumeRow(entry); err != nil {
 				return err
@@ -139,6 +160,10 @@ func streamRowsForDialect(rows *sql.Rows, dialect string, consumer QueryStreamCo
 	}
 
 	return rows.Err()
+}
+
+func newQueryRowScanError(rowNumber int64, columns []string, err error) error {
+	return fmt.Errorf("scan query row %d (columns: %s): %w", rowNumber, strings.Join(columns, ", "), err)
 }
 
 func newQueryRowScanner(columns []string, colTypes []*sql.ColumnType, dialect string) *queryRowScanner {

--- a/internal/db/scan_rows_test.go
+++ b/internal/db/scan_rows_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -135,6 +136,16 @@ func (scanRowsDuplicateConn) QueryContext(_ context.Context, query string, args 
 			},
 		}, nil
 	}
+	if query == "SELECT scan_error_rows" {
+		return &scanRowsDuplicateRows{
+			columns: []string{"id"},
+			rows: [][]driver.Value{
+				{int64(1)},
+				{int64(2)},
+				{int64(3)},
+			},
+		}, nil
+	}
 	return &scanRowsDuplicateRows{
 		columns: []string{"id", "id", "name"},
 		rows: [][]driver.Value{
@@ -165,6 +176,73 @@ func (c *scanRowsValueConsumer) ConsumeRow(row map[string]interface{}) error {
 func (c *scanRowsValueConsumer) ConsumeRowValues(values []interface{}) error {
 	c.rows = append(c.rows, append([]interface{}(nil), values...))
 	return nil
+}
+
+type scanRowsMapConsumer struct {
+	columns []string
+	rows    []map[string]interface{}
+}
+
+func (c *scanRowsMapConsumer) SetColumns(columns []string) error {
+	c.columns = append([]string(nil), columns...)
+	return nil
+}
+
+func (c *scanRowsMapConsumer) ConsumeRow(row map[string]interface{}) error {
+	c.rows = append(c.rows, row)
+	return nil
+}
+
+var errScanRowsTest = errors.New("simulated scan error")
+
+type scanRowsErrorScanner struct {
+	failAt    int
+	scanCount int
+}
+
+func (s *scanRowsErrorScanner) scanCurrentPreviewRow(rows *sql.Rows) (map[string]interface{}, error) {
+	return s.scanCurrentRow(rows)
+}
+
+func (s *scanRowsErrorScanner) scanCurrentRow(_ *sql.Rows) (map[string]interface{}, error) {
+	s.scanCount++
+	if s.scanCount == s.failAt {
+		return nil, errScanRowsTest
+	}
+	return map[string]interface{}{"id": int64(s.scanCount)}, nil
+}
+
+func (s *scanRowsErrorScanner) scanCurrentRowValues(_ *sql.Rows) ([]interface{}, error) {
+	s.scanCount++
+	if s.scanCount == s.failAt {
+		return nil, errScanRowsTest
+	}
+	return []interface{}{int64(s.scanCount)}, nil
+}
+
+func openScanRowsErrorRows(t *testing.T) *sql.Rows {
+	t.Helper()
+
+	registerScanRowsDuplicateDriverOnce.Do(func() {
+		sql.Register(scanRowsDuplicateDriverName, scanRowsDuplicateDriver{})
+	})
+
+	dbConn, err := sql.Open(scanRowsDuplicateDriverName, "")
+	if err != nil {
+		t.Fatalf("open scan error db failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = dbConn.Close()
+	})
+
+	rows, err := dbConn.QueryContext(context.Background(), "SELECT scan_error_rows")
+	if err != nil {
+		t.Fatalf("query scan error db failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = rows.Close()
+	})
+	return rows
 }
 
 func TestScanRowsBoundsOracleBlobPreview(t *testing.T) {
@@ -342,6 +420,53 @@ func (r *scanRowsDuplicateRows) Next(dest []driver.Value) error {
 	}
 	r.index++
 	return nil
+}
+
+func TestScanRowsReturnsSecondRowScanErrorWithPartialResults(t *testing.T) {
+	rows := openScanRowsErrorRows(t)
+
+	data, columns, err := scanRowsWithScanner(rows, []string{"id"}, &scanRowsErrorScanner{failAt: 2}, false)
+	if !errors.Is(err, errScanRowsTest) {
+		t.Fatalf("scanRows error = %v, want wrapped scan error", err)
+	}
+	if !reflect.DeepEqual(columns, []string{"id"}) || len(data) != 1 || data[0]["id"] != int64(1) {
+		t.Fatalf("unexpected partial result: columns=%v rows=%#v", columns, data)
+	}
+	if !strings.Contains(err.Error(), "scan query row 2 (columns: id)") {
+		t.Fatalf("scan error lacks row and column context: %v", err)
+	}
+}
+
+func TestStreamRowsValueConsumerReturnsSecondRowScanError(t *testing.T) {
+	rows := openScanRowsErrorRows(t)
+	consumer := &scanRowsValueConsumer{}
+
+	err := streamRowsWithScanner(rows, []string{"id"}, consumer, &scanRowsErrorScanner{failAt: 2})
+	if !errors.Is(err, errScanRowsTest) {
+		t.Fatalf("streamRows error = %v, want wrapped scan error", err)
+	}
+	if !reflect.DeepEqual(consumer.rows, [][]interface{}{{int64(1)}}) {
+		t.Fatalf("unexpected streamed rows: %#v", consumer.rows)
+	}
+	if !strings.Contains(err.Error(), "scan query row 2 (columns: id)") {
+		t.Fatalf("stream scan error lacks row and column context: %v", err)
+	}
+}
+
+func TestStreamRowsMapConsumerReturnsSecondRowScanError(t *testing.T) {
+	rows := openScanRowsErrorRows(t)
+	consumer := &scanRowsMapConsumer{}
+
+	err := streamRowsWithScanner(rows, []string{"id"}, consumer, &scanRowsErrorScanner{failAt: 2})
+	if !errors.Is(err, errScanRowsTest) {
+		t.Fatalf("streamRows error = %v, want wrapped scan error", err)
+	}
+	if len(consumer.rows) != 1 || consumer.rows[0]["id"] != int64(1) {
+		t.Fatalf("unexpected streamed rows: %#v", consumer.rows)
+	}
+	if !strings.Contains(err.Error(), "scan query row 2 (columns: id)") {
+		t.Fatalf("map consumer stream scan error lacks row and column context: %v", err)
+	}
 }
 
 func TestScanRowsRenamesDuplicateColumns(t *testing.T) {


### PR DESCRIPTION
Closes #959。背景：行扫描失败此前会被跳过并返回成功，可能造成静默缺行。变更：首次扫描失败立即返回含行号和列上下文的错误。范围：普通查询及两种流式消费者。验证：go test ./internal/db -count=1；第 2 行扫描错误回归测试重复 100 次通过。