### PR TITLE
✨ feat(download): 迁移 Bero 下载源站

### DIFF
--- a/.github/actions/publish-vps-mirror/action.yml
+++ b/.github/actions/publish-vps-mirror/action.yml
@@ -1,5 +1,5 @@
 name: Publish verified download edges
-description: Publish immutable assets to the DMIT edge and netcup origin before mutable pointers and KV control
+description: Publish immutable assets to the DMIT edge and Bero origin before mutable pointers and KV control
 
 inputs:
   channel: { required: true, description: stable or dev }
@@ -16,20 +16,20 @@ inputs:
   dmit-ssh-user: { required: true, description: Restricted gonavi-cdn user }
   dmit-ssh-private-key: { required: true, description: DMIT deployment key }
   dmit-ssh-known-hosts: { required: true, description: Pinned DMIT host key }
-  netcup-ssh-host: { required: true, description: Netcup origin SSH host; must be 152.53.66.99 }
-  netcup-ssh-port: { required: true, description: Netcup origin SSH port }
-  netcup-ssh-user: { required: true, description: Restricted gonavi-cdn user }
-  netcup-ssh-private-key: { required: true, description: Netcup origin deployment key }
-  netcup-ssh-known-hosts: { required: true, description: Pinned netcup origin host key }
-  netcup-base-url: { required: true, description: HTTPS Cloudflare-proxied netcup origin base URL }
+  bero-ssh-host: { required: true, description: Bero origin SSH host; must be 94.103.173.47 }
+  bero-ssh-port: { required: true, description: Bero origin SSH port; must be 37167 }
+  bero-ssh-user: { required: true, description: Restricted gonavi-cdn user }
+  bero-ssh-private-key: { required: true, description: Bero origin deployment key }
+  bero-ssh-known-hosts: { required: true, description: Pinned Bero origin host key }
+  bero-base-url: { required: true, description: HTTPS Cloudflare-proxied Bero origin base URL }
   cloudflare-account-id: { required: true, description: Cloudflare account ID }
   cloudflare-api-token: { required: true, description: Token restricted to Workers KV Storage Write }
   routing-state-kv-id: { required: true, description: Download dispatcher routing KV namespace ID }
   throughput-warning-mbps: { required: false, default: '20', description: Observability-only public eight-Range warning threshold }
   dmit-max-bytes: { required: false, default: '9000000000', description: Maximum DMIT mirror bytes }
   dmit-reserve-free-bytes: { required: false, default: '2000000000', description: Minimum free bytes preserved on DMIT }
-  netcup-max-bytes: { required: false, default: '9000000000', description: Maximum netcup origin bytes }
-  netcup-reserve-free-bytes: { required: false, default: '2000000000', description: Minimum free bytes preserved on netcup }
+  bero-max-bytes: { required: false, default: '9000000000', description: Maximum Bero origin bytes }
+  bero-reserve-free-bytes: { required: false, default: '2000000000', description: Minimum free bytes preserved on Bero }
 
 runs:
   using: composite
@@ -83,13 +83,13 @@ runs:
         EDGE_DMIT_BASE_URL: https://download.syngnat.top
         EDGE_DMIT_MAX_BYTES: ${{ inputs.dmit-max-bytes }}
         EDGE_DMIT_RESERVE_FREE_BYTES: ${{ inputs.dmit-reserve-free-bytes }}
-        EDGE_NETCUP_HOST: ${{ inputs.netcup-ssh-host }}
-        EDGE_NETCUP_PORT: ${{ inputs.netcup-ssh-port }}
-        EDGE_NETCUP_USER: ${{ inputs.netcup-ssh-user }}
-        EDGE_NETCUP_PRIVATE_KEY: ${{ inputs.netcup-ssh-private-key }}
-        EDGE_NETCUP_KNOWN_HOSTS: ${{ inputs.netcup-ssh-known-hosts }}
-        EDGE_NETCUP_ROOT: /srv/gonavi-downloads
-        EDGE_NETCUP_BASE_URL: ${{ inputs.netcup-base-url }}
-        EDGE_NETCUP_MAX_BYTES: ${{ inputs.netcup-max-bytes }}
-        EDGE_NETCUP_RESERVE_FREE_BYTES: ${{ inputs.netcup-reserve-free-bytes }}
+        EDGE_BERO_HOST: ${{ inputs.bero-ssh-host }}
+        EDGE_BERO_PORT: ${{ inputs.bero-ssh-port }}
+        EDGE_BERO_USER: ${{ inputs.bero-ssh-user }}
+        EDGE_BERO_PRIVATE_KEY: ${{ inputs.bero-ssh-private-key }}
+        EDGE_BERO_KNOWN_HOSTS: ${{ inputs.bero-ssh-known-hosts }}
+        EDGE_BERO_ROOT: /srv/gonavi-downloads
+        EDGE_BERO_BASE_URL: ${{ inputs.bero-base-url }}
+        EDGE_BERO_MAX_BYTES: ${{ inputs.bero-max-bytes }}
+        EDGE_BERO_RESERVE_FREE_BYTES: ${{ inputs.bero-reserve-free-bytes }}
       run: bash "${GITHUB_WORKSPACE}/tools/publish-edge-release.sh"

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1857,12 +1857,12 @@ jobs:
           dmit-ssh-user: ${{ secrets.CDN_DMIT_SSH_USER }}
           dmit-ssh-private-key: ${{ secrets.CDN_DMIT_SSH_PRIVATE_KEY }}
           dmit-ssh-known-hosts: ${{ secrets.CDN_DMIT_SSH_KNOWN_HOSTS }}
-          netcup-ssh-host: ${{ secrets.CDN_NETCUP_SSH_HOST }}
-          netcup-ssh-port: ${{ secrets.CDN_NETCUP_SSH_PORT }}
-          netcup-ssh-user: ${{ secrets.CDN_NETCUP_SSH_USER }}
-          netcup-ssh-private-key: ${{ secrets.CDN_NETCUP_SSH_PRIVATE_KEY }}
-          netcup-ssh-known-hosts: ${{ secrets.CDN_NETCUP_SSH_KNOWN_HOSTS }}
-          netcup-base-url: ${{ vars.CDN_NETCUP_BASE_URL }}
+          bero-ssh-host: ${{ secrets.CDN_BERO_SSH_HOST }}
+          bero-ssh-port: ${{ secrets.CDN_BERO_SSH_PORT }}
+          bero-ssh-user: ${{ secrets.CDN_BERO_SSH_USER }}
+          bero-ssh-private-key: ${{ secrets.CDN_BERO_SSH_PRIVATE_KEY }}
+          bero-ssh-known-hosts: ${{ secrets.CDN_BERO_SSH_KNOWN_HOSTS }}
+          bero-base-url: ${{ vars.CDN_BERO_BASE_URL }}
           cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           cloudflare-api-token: ${{ secrets.CLOUDFLARE_KV_API_TOKEN }}
           routing-state-kv-id: ${{ vars.ROUTING_STATE_KV_ID }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -651,12 +651,12 @@ jobs:
           dmit-ssh-user: ${{ secrets.CDN_DMIT_SSH_USER }}
           dmit-ssh-private-key: ${{ secrets.CDN_DMIT_SSH_PRIVATE_KEY }}
           dmit-ssh-known-hosts: ${{ secrets.CDN_DMIT_SSH_KNOWN_HOSTS }}
-          netcup-ssh-host: ${{ secrets.CDN_NETCUP_SSH_HOST }}
-          netcup-ssh-port: ${{ secrets.CDN_NETCUP_SSH_PORT }}
-          netcup-ssh-user: ${{ secrets.CDN_NETCUP_SSH_USER }}
-          netcup-ssh-private-key: ${{ secrets.CDN_NETCUP_SSH_PRIVATE_KEY }}
-          netcup-ssh-known-hosts: ${{ secrets.CDN_NETCUP_SSH_KNOWN_HOSTS }}
-          netcup-base-url: ${{ vars.CDN_NETCUP_BASE_URL }}
+          bero-ssh-host: ${{ secrets.CDN_BERO_SSH_HOST }}
+          bero-ssh-port: ${{ secrets.CDN_BERO_SSH_PORT }}
+          bero-ssh-user: ${{ secrets.CDN_BERO_SSH_USER }}
+          bero-ssh-private-key: ${{ secrets.CDN_BERO_SSH_PRIVATE_KEY }}
+          bero-ssh-known-hosts: ${{ secrets.CDN_BERO_SSH_KNOWN_HOSTS }}
+          bero-base-url: ${{ vars.CDN_BERO_BASE_URL }}
           cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           cloudflare-api-token: ${{ secrets.CLOUDFLARE_KV_API_TOKEN }}
           routing-state-kv-id: ${{ vars.ROUTING_STATE_KV_ID }}

--- a/deploy/download-dispatcher/src/core.ts
+++ b/deploy/download-dispatcher/src/core.ts
@@ -1,5 +1,6 @@
-const NODE_IDS = ["dmit", "netcup"] as const;
-const LEGACY_DISABLED_NETCUP_BASE_URL = "https://netcup-disabled.invalid";
+const NODE_IDS = ["dmit", "bero"] as const;
+const LEGACY_DISABLED_BERO_BASE_URL = "https://bero-disabled.invalid";
+const BERO_PROXY_BASE_URL = "https://origin-download.syngnat.top:8443";
 const CHANNELS = ["stable", "dev"] as const;
 const SUCCESS_THRESHOLD = 2;
 const FAILURE_THRESHOLD = 3;
@@ -107,19 +108,8 @@ function normalizeHttpsBaseUrl(value: unknown): string | null {
   }
 }
 
-function isNetcupProxyBaseUrl(value: string): boolean {
-  let parsed: URL;
-  try {
-    parsed = new URL(value);
-  } catch {
-    return false;
-  }
-  if (parsed.pathname !== "/" && parsed.pathname !== "") return false;
-  const hostname = parsed.hostname.toLowerCase();
-  return !/^(?:\d{1,3}\.){3}\d{1,3}$/.test(hostname)
-    && !hostname.includes(":")
-    && hostname !== "download.syngnat.top"
-    && hostname !== "157.254.234.28";
+function isBeroProxyBaseUrl(value: string): boolean {
+  return value === BERO_PROXY_BASE_URL;
 }
 
 function parseStrictUTCTimestamp(value: string): number | null {
@@ -153,10 +143,11 @@ function validateControl(value: unknown, expectedChannel: Channel): PublicationC
   const nodes = {} as Record<NodeId, EdgeConfig>;
   for (const nodeId of NODE_IDS) {
     const rawNode = value.nodes[nodeId];
-    // A control written before netcup was introduced remains readable, but its
-    // missing fallback is explicitly disabled until the next publication.
-    if (rawNode === undefined && nodeId === "netcup") {
-      nodes[nodeId] = { baseUrl: LEGACY_DISABLED_NETCUP_BASE_URL, enabled: false };
+    // A control written before the Bero fallback remains readable, but its old
+    // netcup node is intentionally not reused: that generation is not verified
+    // on Bero yet and must fall back to GitHub until the next publication.
+    if (rawNode === undefined && nodeId === "bero") {
+      nodes[nodeId] = { baseUrl: LEGACY_DISABLED_BERO_BASE_URL, enabled: false };
       continue;
     }
     if (!isRecord(rawNode) || typeof rawNode.enabled !== "boolean") {
@@ -166,8 +157,8 @@ function validateControl(value: unknown, expectedChannel: Channel): PublicationC
     if (!baseUrl) {
       throw new Error(`invalid HTTPS base URL for ${nodeId}`);
     }
-    if (nodeId === "netcup" && !isNetcupProxyBaseUrl(baseUrl)) {
-      throw new Error("netcup base URL must be a separate HTTPS hostname");
+    if (nodeId === "bero" && !isBeroProxyBaseUrl(baseUrl)) {
+      throw new Error("bero base URL must be a separate HTTPS hostname");
     }
     nodes[nodeId] = { baseUrl, enabled: rawNode.enabled };
   }
@@ -384,7 +375,7 @@ async function readRoutingState(env: Env, channel: Channel): Promise<RoutingStat
     const nodes = {} as Record<NodeId, NodeHealth>;
     for (const nodeId of NODE_IDS) {
       const raw = value.nodes[nodeId];
-      if (raw === undefined && nodeId === "netcup") {
+      if (raw === undefined && nodeId === "bero") {
         nodes[nodeId] = {
           generation: control.generation,
           healthy: false,
@@ -490,7 +481,7 @@ export async function refreshChannel(
 }
 
 export function orderedNodeIds(): NodeId[] {
-  return ["dmit", "netcup"];
+  return ["dmit", "bero"];
 }
 
 export function isRoutingStateFresh(checkedAt: string, now: number = Date.now()): boolean {
@@ -514,7 +505,7 @@ function joinBaseAndPath(baseUrl: string, relativePath: string): string {
 
 export function selectLegacyRedirectCandidate<T extends { source: string }>(candidates: T[]): T {
   return candidates.find((candidate) => candidate.source === "dmit")
-    ?? candidates.find((candidate) => candidate.source === "netcup")
+    ?? candidates.find((candidate) => candidate.source === "bero")
     ?? candidates[0];
 }
 

--- a/deploy/download-dispatcher/test/index.test.ts
+++ b/deploy/download-dispatcher/test/index.test.ts
@@ -21,18 +21,18 @@ describe("download dispatcher", () => {
     ]);
   });
 
-  it("keeps DMIT first and netcup second in every region", () => {
-    expect(orderedNodeIds()).toEqual(["dmit", "netcup"]);
+  it("keeps DMIT first and Bero second in every region", () => {
+    expect(orderedNodeIds()).toEqual(["dmit", "bero"]);
   });
 
-  it("keeps legacy 302 downloads on healthy DMIT before netcup and GitHub", () => {
+  it("keeps legacy 302 downloads on healthy DMIT before Bero and GitHub", () => {
     const candidates = [
       { source: "dmit", url: "https://download.syngnat.top/asset" },
-      { source: "netcup", url: "https://origin.example/asset" },
+      { source: "bero", url: "https://origin-download.syngnat.top:8443/asset" },
       { source: "github", url: "https://github.com/example/asset" },
     ];
     expect(selectLegacyRedirectCandidate(candidates).source).toBe("dmit");
-    expect(selectLegacyRedirectCandidate(candidates.filter((candidate) => candidate.source !== "dmit")).source).toBe("netcup");
+    expect(selectLegacyRedirectCandidate(candidates.filter((candidate) => candidate.source !== "dmit")).source).toBe("bero");
     expect(selectLegacyRedirectCandidate(candidates.filter((candidate) => candidate.source === "github")).source).toBe("github");
   });
 
@@ -200,9 +200,9 @@ describe("download dispatcher", () => {
     }
   });
 
-  it("routes healthy DMIT, then netcup, then GitHub", async () => {
-    const generation = "stable-dual-edge";
-    const control = {
+  it("does not reuse a legacy netcup fallback before Bero receives that generation", async () => {
+    const generation = "stable-legacy-netcup";
+    const legacyControl = {
       schemaVersion: 1,
       channel: "stable" as const,
       generation,
@@ -216,66 +216,12 @@ describe("download dispatcher", () => {
         netcup: { baseUrl: "https://origin.example", enabled: true },
       },
     };
-    await env.ROUTING_STATE.put("control:stable", JSON.stringify(control));
+    await env.ROUTING_STATE.put("control:stable", JSON.stringify(legacyControl));
     await env.ROUTING_STATE.put("routing:stable", JSON.stringify({
       schemaVersion: 1,
       channel: "stable",
       generation,
-      control,
-      nodes: {
-        dmit: {
-          generation,
-          healthy: true,
-          consecutiveFailures: 0,
-          consecutiveSuccesses: 2,
-          checkedAt: new Date().toISOString(),
-          detail: "ok",
-        },
-        netcup: {
-          generation,
-          healthy: true,
-          consecutiveFailures: 0,
-          consecutiveSuccesses: 2,
-          checkedAt: new Date().toISOString(),
-          detail: "ok",
-        },
-      },
-      checkedAt: new Date().toISOString(),
-    }));
-
-    const response = await SELF.fetch(
-      "https://download-dispatch.syngnat.top/v1/resolve?format=json&path=/gonavi/releases/download/v1.2.3/GoNavi.zip",
-    );
-    const body = await response.json<{ candidates: Array<{ source: string; url: string }> }>();
-    expect(body.candidates).toEqual([
-      { source: "dmit", url: "https://download.syngnat.top/gonavi/releases/download/v1.2.3/GoNavi.zip" },
-      { source: "netcup", url: "https://origin.example/gonavi/releases/download/v1.2.3/GoNavi.zip" },
-      { source: "github", url: "https://github.com/Syngnat/GoNavi/releases/download/v1.2.3/GoNavi.zip" },
-    ]);
-  });
-
-  it("falls back to healthy netcup when DMIT is unhealthy", async () => {
-    const generation = "stable-netcup-fallback";
-    const control = {
-      schemaVersion: 1,
-      channel: "stable" as const,
-      generation,
-      appTag: "v1.2.3",
-      driverTag: null,
-      probePath: "/gonavi/releases/download/v1.2.3/GoNavi.zip",
-      probeSize: 1024,
-      probeSha256: "a".repeat(64),
-      nodes: {
-        dmit: { baseUrl: "https://download.syngnat.top", enabled: true },
-        netcup: { baseUrl: "https://origin.example", enabled: true },
-      },
-    };
-    await env.ROUTING_STATE.put("control:stable", JSON.stringify(control));
-    await env.ROUTING_STATE.put("routing:stable", JSON.stringify({
-      schemaVersion: 1,
-      channel: "stable",
-      generation,
-      control,
+      control: legacyControl,
       nodes: {
         dmit: {
           generation,
@@ -298,21 +244,20 @@ describe("download dispatcher", () => {
     }));
 
     const response = await SELF.fetch(
-      "https://download-dispatch.syngnat.top/v1/resolve?path=/gonavi/releases/download/v1.2.3/GoNavi.zip",
-      { redirect: "manual" },
+      "https://download-dispatch.syngnat.top/v1/resolve?format=json&path=/gonavi/releases/download/v1.2.3/GoNavi.zip",
     );
-    expect(response.status).toBe(302);
-    expect(response.headers.get("X-GoNavi-Download-Source")).toBe("netcup");
-    expect(response.headers.get("Location")).toBe(
-      "https://origin.example/gonavi/releases/download/v1.2.3/GoNavi.zip",
-    );
+    const body = await response.json<{ candidates: Array<{ source: string; url: string }> }>();
+    expect(body.candidates).toEqual([
+      { source: "github", url: "https://github.com/Syngnat/GoNavi/releases/download/v1.2.3/GoNavi.zip" },
+    ]);
   });
 
-  it("does not accept a netcup origin IP as a public fallback URL", async () => {
-    await env.ROUTING_STATE.put("control:stable", JSON.stringify({
+  it("routes healthy DMIT, then Bero, then GitHub", async () => {
+    const generation = "stable-dual-edge";
+    const control = {
       schemaVersion: 1,
-      channel: "stable",
-      generation: "stable-invalid-netcup-url",
+      channel: "stable" as const,
+      generation,
       appTag: "v1.2.3",
       driverTag: null,
       probePath: "/gonavi/releases/download/v1.2.3/GoNavi.zip",
@@ -320,7 +265,114 @@ describe("download dispatcher", () => {
       probeSha256: "a".repeat(64),
       nodes: {
         dmit: { baseUrl: "https://download.syngnat.top", enabled: true },
-        netcup: { baseUrl: "https://152.53.66.99", enabled: true },
+        bero: { baseUrl: "https://origin-download.syngnat.top:8443", enabled: true },
+      },
+    };
+    await env.ROUTING_STATE.put("control:stable", JSON.stringify(control));
+    await env.ROUTING_STATE.put("routing:stable", JSON.stringify({
+      schemaVersion: 1,
+      channel: "stable",
+      generation,
+      control,
+      nodes: {
+        dmit: {
+          generation,
+          healthy: true,
+          consecutiveFailures: 0,
+          consecutiveSuccesses: 2,
+          checkedAt: new Date().toISOString(),
+          detail: "ok",
+        },
+        bero: {
+          generation,
+          healthy: true,
+          consecutiveFailures: 0,
+          consecutiveSuccesses: 2,
+          checkedAt: new Date().toISOString(),
+          detail: "ok",
+        },
+      },
+      checkedAt: new Date().toISOString(),
+    }));
+
+    const response = await SELF.fetch(
+      "https://download-dispatch.syngnat.top/v1/resolve?format=json&path=/gonavi/releases/download/v1.2.3/GoNavi.zip",
+    );
+    const body = await response.json<{ candidates: Array<{ source: string; url: string }> }>();
+    expect(body.candidates).toEqual([
+      { source: "dmit", url: "https://download.syngnat.top/gonavi/releases/download/v1.2.3/GoNavi.zip" },
+      { source: "bero", url: "https://origin-download.syngnat.top:8443/gonavi/releases/download/v1.2.3/GoNavi.zip" },
+      { source: "github", url: "https://github.com/Syngnat/GoNavi/releases/download/v1.2.3/GoNavi.zip" },
+    ]);
+  });
+
+  it("falls back to healthy Bero when DMIT is unhealthy", async () => {
+    const generation = "stable-bero-fallback";
+    const control = {
+      schemaVersion: 1,
+      channel: "stable" as const,
+      generation,
+      appTag: "v1.2.3",
+      driverTag: null,
+      probePath: "/gonavi/releases/download/v1.2.3/GoNavi.zip",
+      probeSize: 1024,
+      probeSha256: "a".repeat(64),
+      nodes: {
+        dmit: { baseUrl: "https://download.syngnat.top", enabled: true },
+        bero: { baseUrl: "https://origin-download.syngnat.top:8443", enabled: true },
+      },
+    };
+    await env.ROUTING_STATE.put("control:stable", JSON.stringify(control));
+    await env.ROUTING_STATE.put("routing:stable", JSON.stringify({
+      schemaVersion: 1,
+      channel: "stable",
+      generation,
+      control,
+      nodes: {
+        dmit: {
+          generation,
+          healthy: false,
+          consecutiveFailures: 3,
+          consecutiveSuccesses: 0,
+          checkedAt: new Date().toISOString(),
+          detail: "timeout",
+        },
+        bero: {
+          generation,
+          healthy: true,
+          consecutiveFailures: 0,
+          consecutiveSuccesses: 2,
+          checkedAt: new Date().toISOString(),
+          detail: "ok",
+        },
+      },
+      checkedAt: new Date().toISOString(),
+    }));
+
+    const response = await SELF.fetch(
+      "https://download-dispatch.syngnat.top/v1/resolve?path=/gonavi/releases/download/v1.2.3/GoNavi.zip",
+      { redirect: "manual" },
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("X-GoNavi-Download-Source")).toBe("bero");
+    expect(response.headers.get("Location")).toBe(
+      "https://origin-download.syngnat.top:8443/gonavi/releases/download/v1.2.3/GoNavi.zip",
+    );
+  });
+
+  it("does not accept a Bero origin IP as a public fallback URL", async () => {
+    await env.ROUTING_STATE.put("control:stable", JSON.stringify({
+      schemaVersion: 1,
+      channel: "stable",
+      generation: "stable-invalid-bero-url",
+      appTag: "v1.2.3",
+      driverTag: null,
+      probePath: "/gonavi/releases/download/v1.2.3/GoNavi.zip",
+      probeSize: 1024,
+      probeSha256: "a".repeat(64),
+      nodes: {
+        dmit: { baseUrl: "https://download.syngnat.top", enabled: true },
+        bero: { baseUrl: "https://94.103.173.47", enabled: true },
       },
     }));
 

--- a/deploy/download-mirror/bero-origin-download.conf
+++ b/deploy/download-mirror/bero-origin-download.conf
@@ -1,31 +1,14 @@
+# Bero reserves :443 for sing-box. Cloudflare supports proxied HTTPS on :8443,
+# so this source serves its dedicated Cloudflare hostname on that port only.
+# The Origin CA certificate must cover the hostname, never the origin IP.
 server {
-    listen 80;
-    listen [::]:80;
+    listen 8443 ssl;
+    listen [::]:8443 ssl;
     server_name origin-download.syngnat.top;
 
-    location ^~ /.well-known/acme-challenge/ {
-        root /var/www/certbot;
-        default_type text/plain;
-        try_files $uri =404;
-    }
-
-    location / {
-        return 301 https://$host$request_uri;
-    }
-}
-
-# Public :443 is handled by the existing SNI stream router and forwarded to
-# this local TLS listener. The certificate is issued for the Cloudflare
-# hostname, never for the origin IP.
-server {
-    listen 127.0.0.1:9443 ssl;
-    listen [::1]:9443 ssl;
-    server_name origin-download.syngnat.top;
-
-    ssl_certificate /etc/letsencrypt/live/origin-download.syngnat.top/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/origin-download.syngnat.top/privkey.pem;
-    include /etc/letsencrypt/options-ssl-nginx.conf;
-    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+    ssl_certificate /etc/ssl/cloudflare/origin-download.syngnat.top.pem;
+    ssl_certificate_key /etc/ssl/cloudflare/origin-download.syngnat.top.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
 
     root /srv/gonavi-downloads;
     access_log /var/log/nginx/gonavi-origin-download-access.log;

--- a/deploy/download-mirror/install-edge.sh
+++ b/deploy/download-mirror/install-edge.sh
@@ -25,9 +25,9 @@ retention_target="/usr/local/libexec/gonavi-edge-retention"
 [[ "${public_root}" == /srv/* && -f "${server_source}" ]] || { echo "invalid root or server config" >&2; exit 2; }
 [[ -f "${transaction_source}" && -f "${retention_source}" ]] || { echo "run installer from a complete GoNavi checkout" >&2; exit 2; }
 case "${node_id}:${server_kind}" in
-  dmit:caddy|netcup:nginx) ;;
+  dmit:caddy|bero:nginx) ;;
   dmit:*) echo "DMIT must retain its existing Caddy listener" >&2; exit 2 ;;
-  netcup:*) echo "netcup must use the Nginx static-site configuration" >&2; exit 2 ;;
+  bero:*) echo "Bero must use the Nginx static-site configuration" >&2; exit 2 ;;
   *) echo "unsupported edge node: ${node_id}" >&2; exit 2 ;;
 esac
 getent group "${server_group}" >/dev/null || { echo "server group does not exist" >&2; exit 2; }
@@ -114,11 +114,19 @@ if [[ "${server_kind}" == caddy ]]; then
   rm -f -- "${backup_path}"
   systemctl reload caddy
 else
-  # netcup already uses Nginx. The caller supplies a complete server snippet
-  # whose server_name is the Cloudflare-proxied hostname, never the origin IP.
+  # Bero serves the dedicated Cloudflare hostname on :8443 because sing-box
+  # owns :443. The caller supplies a complete static-site server snippet.
   command -v nginx >/dev/null || { echo "nginx is not installed" >&2; exit 2; }
-  grep -Eq '^[[:space:]]*server_name[[:space:]]+' "${server_source}" || { echo "netcup Nginx config must declare server_name" >&2; exit 2; }
-  grep -Fq "root ${public_root}" "${server_source}" || { echo "netcup Nginx config must serve the mirror root" >&2; exit 2; }
+  grep -Eq '^[[:space:]]*server_name[[:space:]]+' "${server_source}" || { echo "Bero Nginx config must declare server_name" >&2; exit 2; }
+  grep -Fq "root ${public_root}" "${server_source}" || { echo "Bero Nginx config must serve the mirror root" >&2; exit 2; }
+  grep -Eq '^[[:space:]]*listen[[:space:]]+8443[[:space:]]+ssl;' "${server_source}" || {
+    echo "Bero Nginx config must listen on 8443 with TLS" >&2
+    exit 2
+  }
+  if grep -Eq '^[[:space:]]*listen[[:space:]]+(\[::\]:)?(80|443|2053)[[:space:];]' "${server_source}"; then
+    echo "Bero Nginx config must not claim ports 80, 443, or 2053" >&2
+    exit 2
+  fi
   site_dir="/etc/nginx/conf.d"
   site_path="${site_dir}/gonavi-download.conf"
   install -d -m 0755 "${site_dir}"
@@ -140,7 +148,11 @@ else
     exit 1
   fi
   rm -f -- "${backup_path}"
-  systemctl reload nginx
+  if systemctl is-active --quiet nginx; then
+    systemctl reload nginx
+  else
+    systemctl enable --now nginx
+  fi
 fi
 
 echo "GoNavi static edge installed: node=${node_id} server=${server_kind} root=${public_root} user=${deploy_user}"

--- a/docs/download-cdn-operations.md
+++ b/docs/download-cdn-operations.md
@@ -5,47 +5,47 @@
 ```mermaid
 flowchart LR
     CI["GitHub Actions"] --> DMIT["DMIT CDN\n179.253.224.58\ndownload.syngnat.top"]
-    CI --> NETCUP["netcup 源站\n152.53.66.99\norigin-download.syngnat.top"]
+    CI --> BERO["Bero 源站\n94.103.173.47:37167 SSH\norigin-download.syngnat.top:8443"]
     CI --> KV["Cloudflare KV\ncontrol / routing state"]
     Client["GoNavi 客户端"] --> Worker["download-dispatch.syngnat.top\nCloudflare Worker"]
     Worker --> DMIT
-    Worker -. "DMIT 不健康或状态过期" .-> NETCUP
-    Worker -. "DMIT 与 netcup 均不可用" .-> GH["GitHub Releases"]
+    Worker -. "DMIT 不健康或状态过期" .-> BERO
+    Worker -. "DMIT 与 Bero 均不可用" .-> GH["GitHub Releases"]
 ```
 
 - `download-dispatch.syngnat.top` 是 Cloudflare Worker Custom Domain，只返回 JSON 或 `302`，绝不代理大文件内容。
-- `download.syngnat.top` 是 DMIT 的静态下载域名，当前解析到 DMIT（`179.253.224.58`）。DMIT 是默认下载节点，也是 CI 的第一个上传目标。
-- `CDN_NETCUP_BASE_URL` 是 netcup 源站的 HTTPS 基础 URL，当前配置为 `https://origin-download.syngnat.top`。它必须是单独的 Cloudflare 橙云代理域名，不能填写 `152.53.66.99`、旧 GatewaySentry 地址或 DMIT 域名。
-- netcup 的源站地址是 `152.53.66.99`。它保留最新版驱动资产、安装包和 mutable manifest；客户端通过 `CDN_NETCUP_BASE_URL` 访问时先经过 Cloudflare CDN。
-- GitHub Releases 是最后灾备源。GatewaySentry（旧地址 `157.254.234.28`）、腾讯节点和 Cloudflare R2 不参与新的上传、下载调度或 KV control。
+- `download.syngnat.top` 是 DMIT 的静态下载域名，解析到 DMIT（`179.253.224.58`）。DMIT 是默认下载节点，也是 CI 的第一个上传目标。
+- Bero 是唯一的回退源站，地址为 `94.103.173.47`，SSH 端口为 `37167`。CI 与 Worker 的节点 ID 都是 `bero`。
+- `CDN_BERO_BASE_URL` 固定为 `https://origin-download.syngnat.top:8443`。它必须是单独的 Cloudflare 橙云代理 URL，不能填写 Bero IP、DMIT 域名或旧 GatewaySentry 地址。
+- GitHub Releases 是最后灾备源。GatewaySentry（旧地址 `157.254.234.28`）、腾讯节点和 Cloudflare R2 不参与上传、下载调度或 KV control。
 
-下载候选顺序必须始终是：**DMIT -> netcup（Cloudflare 代理 HTTPS） -> GitHub**。DMIT 仍是默认源；netcup 不是替代 DMIT 的默认源，也不应通过源站 IP 直连暴露给 Worker 或客户端。
+下载候选顺序必须始终是：**DMIT -> Bero（Cloudflare 代理 HTTPS） -> GitHub**。DMIT 仍是默认源；Bero 不应通过源站 IP 直接暴露给 Worker 或客户端。
 
-## Cloudflare 与 netcup DNS/TLS 契约
+## Cloudflare 与 Bero DNS/TLS 契约
 
-在 Cloudflare 上为 `CDN_NETCUP_BASE_URL` 对应的主机名建立单独的 DNS 记录：
+Cloudflare 为 `origin-download.syngnat.top` 保留单独的 DNS 记录：
 
-1. `A` 记录指向 `152.53.66.99`；只有在 netcup 已配置并验证 IPv6 时才增加 `AAAA` 记录。
-2. 代理状态必须是 **Proxied/橙云**。DNS-only 只会暴露源站，不能提供本架构要求的 Cloudflare 回退 CDN。
-3. 目标 SSL/TLS 模式是 `Full (strict)`。当前 `syngnat.top` zone 仍保持 Cloudflare `Full` 自动模式，因为同区的旧 proxied 服务中还有自签名源站；切换为 strict 需要先完成那些服务的证书迁移。netcup 已配置包含该主机名的 Let's Encrypt 证书，不得使用仅对 IP 有效的证书。
-4. Worker、CI 公网验证和客户端候选 URL 都使用 `https://` 主机名，不使用 `http://`、裸 IP、查询串或旧 GatewaySentry 域名。
-5. Cloudflare 不应对该主机启用 Access 登录、浏览器挑战、强制验证码或会改写下载响应的规则。否则健康检查和客户端的 Range 下载会被误判为源站故障。
-6. 源站防火墙可只允许 Cloudflare 的 HTTP/HTTPS 回源网段；SSH 仅开放发布所需端口，并使用受限 `gonavi-cdn` 用户和固定 host key。不要因为启用代理而把 SSH 迁移到 Cloudflare 代理地址。
+1. `A` 记录指向 `94.103.173.47`；只有 Bero 已配置并验证 IPv6 时才增加 `AAAA` 记录。
+2. 代理状态必须是 **Proxied/橙云**。Cloudflare 支持代理 HTTPS `8443`，因此客户端和 Worker 都使用 `https://origin-download.syngnat.top:8443`，不是裸 IP 或省略端口的 `443` URL。
+3. Bero 的 `443` 已由 sing-box 占用。Nginx 只监听公开 TLS `8443`，不得抢占 `80`、`443` 或 `2053`。使用覆盖 `origin-download.syngnat.top` 的 Cloudflare Origin CA 证书；证书和私钥分别放在 `/etc/ssl/cloudflare/origin-download.syngnat.top.pem` 与 `/etc/ssl/cloudflare/origin-download.syngnat.top.key`，私钥必须仅 root 可读。
+4. Cloudflare SSL/TLS 应使用 `Full (strict)`。在无法立刻切换整个 zone 时，Bero 的 Origin CA 证书仍应先安装好，待同区其他旧服务完成证书迁移后再切换。
+5. 不要为该主机启用 Access 登录、浏览器挑战、强制验证码或改写下载响应的规则。否则健康检查和 Range 下载会被误判为源站故障。
+6. 源站防火墙可只允许 Cloudflare 的 HTTPS 回源网段访问 `8443`；SSH 仅开放 `37167`，并使用受限 `gonavi-cdn` 用户和固定 host key。
 
-`CDN_NETCUP_BASE_URL` 只表示公网 HTTPS 基础 URL，当前值为 `https://origin-download.syngnat.top`。配置时去掉尾部 `/`，不要把 `/gonavi`、`/drivers` 或任何具体产物路径拼进变量。
+`CDN_BERO_BASE_URL` 只表示公网 HTTPS 基础 URL，必须恰好为 `https://origin-download.syngnat.top:8443`。不要增加尾部 `/`、`/gonavi`、`/drivers` 或任何具体产物路径。
 
 ## 发布流程
 
 1. `tools/prepare-vps-release-payload.py` 从已校验的 release 产物生成 payload、`deployment.json` 和 `SHA256SUMS`。
 2. `tools/publish-edge-release.sh` 使用两套独立 SSH 凭据，将同一 generation 上传到：
    - DMIT：`CDN_DMIT_SSH_HOST` 必须为 `179.253.224.58`；
-   - netcup：`CDN_NETCUP_SSH_HOST` 必须为 `152.53.66.99`。
+   - Bero：`CDN_BERO_SSH_HOST=94.103.173.47`、`CDN_BERO_SSH_PORT=37167`。
 3. 两个节点都先写入各自的 `.incoming/<generation>`，再由节点上的 root-owned transaction 依次执行 `verify`、`promote-immutable`、`promote-mutable` 和 `finalize`。CI 不上传可执行发布逻辑，也不直接写正式目录。
-4. CI 分别从公网验证 DMIT 域名和 `CDN_NETCUP_BASE_URL`：`/healthz` 必须返回 `ready=true` 和目标 generation；immutable 产物必须返回真实 `206`、正确 `Content-Range`、`Content-Length`、总大小和 SHA-256。
-5. 只有 DMIT 与 netcup 均完成验证后，才写入 `control:history:<channel>:<generation>`，再原子更新 Worker KV 的 `control:<channel>`。control 同时记录 `dmit` 和 `netcup` 的 base URL、enabled 状态及本次 app/driver tag。
-6. 如果任一节点的上传、校验、公开 Range 或 health 验证失败，发布失败且不写新的 KV control；不能只发布 DMIT 后把 netcup 留在旧 generation，也不能把失败自动改投 `157.254.234.28`。
+4. CI 分别从公网验证 DMIT 域名和 `CDN_BERO_BASE_URL`：`/healthz` 必须返回 `ready=true` 和目标 generation；immutable 产物必须返回真实 `206`、正确 `Content-Range`、`Content-Length`、总大小和 SHA-256。
+5. 只有 DMIT 与 Bero 均完成验证后，才写入 `control:history:<channel>:<generation>`，再原子更新 Worker KV 的 `control:<channel>`。control 同时记录 `dmit` 和 `bero` 的 base URL、enabled 状态及本次 app/driver tag。
+6. 如果任一节点上传、校验、公开 Range 或 health 验证失败，发布失败且不写新的 KV control；不能只发布 DMIT 后把 Bero 留在旧 generation，也不能回退到 GatewaySentry。
 
-两台服务器必须保留相同的目录、文件内容和 generation。netcup 是源站而不是第二个待选旧镜像：它必须保留当前已验证版本，供 DMIT 故障时立即回退。
+两台服务器必须保留相同的目录、文件内容和 generation。Bero 是源站而不是默认 CDN：它必须保留当前已验证版本，供 DMIT 故障时立即回退。
 
 ## 超时与失败行为
 
@@ -53,24 +53,26 @@ flowchart LR
 
 - SSH 连接超时 15 秒，保活间隔 15 秒，连续 4 次未响应断开；marker、空间检查和建目录最多 60 秒，事务命令最多 300 秒，retention 最多 120 秒。
 - payload 准备最多 600 秒；每个节点的 `rsync` 空闲 I/O 最多 120 秒，单节点整个传输最多 900 秒。
-- DMIT 域名和 netcup Cloudflare 域名的 Range、health HTTP 请求最多 60 秒，8 路吞吐观测每个节点每路最多 120 秒；KV 写入连接最多 10 秒、单次最多 30 秒。
+- DMIT 域名和 Bero Cloudflare 域名的 Range、health HTTP 请求最多 60 秒，8 路吞吐观测每个节点每路最多 120 秒；KV 写入连接最多 10 秒、单次最多 30 秒。
 - 所有受控命令超时后先发 `TERM`，15 秒后强杀。吞吐观测失败仅记录 `limited` 告警，但 Range 与 health 未通过时不得写 KV control。
-- 任一节点失败都应使本次发布失败，防止两个源的 generation 分裂。客户端运行时仍按 DMIT、netcup、GitHub 的顺序回退。
+- 任一节点失败都应使本次发布失败，防止两个源的 generation 分裂。客户端运行时仍按 DMIT、Bero、GitHub 的顺序回退。
 
 ## Worker 和客户端行为
 
-Worker 维护两个节点，固定顺序为 `dmit`、`netcup`。每 5 分钟检查每个启用节点的：
+Worker 维护两个 canonical 节点，固定顺序为 `dmit`、`bero`。每 5 分钟检查每个启用节点的：
 
 - 受系统信任的 HTTPS；
 - `/healthz` 中的 `ready=true` 和目标 generation；
 - control 指定 immutable 文件的真实 `206`、`Content-Range`、`Content-Length` 和总大小。
 
-新 control 携带 CI 刚完成的 `verifiedAt` 时，Worker 只会在 15 分钟内为同一 app/driver tag 立即选择 DMIT；若 DMIT 失败、状态过期或跨 PoP 的健康状态不可用，则按同一 generation 选择 netcup。netcup 的 URL 必须来自 control 中的 `CDN_NETCUP_BASE_URL`，请求路径与 DMIT 完全相同，流量经 Cloudflare 代理到 `152.53.66.99`。
+新 control 携带 CI 刚完成的 `verifiedAt` 时，Worker 只会在 15 分钟内为同一 app/driver tag 立即选择 DMIT；若 DMIT 失败、状态过期或跨 PoP 的健康状态不可用，则按同一 generation 选择 Bero。Bero URL 来自 control 中的 `CDN_BERO_BASE_URL`，请求路径与 DMIT 完全相同，流量经 Cloudflare 代理到 `94.103.173.47:8443`。
+
+旧 KV 的 `nodes.netcup` 不会映射为 Bero：旧 generation 尚未在 Bero 验证，迁移窗口内它会被视为禁用，DMIT 不可用时直接回退 GitHub。下一次成功双节点发布会写入只含 `dmit`、`bero` 的新 control；旧 `CDN_NETCUP_*` secrets/variable 可暂时保留作人工回滚，但 workflow、action 与发布脚本不得引用它们。
 
 JSON 响应和旧客户端 `302` 的候选顺序都必须是：
 
 1. `dmit`：`https://download.syngnat.top/...`；
-2. `netcup`：`CDN_NETCUP_BASE_URL/...`；
+2. `bero`：`https://origin-download.syngnat.top:8443/...`；
 3. `github`：对应 GitHub Releases URL。
 
 Worker 只返回候选，不跟随或代理文件；客户端按顺序执行严格的 Range、状态码、`Content-Range`、大小和校验校验，当前候选失败立即尝试下一个。没有区域偏置，也没有腾讯/GatewaySentry 分支。
@@ -85,23 +87,21 @@ sudo deploy/download-mirror/install-edge.sh \
   deploy/download-mirror/dmit-caddy-site.caddy caddy
 ```
 
-DMIT 现有 Caddy 监听器同时承载其他站点。安装器只暂存 `download.syngnat.top` 片段，要求在现有 Caddyfile 中导入 `/etc/caddy/conf.d/*.caddy`，并在 reload 前执行 `caddy validate`；不得安装 Nginx 抢占 80/443，也不得替换完整 Caddyfile。
+DMIT 现有 Caddy 监听器同时承载其他站点。安装器只暂存 `download.syngnat.top` 片段，要求在现有 Caddyfile 中导入 `/etc/caddy/conf.d/*.caddy`，并在 reload 前执行 `caddy validate`；不得安装 Nginx 抢占其 80/443，也不得替换完整 Caddyfile。
 
-netcup 必须按相同的目录和权限契约部署 `/srv/gonavi-downloads`、root-owned transaction/retention helper、`healthz` 和静态站点；当前站点名是 `origin-download.syngnat.top`。netcup 的 443 站点由 Cloudflare 橙云回源，源站证书必须覆盖该主机名。netcup 的安装不能改动 DMIT 的 Caddy 监听器，也不能把旧 GatewaySentry（`157.254.234.28`）作为第三个节点加入。
-
-在 netcup 上准备一份只包含该 Cloudflare 主机名的 Nginx `server` 配置（必须声明 `root /srv/gonavi-downloads`，并提供下列静态路径的 GET/HEAD、Range/206、`/healthz` 和缓存头），再运行：
+Bero 必须按相同目录和权限契约部署 `/srv/gonavi-downloads`、root-owned transaction/retention helper、`healthz` 和静态站点。先把 Cloudflare Origin CA 证书放到上文规定路径，随后运行：
 
 ```bash
 sudo deploy/download-mirror/install-edge.sh \
-  netcup /srv/gonavi-downloads nginx \
-  deploy/download-mirror/netcup-origin-download.conf www-data
+  bero /srv/gonavi-downloads nginx \
+  deploy/download-mirror/bero-origin-download.conf www-data
 ```
 
-安装器只写入 `/etc/nginx/conf.d/gonavi-download.conf`，先执行 `nginx -t` 再 reload；它不会替换完整 Nginx 配置。`server_name` 必须是 `CDN_NETCUP_BASE_URL` 对应的 Cloudflare 主机名，不能写 `152.53.66.99`、`download.syngnat.top` 或旧 GatewaySentry 地址。DMIT 继续使用上面的 Caddy 命令，不能用 netcup 参数重装。
+安装器只写入 `/etc/nginx/conf.d/gonavi-download.conf`，先执行 `nginx -t`，运行中的服务 reload，未启动的服务才 enable 并启动；它不会替换完整 Nginx 配置。Bero 片段必须声明 `server_name origin-download.syngnat.top`、`root /srv/gonavi-downloads` 和 TLS `listen 8443`，并拒绝占用 `80`、`443` 或 `2053`。DMIT 继续使用上面的 Caddy 命令，不能用 Bero 参数重装。
 
 immutable 文件必须支持 HEAD、Range/206、稳定 ETag，并返回 `Cache-Control: public,max-age=31536000,immutable`。latest、latest-dev、driver index 和 healthz 使用 `no-cache` 或 `no-store`。Cloudflare 代理侧必须保留真实 `206`、`Content-Range`、`Content-Length`、ETag 和 `Accept-Ranges`，不能把挑战页、错误页或压缩转换后的响应缓存成资产。
 
-两个节点必须由各自的静态服务器（DMIT 使用 Caddy，netcup 使用 Nginx）提供同一根目录 `/srv/gonavi-downloads`，并同时满足：
+两个节点必须由各自的静态服务器（DMIT 使用 Caddy，Bero 使用 Nginx）提供同一根目录 `/srv/gonavi-downloads`，并同时满足：
 
 - `/healthz` 返回 `Content-Type: application/json`、`Cache-Control: no-store`，内容至少包含 `schemaVersion`、`status`、`ready`、`nodeId` 和两个 channel 的 generation；
 - `latest`、`latest-dev`、driver index 等 mutable 路径使用 `no-store` 或 `no-cache, must-revalidate`，避免 Cloudflare 或浏览器继续使用旧指针；
@@ -113,26 +113,26 @@ immutable 文件必须支持 HEAD、Range/206、稳定 ETag，并返回 `Cache-C
 发布需要以下 GitHub Actions secrets：
 
 - DMIT（保持现状，不修改目标）：`CDN_DMIT_SSH_HOST`、`CDN_DMIT_SSH_PORT`、`CDN_DMIT_SSH_USER`、`CDN_DMIT_SSH_PRIVATE_KEY`、`CDN_DMIT_SSH_KNOWN_HOSTS`。其中 host 应解析/固定到 `179.253.224.58`。
-- netcup（新增源站目标）：`CDN_NETCUP_SSH_HOST`、`CDN_NETCUP_SSH_PORT`、`CDN_NETCUP_SSH_USER`、`CDN_NETCUP_SSH_PRIVATE_KEY`、`CDN_NETCUP_SSH_KNOWN_HOSTS`。其中 `CDN_NETCUP_SSH_HOST` 必须严格为 `152.53.66.99`；不要填 `157.254.234.28`，也不要复用旧 `MIRROR_SSH_*`。
+- Bero：`CDN_BERO_SSH_HOST`、`CDN_BERO_SSH_PORT`、`CDN_BERO_SSH_USER`、`CDN_BERO_SSH_PRIVATE_KEY`、`CDN_BERO_SSH_KNOWN_HOSTS`。必须分别为 `94.103.173.47`、`37167`、`gonavi-cdn`、部署私钥和 Bero 的固定 host key；不要填 `157.254.234.28`，也不要复用旧 `MIRROR_SSH_*`。
 - Cloudflare KV：`CLOUDFLARE_ACCOUNT_ID`、`CLOUDFLARE_KV_API_TOKEN`；部署 Worker 另需 `CLOUDFLARE_WORKERS_API_TOKEN`。
 
 还需要以下 repository variable：
 
-- `CDN_NETCUP_BASE_URL`：当前为 `https://origin-download.syngnat.top`，必须与 DNS、证书和 Worker control 中的 netcup 节点一致；不能是 IP、DNS-only 主机、DMIT 域名或 GatewaySentry 域名。
+- `CDN_BERO_BASE_URL`：固定为 `https://origin-download.syngnat.top:8443`，必须与 DNS、Origin CA 证书和 Worker control 中的 Bero 节点一致；不能是 IP、DNS-only 主机、DMIT 域名或 GatewaySentry 域名。
 - `ROUTING_STATE_KV_ID`：Worker routing state KV namespace ID。
 
-netcup 和 DMIT 的 SSH 用户只能写 `.incoming`。正式文件、状态、事务、`healthz` 和 marker 均由 root 管理；CI 只能通过节点上已安装的 transaction/retention helper 进行受控提升与清理。DMIT 的现有配置和文件不因新增 netcup 而重装或改名。
+Bero 和 DMIT 的 SSH 用户只能写 `.incoming`。正式文件、状态、事务、`healthz` 和 marker 均由 root 管理；CI 只能通过节点上已安装的 transaction/retention helper 进行受控提升与清理。DMIT 的现有配置和文件不因 Bero 迁移而重装或改名。
 
 ## 上线与验收
 
-先完成 netcup 主机、Nginx 和 Cloudflare DNS/TLS 配置，再部署 Worker：
+先完成 Bero 主机、Nginx、Origin CA 证书和 Cloudflare DNS/TLS 配置，再部署 Worker：
 
-1. 确认 `CDN_NETCUP_SSH_HOST=152.53.66.99`、host key 与受限用户；确认 `CDN_DMIT_SSH_HOST` 仍为 `179.253.224.58`。旧 `MIRROR_SSH_*` 即使暂时仍存在于 GitHub secret store，也不得被 workflow、action 或脚本引用；`157.254.234.28` 同样不得进入新链路。
-2. 在 Cloudflare DNS 中确认 `origin-download.syngnat.top` 为橙云、A 记录指向 `152.53.66.99`；当前 zone SSL/TLS 为 `Full`，待同区旧自签名服务完成证书迁移后再切换 `Full (strict)`。
-3. 从公网验证两个 endpoint 的 `/healthz`、HEAD 和一个小 Range；对 netcup 必须验证经过 Cloudflare 的响应，而不是直接请求 `152.53.66.99`。
-4. 手动部署 `Deploy Download Dispatcher`，确认 `npm run check` 通过后再部署 Worker。
-5. 运行一次 dev build 或 stable publish，确认两个节点都得到同一 generation，KV control 同时包含 `dmit`、`netcup`，且 `candidates` 顺序为 `dmit`、`netcup`、`github`。
-6. 模拟 DMIT 不健康：JSON 和旧式 `302` 的第一个候选应为 netcup；恢复 DMIT 后默认源应回到 dmit。再模拟 netcup/Cloudflare 不健康，确认最终回退 GitHub。
-7. 验证客户端对三个候选都执行 Range/校验失败回退；确认 Worker 从不代理大文件，netcup fallback 的实际 TCP/HTTPS 入口是 Cloudflare 而不是源站 IP。
+1. 确认 `CDN_BERO_SSH_HOST=94.103.173.47`、`CDN_BERO_SSH_PORT=37167`、host key 与受限用户；确认 `CDN_DMIT_SSH_HOST` 仍为 `179.253.224.58`。旧 `CDN_NETCUP_*`/`MIRROR_SSH_*` 即使暂时仍存在于 GitHub secret store，也不得被 workflow、action 或脚本引用；`157.254.234.28` 同样不得进入新链路。
+2. 在 Cloudflare DNS 中确认 `origin-download.syngnat.top` 为橙云、A 记录指向 `94.103.173.47`，并从公网请求 `https://origin-download.syngnat.top:8443/healthz`。不要把公网回退 URL 改成源站 IP 或 `443`。
+3. 从公网验证两个 endpoint 的 `/healthz`、HEAD 和一个小 Range；对 Bero 必须验证经过 Cloudflare 的 `:8443` 响应，而不是直接请求 `94.103.173.47`。
+4. 手动部署 `Deploy Download Dispatcher`，确认 `npm run check` 通过后再部署 Worker。该版本必须忽略旧 KV 的 `netcup` URL，直至首次 Bero 双节点发布完成，避免把旧 generation 错误路由到新源站。
+5. 运行一次 dev build 或 stable publish，确认两个节点都得到同一 generation，KV control 同时包含 `dmit`、`bero`，且 `candidates` 顺序为 `dmit`、`bero`、`github`。
+6. 模拟 DMIT 不健康：JSON 和旧式 `302` 的第一个候选应为 Bero；恢复 DMIT 后默认源应回到 DMIT。再模拟 Bero/Cloudflare 不健康，确认最终回退 GitHub。
+7. 验证客户端对三个候选都执行 Range/校验失败回退；确认 Worker 从不代理大文件，Bero fallback 的实际 TCP/HTTPS 入口是 Cloudflare `:8443` 而不是源站 IP。
 
-不要在本次变更中删除 DMIT、修改 DMIT 的 Caddy 监听器或删除旧腾讯/GatewaySentry 服务器；这些是独立的运维变更。`origin-download.syngnat.top` 的 Cloudflare DNS 记录已建立，旧地址若仍在 DNS、secrets、KV 或客户端缓存中，应先清点并单独下线，不能让新 CI 误上传过去。
+不要在本次变更中删除 DMIT、修改 DMIT 的 Caddy 监听器或删除旧 GatewaySentry 服务器；这些是独立的运维变更。DNS、secrets、KV 和客户端缓存中若还存有旧地址，应在 Bero 发布和公网验收稳定后单独下线，不能让新 CI 误上传过去。

--- a/tools/download-mirror-config.test.py
+++ b/tools/download-mirror-config.test.py
@@ -22,16 +22,35 @@ class DownloadMirrorConfigTest(unittest.TestCase):
         self.assertNotIn("reverse_proxy", snippet)
         self.assertFalse((ROOT / "deploy/download-mirror/dmit-nginx.conf").exists())
         self.assertFalse((ROOT / "deploy/download-mirror/tencent-ip-nginx.conf").exists())
+        self.assertFalse((ROOT / "deploy/download-mirror/netcup-origin-download.conf").exists())
         self.assertIn("DMIT must retain its existing Caddy listener", installer)
-        self.assertIn("dmit:caddy|netcup:nginx", installer)
-        self.assertIn("netcup Nginx config must declare server_name", installer)
+        self.assertIn("dmit:caddy|bero:nginx", installer)
+        self.assertIn("Bero Nginx config must declare server_name", installer)
+        self.assertIn("Bero Nginx config must listen on 8443 with TLS", installer)
+        self.assertIn("Bero Nginx config must not claim ports 80, 443, or 2053", installer)
         self.assertIn("nginx -t", installer)
+        self.assertIn("systemctl is-active --quiet nginx", installer)
+        self.assertIn("systemctl enable --now nginx", installer)
+        self.assertLess(installer.index("nginx -t"), installer.index("systemctl enable --now nginx"))
         self.assertNotIn("tencent", installer.lower())
         self.assertIn("caddy validate", installer)
         self.assertIn("/usr/local/libexec/gonavi-edge-transaction", installer)
         self.assertIn("NOPASSWD: GONAVI_EDGE_CONTROL", installer)
 
-    def test_publication_uses_dmit_and_netcup_with_observability_only_throughput(self) -> None:
+    def test_bero_uses_public_tls_8443_without_claiming_sing_box_ports(self) -> None:
+        config = (ROOT / "deploy/download-mirror/bero-origin-download.conf").read_text(encoding="utf-8")
+
+        self.assertIn("server_name origin-download.syngnat.top", config)
+        self.assertIn("listen 8443 ssl;", config)
+        self.assertIn("listen [::]:8443 ssl;", config)
+        self.assertNotIn("listen 80", config)
+        self.assertNotIn("listen 443", config)
+        self.assertNotIn("listen 2053", config)
+        self.assertIn("ssl_certificate /etc/ssl/cloudflare/origin-download.syngnat.top.pem;", config)
+        self.assertIn("ssl_certificate_key /etc/ssl/cloudflare/origin-download.syngnat.top.key;", config)
+        self.assertIn("root /srv/gonavi-downloads", config)
+
+    def test_publication_uses_dmit_and_bero_with_observability_only_throughput(self) -> None:
         action = (ROOT / ".github/actions/publish-vps-mirror/action.yml").read_text(encoding="utf-8")
         publication = (ROOT / "tools/publish-edge-release.sh").read_text(encoding="utf-8")
         stable_workflow = (ROOT / ".github/workflows/publish-release.yml").read_text(encoding="utf-8")
@@ -39,22 +58,27 @@ class DownloadMirrorConfigTest(unittest.TestCase):
 
         self.assertIn("dmit-max-bytes", action)
         self.assertIn("default: '9000000000'", action)
-        self.assertIn("netcup-ssh-host", action)
-        self.assertIn("netcup-base-url", action)
-        self.assertIn("EDGE_NETCUP_HOST", action)
-        self.assertIn("CDN_NETCUP_SSH_HOST", stable_workflow)
-        self.assertIn("CDN_NETCUP_SSH_HOST", dev_workflow)
-        self.assertIn("CDN_NETCUP_BASE_URL", stable_workflow)
-        self.assertIn("CDN_NETCUP_BASE_URL", dev_workflow)
+        self.assertIn("bero-ssh-host", action)
+        self.assertIn("bero-base-url", action)
+        self.assertIn("EDGE_BERO_HOST", action)
+        self.assertIn("CDN_BERO_SSH_HOST", stable_workflow)
+        self.assertIn("CDN_BERO_SSH_HOST", dev_workflow)
+        self.assertIn("CDN_BERO_BASE_URL", stable_workflow)
+        self.assertIn("CDN_BERO_BASE_URL", dev_workflow)
+        self.assertNotIn("CDN_NETCUP_", stable_workflow)
+        self.assertNotIn("CDN_NETCUP_", dev_workflow)
         self.assertNotIn("tencent-ssh-", action)
         self.assertNotIn("tencent-max-bytes", action)
         self.assertNotIn("EDGE_TENCENT_", action)
         self.assertNotIn("CDN_TENCENT_", stable_workflow)
         self.assertNotIn("CDN_TENCENT_", dev_workflow)
         self.assertIn("stage_node \"${node}\"", publication)
-        self.assertIn("for node in dmit netcup", publication)
+        self.assertIn("for node in dmit bero", publication)
         self.assertIn("activate_node \"${node}\"", publication)
-        self.assertIn("netcup origin SSH host must be 152.53.66.99", publication)
+        self.assertIn("Bero origin SSH host must be 94.103.173.47", publication)
+        self.assertIn("Bero origin SSH port must be 37167", publication)
+        self.assertIn("https://origin-download.syngnat.top:8443", publication)
+        self.assertNotIn("netcup", publication.lower())
         self.assertNotIn("node_value tencent", publication)
         self.assertNotIn("tencent", publication.lower())
         self.assertIn("PUB_THROUGHPUT_WARN_MBPS", publication)
@@ -90,7 +114,7 @@ class DownloadMirrorConfigTest(unittest.TestCase):
         self.assertIn('echo "[${node}] uploading payload"', publication)
         self.assertIn('echo "[${node}] verifying immutable Range"', publication)
 
-    def test_publication_control_contains_dmit_and_netcup(self) -> None:
+    def test_publication_control_contains_dmit_and_bero(self) -> None:
         publication = (ROOT / "tools/publish-edge-release.sh").read_text(encoding="utf-8")
         filter_start = publication.index("'{schemaVersion:1") + 1
         filter_end = publication.index("}'", filter_start) + 1
@@ -127,8 +151,8 @@ class DownloadMirrorConfigTest(unittest.TestCase):
                 "dmitBase",
                 "https://download.syngnat.top",
                 "--arg",
-                "netcupBase",
-                "https://origin.example",
+                "beroBase",
+                "https://origin.example:8443",
                 jq_filter,
             ],
             check=True,
@@ -138,7 +162,7 @@ class DownloadMirrorConfigTest(unittest.TestCase):
         control = json.loads(result.stdout)
         self.assertEqual(control["nodes"], {
             "dmit": {"baseUrl": "https://download.syngnat.top", "enabled": True},
-            "netcup": {"baseUrl": "https://origin.example", "enabled": True},
+            "bero": {"baseUrl": "https://origin.example:8443", "enabled": True},
         })
         self.assertEqual(control["appTag"], "dev-abc123")
         self.assertEqual(control["driverTag"], "driver-abc123")

--- a/tools/publish-edge-release.sh
+++ b/tools/publish-edge-release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Publish one prepared generation to the DMIT static edge and netcup origin,
+# Publish one prepared generation to the DMIT static edge and Bero origin,
 # then commit their routing control to Cloudflare KV.
 # Secrets are consumed only from the environment and are never printed.
 
@@ -24,10 +24,14 @@ PUB_THROUGHPUT_WARN_MBPS="${PUB_THROUGHPUT_WARN_MBPS:-20}"
 [[ "${PUB_THROUGHPUT_WARN_MBPS}" =~ ^[0-9]+([.][0-9]+)?$ ]] || { echo "Invalid throughput warning threshold" >&2; exit 1; }
 EDGE_DMIT_MAX_BYTES="${EDGE_DMIT_MAX_BYTES:-9000000000}"
 EDGE_DMIT_RESERVE_FREE_BYTES="${EDGE_DMIT_RESERVE_FREE_BYTES:-2000000000}"
-EDGE_NETCUP_MAX_BYTES="${EDGE_NETCUP_MAX_BYTES:-9000000000}"
-EDGE_NETCUP_RESERVE_FREE_BYTES="${EDGE_NETCUP_RESERVE_FREE_BYTES:-2000000000}"
-[[ "${EDGE_NETCUP_HOST:-}" == "152.53.66.99" ]] || {
-  echo "Netcup origin SSH host must be 152.53.66.99" >&2
+EDGE_BERO_MAX_BYTES="${EDGE_BERO_MAX_BYTES:-9000000000}"
+EDGE_BERO_RESERVE_FREE_BYTES="${EDGE_BERO_RESERVE_FREE_BYTES:-2000000000}"
+[[ "${EDGE_BERO_HOST:-}" == "94.103.173.47" ]] || {
+  echo "Bero origin SSH host must be 94.103.173.47" >&2
+  exit 1
+}
+[[ "${EDGE_BERO_PORT:-}" == "37167" ]] || {
+  echo "Bero origin SSH port must be 37167" >&2
   exit 1
 }
 PUB_TIMEOUT_KILL_AFTER_SECONDS="${PUB_TIMEOUT_KILL_AFTER_SECONDS:-15}"
@@ -135,19 +139,17 @@ stage_node() (
   done
   [[ "${port}" =~ ^[0-9]+$ ]] || { echo "${node} has an invalid SSH port" >&2; exit 1; }
   [[ "${max_bytes}" =~ ^[0-9]+$ && "${reserve_free_bytes}" =~ ^[0-9]+$ ]] || { echo "${node} has an invalid disk budget" >&2; exit 1; }
-  [[ "${root}" == /srv/* && "${base_url}" =~ ^https://[A-Za-z0-9.-]+/?$ ]] || { echo "${node} root or HTTPS URL is invalid" >&2; exit 1; }
-  if [[ "${node}" == netcup && "${host}" != "152.53.66.99" ]]; then
-    echo "netcup origin SSH host must be 152.53.66.99" >&2
+  [[ "${root}" == /srv/* && "${base_url}" =~ ^https://[A-Za-z0-9.-]+(:[0-9]{1,5})?/?$ ]] || { echo "${node} root or HTTPS URL is invalid" >&2; exit 1; }
+  if [[ "${node}" == bero && ( "${host}" != "94.103.173.47" || "${port}" != "37167" ) ]]; then
+    echo "bero origin SSH target must be 94.103.173.47:37167" >&2
     exit 1
   fi
-  if [[ "${node}" == netcup ]]; then
+  if [[ "${node}" == bero ]]; then
     base_url_without_slash="${base_url%/}"
-    case "${base_url_without_slash}" in
-      https://download.syngnat.top|https://152.53.66.99|https://179.253.224.58|https://157.254.234.28)
-        echo "netcup base URL must be a separate Cloudflare-proxied hostname" >&2
-        exit 1
-        ;;
-    esac
+    [[ "${base_url_without_slash}" == "https://origin-download.syngnat.top:8443" ]] || {
+      echo "bero base URL must be https://origin-download.syngnat.top:8443" >&2
+      exit 1
+    }
   fi
 
   ssh_dir="${credential_root}/${node}"
@@ -281,7 +283,7 @@ PY
   printf 'immutable\n' > "${status_root}/${node}.status"
 )
 
-for node in dmit netcup; do
+for node in dmit bero; do
   echo "[${node}] staging generation ${PUB_GENERATION}"
   stage_node "${node}"
   [[ "$(cat "${status_root}/${node}.status" 2>/dev/null || true)" == immutable ]] || {
@@ -356,7 +358,7 @@ activate_node() (
   printf 'ready\n' > "${status_root}/${node}.status"
 )
 
-for node in dmit netcup; do
+for node in dmit bero; do
   echo "[${node}] activating generation ${PUB_GENERATION}"
   activate_node "${node}"
   [[ "$(cat "${status_root}/${node}.status" 2>/dev/null || true)" == ready ]] || {
@@ -373,8 +375,8 @@ jq -n \
   --arg verifiedAt "${verified_at}" \
   --arg probePath "${probe_path}" --argjson probeSize "${probe_size}" --arg probeSha256 "${probe_sha}" \
   --arg dmitBase "$(node_value dmit BASE_URL)" \
-  --arg netcupBase "$(node_value netcup BASE_URL)" \
-  '{schemaVersion:1,channel:$channel,generation:$generation,appTag:$appTag,driverTag:$driverTag,verifiedAt:$verifiedAt,probePath:$probePath,probeSize:$probeSize,probeSha256:$probeSha256,nodes:{dmit:{baseUrl:$dmitBase,enabled:true},netcup:{baseUrl:$netcupBase,enabled:true}}}' \
+  --arg beroBase "$(node_value bero BASE_URL)" \
+  '{schemaVersion:1,channel:$channel,generation:$generation,appTag:$appTag,driverTag:$driverTag,verifiedAt:$verifiedAt,probePath:$probePath,probeSize:$probeSize,probeSha256:$probeSha256,nodes:{dmit:{baseUrl:$dmitBase,enabled:true},bero:{baseUrl:$beroBase,enabled:true}}}' \
   > "${control_file}"
 
 put_kv_control() {
@@ -404,4 +406,4 @@ put_kv_control() {
 put_kv_control "control:history:${PUB_CHANNEL}:${PUB_GENERATION}" "${control_file}"
 put_kv_control "control:${PUB_CHANNEL}" "${control_file}"
 
-echo "Published generation ${PUB_GENERATION}: dmit=true netcup=true"
+echo "Published generation ${PUB_GENERATION}: dmit=true bero=true"


### PR DESCRIPTION
将下载发布拓扑调整为 DMIT -> Bero -> GitHub：Bero 固定为 94.103.173.47:37167，公网回退走 Cloudflare 代理的 origin-download.syngnat.top:8443。旧 KV 的 netcup 节点在 Bero 首次发布前显式禁用，避免迁移窗口误路由。