### PR TITLE
🐛 fix(ai): 限制 provider 错误响应体

### DIFF
--- a/internal/ai/provider/anthropic.go
+++ b/internal/ai/provider/anthropic.go
@@ -647,8 +647,7 @@ func (p *AnthropicProvider) doRequest(ctx context.Context, body interface{}) (io
 
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		statusErr := fmt.Errorf("Anthropic API returned error (HTTP %d): %s", resp.StatusCode, string(bodyBytes))
+		statusErr := fmt.Errorf("Anthropic API returned error (HTTP %d): %s", resp.StatusCode, readProviderErrorBody(resp.Body, resp.ContentLength))
 		logAIUpstreamRequestFinish(requestLog, resp.StatusCode, statusErr)
 		return nil, statusErr
 	}

--- a/internal/ai/provider/gemini.go
+++ b/internal/ai/provider/gemini.go
@@ -335,8 +335,7 @@ func (p *GeminiProvider) doRequest(ctx context.Context, url string, body interfa
 
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		statusErr := fmt.Errorf("Gemini API returned error (HTTP %d): %s", resp.StatusCode, string(bodyBytes))
+		statusErr := fmt.Errorf("Gemini API returned error (HTTP %d): %s", resp.StatusCode, readProviderErrorBody(resp.Body, resp.ContentLength))
 		logAIUpstreamRequestFinish(requestLog, resp.StatusCode, statusErr)
 		return nil, statusErr
 	}

--- a/internal/ai/provider/http_error.go
+++ b/internal/ai/provider/http_error.go
@@ -1,0 +1,34 @@
+package provider
+
+import (
+	"fmt"
+	"io"
+)
+
+const maxProviderErrorBodyBytes int64 = 64 * 1024
+
+// readProviderErrorBody limits diagnostic error bodies from configurable upstream endpoints.
+func readProviderErrorBody(body io.Reader, contentLength int64) string {
+	if contentLength > maxProviderErrorBodyBytes {
+		return fmt.Sprintf(
+			"[error response body truncated after %d bytes; declared Content-Length=%d]",
+			maxProviderErrorBodyBytes,
+			contentLength,
+		)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(body, maxProviderErrorBodyBytes+1))
+	if err != nil {
+		if len(data) > 0 {
+			return string(data) + fmt.Sprintf("\n[failed to read error response body: %v]", err)
+		}
+		return fmt.Sprintf("[failed to read error response body: %v]", err)
+	}
+	if int64(len(data)) > maxProviderErrorBodyBytes {
+		return string(data[:maxProviderErrorBodyBytes]) + fmt.Sprintf(
+			"\n[error response body truncated after %d bytes]",
+			maxProviderErrorBodyBytes,
+		)
+	}
+	return string(data)
+}

--- a/internal/ai/provider/http_error_test.go
+++ b/internal/ai/provider/http_error_test.go
@@ -1,0 +1,161 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"GoNavi-Wails/internal/ai"
+)
+
+type providerErrorRoundTripper func(*http.Request) (*http.Response, error)
+
+func (fn providerErrorRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+type trackingErrorBody struct {
+	reader       *strings.Reader
+	readBytes    int
+	closed       bool
+	readErrAfter int
+	readErr      error
+}
+
+func newTrackingErrorBody(content string) *trackingErrorBody {
+	return &trackingErrorBody{reader: strings.NewReader(content)}
+}
+
+func (b *trackingErrorBody) Read(p []byte) (int, error) {
+	if b.readErr != nil && b.readBytes >= b.readErrAfter {
+		return 0, b.readErr
+	}
+	if b.readErr != nil && b.readErrAfter-b.readBytes < len(p) {
+		p = p[:b.readErrAfter-b.readBytes]
+	}
+	n, err := b.reader.Read(p)
+	b.readBytes += n
+	if n > 0 && b.readErr != nil && b.readBytes >= b.readErrAfter {
+		return n, b.readErr
+	}
+	return n, err
+}
+
+func (b *trackingErrorBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+func TestReadProviderErrorBodyLimitsUnknownLength(t *testing.T) {
+	body := newTrackingErrorBody(strings.Repeat("x", int(maxProviderErrorBodyBytes)+32))
+
+	got := readProviderErrorBody(body, -1)
+	if body.readBytes != int(maxProviderErrorBodyBytes)+1 {
+		t.Fatalf("expected at most limit+1 bytes read, got %d", body.readBytes)
+	}
+	if !strings.Contains(got, "error response body truncated") {
+		t.Fatalf("expected truncation marker, got %q", got)
+	}
+	if len(got) <= int(maxProviderErrorBodyBytes) {
+		t.Fatalf("expected diagnostic suffix after limited body, got length %d", len(got))
+	}
+}
+
+func TestReadProviderErrorBodySkipsDeclaredOversizedBody(t *testing.T) {
+	body := newTrackingErrorBody(strings.Repeat("x", int(maxProviderErrorBodyBytes)+1))
+
+	got := readProviderErrorBody(body, maxProviderErrorBodyBytes+1)
+	if body.readBytes != 0 {
+		t.Fatalf("declared oversized body should not be read, got %d bytes", body.readBytes)
+	}
+	if !strings.Contains(got, "declared Content-Length") || !strings.Contains(got, "truncated") {
+		t.Fatalf("expected declared-length truncation diagnostic, got %q", got)
+	}
+}
+
+func TestReadProviderErrorBodyPreservesPartialBodyOnReadError(t *testing.T) {
+	body := newTrackingErrorBody("upstream diagnostic")
+	body.readErrAfter = len("upstream ")
+	body.readErr = errors.New("connection reset")
+
+	got := readProviderErrorBody(body, -1)
+	if !strings.Contains(got, "upstream ") {
+		t.Fatalf("expected partial upstream diagnostic to be preserved, got %q", got)
+	}
+	if !strings.Contains(got, "failed to read error response body: connection reset") {
+		t.Fatalf("expected read failure marker, got %q", got)
+	}
+}
+
+func TestProvidersLimitAndCloseOversizedErrorBodies(t *testing.T) {
+	newClient := func(body *trackingErrorBody) *http.Client {
+		return &http.Client{Transport: providerErrorRoundTripper(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode:    http.StatusBadGateway,
+				ContentLength: -1,
+				Header:        make(http.Header),
+				Body:          body,
+				Request:       req,
+			}, nil
+		})}
+	}
+
+	tests := []struct {
+		name string
+		call func(*trackingErrorBody) error
+	}{
+		{
+			name: "openai",
+			call: func(body *trackingErrorBody) error {
+				p := &OpenAIProvider{config: ai.ProviderConfig{APIKey: "test"}, baseURL: "http://provider.test", client: newClient(body)}
+				_, err := p.doRequest(context.Background(), map[string]any{})
+				return err
+			},
+		},
+		{
+			name: "openai responses",
+			call: func(body *trackingErrorBody) error {
+				p := &OpenAIResponsesProvider{config: ai.ProviderConfig{APIKey: "test"}, baseURL: "http://provider.test", client: newClient(body)}
+				_, err := p.doRequest(context.Background(), openAIResponsesRequest{})
+				return err
+			},
+		},
+		{
+			name: "anthropic",
+			call: func(body *trackingErrorBody) error {
+				p := &AnthropicProvider{config: ai.ProviderConfig{APIKey: "test"}, baseURL: "http://provider.test", client: newClient(body)}
+				_, err := p.doRequest(context.Background(), map[string]any{})
+				return err
+			},
+		},
+		{
+			name: "gemini",
+			call: func(body *trackingErrorBody) error {
+				p := &GeminiProvider{config: ai.ProviderConfig{APIKey: "test"}, baseURL: "http://provider.test", client: newClient(body)}
+				_, err := p.doRequest(context.Background(), "http://provider.test", map[string]any{})
+				return err
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := newTrackingErrorBody(strings.Repeat("x", int(maxProviderErrorBodyBytes)+32))
+			err := tc.call(body)
+			if err == nil || !strings.Contains(err.Error(), "error response body truncated") {
+				t.Fatalf("expected limited upstream error, got %v", err)
+			}
+			if body.readBytes != int(maxProviderErrorBodyBytes)+1 {
+				t.Fatalf("expected at most limit+1 bytes read, got %d", body.readBytes)
+			}
+			if !body.closed {
+				t.Fatal("expected provider to close the error response body")
+			}
+		})
+	}
+}
+
+var _ io.ReadCloser = (*trackingErrorBody)(nil)

--- a/internal/ai/provider/openai.go
+++ b/internal/ai/provider/openai.go
@@ -698,8 +698,7 @@ func (p *OpenAIProvider) doRequest(ctx context.Context, body interface{}) (io.Re
 
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		statusErr := fmt.Errorf("OpenAI API returned error (HTTP %d): %s", resp.StatusCode, string(bodyBytes))
+		statusErr := fmt.Errorf("OpenAI API returned error (HTTP %d): %s", resp.StatusCode, readProviderErrorBody(resp.Body, resp.ContentLength))
 		logAIUpstreamRequestFinish(requestLog, resp.StatusCode, statusErr)
 		return nil, statusErr
 	}

--- a/internal/ai/provider/openai_responses.go
+++ b/internal/ai/provider/openai_responses.go
@@ -773,8 +773,7 @@ func (p *OpenAIResponsesProvider) doRequest(ctx context.Context, body openAIResp
 	}
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		statusErr := fmt.Errorf("OpenAI Responses API returned error (HTTP %d): %s", resp.StatusCode, string(bodyBytes))
+		statusErr := fmt.Errorf("OpenAI Responses API returned error (HTTP %d): %s", resp.StatusCode, readProviderErrorBody(resp.Body, resp.ContentLength))
 		logAIUpstreamRequestFinish(requestLog, resp.StatusCode, statusErr)
 		return nil, statusErr
 	}


### PR DESCRIPTION
## 背景

修复可配置 AI HTTP endpoint 在非成功响应时无限制读取错误 body，可能导致内存压力或进程 OOM 的问题。

## 变更

- 新增统一的 provider 错误响应读取上限（64 KiB）。
- Content-Length 超限时不读取正文；未知长度响应在达到上限后标记截断。
- OpenAI、OpenAI Responses、Anthropic、Gemini 统一接入。
- 保留读取失败前已接收的诊断正文，并追加失败标记。
- 覆盖超限、声明长度、部分读取失败、四类 provider 和响应体关闭场景。

## 验证

- `go test ./internal/ai/provider -count=1`
- `go test ./internal/ai/provider -run 'Test(ReadProviderErrorBody|ProvidersLimitAndCloseOversizedErrorBodies)' -count=1 -v`
- `git diff --check`

Closes #958