### PR TITLE
fix(sync): 阻止未知批写结果重试

### DIFF
--- a/internal/app/data_sync_job_executor.go
+++ b/internal/app/data_sync_job_executor.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"GoNavi-Wails/internal/db"
 	syncbackend "GoNavi-Wails/internal/sync"
 	"GoNavi-Wails/internal/syncjob"
 )
@@ -288,6 +289,9 @@ func (executor appDataSyncJobExecutor) executeWatermarkMappingWithRetry(
 			return outcome, nil
 		}
 		runErr := errors.New(result.Message)
+		if result.OutcomeUnknown {
+			return syncjob.ExecutionOutcome{Resumable: false}, db.MarkWriteOutcomeUnknown(runErr)
+		}
 		if result.Cancelled || ctx.Err() != nil || attempt == maxAttempts {
 			if ctx.Err() != nil {
 				return outcome, ctx.Err()
@@ -485,9 +489,12 @@ func (executor appDataSyncJobExecutor) executeOneMapping(ctx context.Context, ru
 		RowsDeleted:  int64(result.RowsDeleted),
 		RowsFailed:   int64(result.RowsSkipped),
 		Message:      result.Message,
-		Resumable:    !result.Success && !strings.EqualFold(strings.TrimSpace(config.Mode), "insert_only"),
+		Resumable:    !result.Success && !result.OutcomeUnknown && !strings.EqualFold(strings.TrimSpace(config.Mode), "insert_only"),
 	}
 	if !result.Success {
+		if result.OutcomeUnknown {
+			return outcome, db.MarkWriteOutcomeUnknown(errors.New(result.Message))
+		}
 		if result.Cancelled && ctx.Err() != nil {
 			return outcome, ctx.Err()
 		}

--- a/internal/app/data_sync_job_executor_cdc.go
+++ b/internal/app/data_sync_job_executor_cdc.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"strings"
 
+	"GoNavi-Wails/internal/db"
 	syncbackend "GoNavi-Wails/internal/sync"
 	"GoNavi-Wails/internal/synccdc"
 	"GoNavi-Wails/internal/syncjob"
@@ -134,6 +135,10 @@ func (executor appDataSyncJobExecutor) executeCDCJob(
 			outcome.RowsDeleted += int64(result.RowsDeleted)
 			outcome.RowsFailed += int64(result.EventsSkipped)
 			if !result.Success {
+				if result.OutcomeUnknown {
+					outcome.Resumable = false
+					return outcome, db.MarkWriteOutcomeUnknown(errors.New(result.Message))
+				}
 				if result.Cancelled && ctx.Err() != nil {
 					return outcome, ctx.Err()
 				}

--- a/internal/app/data_sync_job_executor_cdc_test.go
+++ b/internal/app/data_sync_job_executor_cdc_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"GoNavi-Wails/internal/connection"
+	"GoNavi-Wails/internal/db"
 	syncbackend "GoNavi-Wails/internal/sync"
 	"GoNavi-Wails/internal/synccdc"
 	"GoNavi-Wails/internal/syncjob"
@@ -147,6 +148,56 @@ func TestExecuteCDCJobPersistsBootstrapAndTargetCommitBeforeAcknowledge(t *testi
 	}
 	if len(reporter.checkpoints) != 3 || reporter.checkpoints[0].BatchSequence != 0 || reporter.checkpoints[1].BatchSequence != 1 || reporter.checkpoints[2].BatchSequence != 2 {
 		t.Fatalf("checkpoints = %#v", reporter.checkpoints)
+	}
+}
+
+func TestExecuteCDCJobDoesNotCheckpointOrAcknowledgeUnknownWrite(t *testing.T) {
+	steps := make([]string, 0, 10)
+	position0 := synccdc.Position{Adapter: "executor-test-cdc", Opaque: json.RawMessage(`{"offset":0}`)}
+	position1 := synccdc.Position{Adapter: "executor-test-cdc", Opaque: json.RawMessage(`{"offset":1}`)}
+	stream := &executorTestCDCStream{steps: &steps, transactions: []synccdc.Transaction{{
+		Events: []synccdc.Event{{
+			Object: synccdc.ObjectRef{Database: "source", Name: "events"}, Operation: "insert",
+			Key: map[string]interface{}{"id": int64(1)}, After: map[string]interface{}{"id": int64(1)}, CommitTime: time.Now(),
+		}},
+		Position: position1,
+	}}}
+	adapter := &executorTestCDCAdapter{position: position0, stream: stream, steps: &steps}
+	registry := synccdc.NewRegistry()
+	if err := registry.Register(adapter); err != nil {
+		t.Fatalf("register adapter: %v", err)
+	}
+	application := NewApp()
+	application.dataSyncCDCRegistry = registry
+	application.dataSyncChangeEventRunner = func(context.Context, syncbackend.ChangeEventRequest) syncbackend.ChangeEventResult {
+		steps = append(steps, "apply")
+		return syncbackend.ChangeEventResult{Success: false, OutcomeUnknown: true, Message: "write response lost"}
+	}
+	executor := appDataSyncJobExecutor{app: application}
+	source := resolvedDataSyncJobEndpoint{Config: connection.ConnectionConfig{Type: "executor-test-source"}, Database: "source"}
+	target := resolvedDataSyncJobEndpoint{Config: connection.ConnectionConfig{Type: "mysql"}, Database: "target"}
+	definition := syncjob.JobDefinition{
+		ID: "job-unknown", Revision: 1, Kind: syncjob.JobKindReconcile, IncrementalMode: syncjob.IncrementalCDC,
+		CDC:     &syncjob.CDCSpec{Adapter: adapter.Name(), StartPosition: "latest"},
+		Options: syncjob.ExecutionOptions{BatchSize: 100, SyncMode: "insert_update", TargetTableStrategy: "existing_only", ErrorPolicy: syncjob.ErrorPolicyStop},
+		Mappings: []syncjob.TableMapping{{
+			SourceTable: "events", TargetTable: "events", KeyColumns: []string{"id"}, Enabled: true,
+			Columns: []syncjob.ColumnMapping{{Source: "id", Target: "id"}},
+		}},
+	}
+	reporter := &executorTestReporter{steps: &steps}
+	outcome, err := executor.executeCDCJob(context.Background(), syncjob.ExecutionRequest{Run: syncjob.RunRecord{ID: "run-unknown"}, Definition: definition}, definition, definition.Mappings, source, target, reporter)
+	if !db.IsWriteOutcomeUnknown(err) {
+		t.Fatalf("executeCDCJob error = %v, want unknown write outcome", err)
+	}
+	if outcome.Resumable {
+		t.Fatalf("outcome = %#v, unknown write must not be resumable", outcome)
+	}
+	if len(reporter.checkpoints) != 1 || reporter.checkpoints[0].Phase != "stream_initialized" {
+		t.Fatalf("checkpoints = %#v, want only bootstrap checkpoint", reporter.checkpoints)
+	}
+	if got := strings.Join(steps, ","); got != "barrier,save:stream_initialized,open,next,apply,close" {
+		t.Fatalf("execution order = %s, want no transaction checkpoint or acknowledge", got)
 	}
 }
 

--- a/internal/db/batch_insert.go
+++ b/internal/db/batch_insert.go
@@ -296,10 +296,14 @@ func execLiteralInsertBatch(config literalInsertConfig, rows []preparedInsertRow
 	)
 	res, err := config.Exec(query)
 	if err != nil {
-		return localizedDatabaseRuntimeError("db.backend.error.batch_insert_failed_with_sql", map[string]any{
+		resultErr := localizedDatabaseRuntimeError("db.backend.error.batch_insert_failed_with_sql", map[string]any{
 			"detail": err.Error(),
 			"sql":    query,
 		})
+		if IsAmbiguousWriteResponse(err) {
+			return MarkWriteOutcomeUnknown(resultErr)
+		}
+		return resultErr
 	}
 	if config.RequireAffected {
 		if err := requireInsertAffected(res); err != nil {

--- a/internal/db/batch_insert_test.go
+++ b/internal/db/batch_insert_test.go
@@ -5,10 +5,27 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
+
 	"GoNavi-Wails/shared/i18n"
 )
+
+func TestExecLiteralInsertBatchesMarksLostResponseOutcomeUnknown(t *testing.T) {
+	err := execLiteralInsertBatches(literalInsertConfig{
+		Table:       `"events"`,
+		Rows:        []map[string]interface{}{{"id": 1}},
+		QuoteColumn: func(column string) string { return `"` + column + `"` },
+		Literal:     func(value interface{}) string { return fmt.Sprintf("%v", value) },
+		Exec: func(string) (sql.Result, error) {
+			return nil, io.ErrUnexpectedEOF
+		},
+	})
+	if !IsWriteOutcomeUnknown(err) {
+		t.Fatalf("lost literal insert response must be outcome unknown, got %v", err)
+	}
+}
 
 func TestExecParameterizedInsertBatchesGroupsRowsByColumnSet(t *testing.T) {
 	t.Parallel()
@@ -428,8 +445,6 @@ func TestBatchInsertErrorsUseCurrentLanguage(t *testing.T) {
 		})
 	}
 }
-
-
 func TestBatchInsertErrorCatalogKeysExist(t *testing.T) {
 	catalogs, err := i18n.LoadCatalogs()
 	if err != nil {

--- a/internal/db/clickhouse_impl.go
+++ b/internal/db/clickhouse_impl.go
@@ -1429,10 +1429,14 @@ func (c *ClickHouseDB) ApplyChanges(tableName string, changes connection.ChangeS
 		}
 		query := fmt.Sprintf("ALTER TABLE %s DELETE WHERE %s", qualifiedTable, whereExpr)
 		if _, err := c.Exec(query); err != nil {
-			return localizedDatabaseRuntimeError("db.backend.error.clickhouse_delete_failed_with_sql", map[string]any{
+			resultErr := localizedDatabaseRuntimeError("db.backend.error.clickhouse_delete_failed_with_sql", map[string]any{
 				"detail": err.Error(),
 				"sql":    query,
 			})
+			if IsAmbiguousWriteResponse(err) {
+				return MarkWriteOutcomeUnknown(resultErr)
+			}
+			return resultErr
 		}
 	}
 
@@ -1444,10 +1448,14 @@ func (c *ClickHouseDB) ApplyChanges(tableName string, changes connection.ChangeS
 		}
 		query := fmt.Sprintf("ALTER TABLE %s UPDATE %s WHERE %s", qualifiedTable, setExpr, whereExpr)
 		if _, err := c.Exec(query); err != nil {
-			return localizedDatabaseRuntimeError("db.backend.error.clickhouse_update_failed_with_sql", map[string]any{
+			resultErr := localizedDatabaseRuntimeError("db.backend.error.clickhouse_update_failed_with_sql", map[string]any{
 				"detail": err.Error(),
 				"sql":    query,
 			})
+			if IsAmbiguousWriteResponse(err) {
+				return MarkWriteOutcomeUnknown(resultErr)
+			}
+			return resultErr
 		}
 	}
 

--- a/internal/db/clickhouse_impl_test.go
+++ b/internal/db/clickhouse_impl_test.go
@@ -232,7 +232,6 @@ func TestClickHouseCreateStatementNotFoundUsesCurrentLanguage(t *testing.T) {
 	}
 }
 
-
 func TestClickHouseApplyChangesErrorsUseCurrentLanguage(t *testing.T) {
 	SetBackendLanguage(i18n.LanguageEnUS)
 	t.Cleanup(func() {
@@ -314,6 +313,58 @@ func TestClickHouseApplyChangesErrorsUseCurrentLanguage(t *testing.T) {
 	}
 }
 
+func TestClickHouseApplyChangesMarksAmbiguousMutationOutcomeUnknown(t *testing.T) {
+	registerFakeClickHouseDriverOnce.Do(func() {
+		sql.Register(fakeClickHouseDriverName, fakeClickHouseDriver{})
+	})
+
+	tests := []struct {
+		name    string
+		changes connection.ChangeSet
+		wantSQL string
+	}{
+		{
+			name:    "delete",
+			changes: connection.ChangeSet{Deletes: []map[string]interface{}{{"id": int64(42)}}},
+			wantSQL: "ALTER TABLE `analytics`.`orders` DELETE",
+		},
+		{
+			name: "update",
+			changes: connection.ChangeSet{Updates: []connection.UpdateRow{{
+				Keys: map[string]interface{}{"id": int64(42)}, Values: map[string]interface{}{"name": "Alice"},
+			}}},
+			wantSQL: "ALTER TABLE `analytics`.`orders` UPDATE",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			conn, err := sql.Open(fakeClickHouseDriverName, "")
+			if err != nil {
+				t.Fatalf("open fake clickhouse db: %v", err)
+			}
+			t.Cleanup(func() { _ = conn.Close() })
+
+			fakeClickHouseStateMu.Lock()
+			fakeClickHouseState.execErr = io.ErrUnexpectedEOF
+			fakeClickHouseState.lastExec = ""
+			fakeClickHouseState.execQueries = nil
+			fakeClickHouseStateMu.Unlock()
+
+			err = (&ClickHouseDB{conn: conn, database: "analytics"}).ApplyChanges("orders", testCase.changes)
+			if !IsWriteOutcomeUnknown(err) || !errors.Is(err, io.ErrUnexpectedEOF) {
+				t.Fatalf("ambiguous ClickHouse mutation must mark outcome unknown, got %v", err)
+			}
+			fakeClickHouseStateMu.Lock()
+			query := fakeClickHouseState.lastExec
+			fakeClickHouseStateMu.Unlock()
+			if !strings.Contains(query, testCase.wantSQL) {
+				t.Fatalf("executed SQL = %q, want %q", query, testCase.wantSQL)
+			}
+		})
+	}
+}
+
 func TestClickHouseTableNameRequiredUsesCurrentLanguage(t *testing.T) {
 	SetBackendLanguage(i18n.LanguageEnUS)
 	t.Cleanup(func() {
@@ -332,7 +383,6 @@ func TestClickHouseTableNameRequiredUsesCurrentLanguage(t *testing.T) {
 		t.Fatalf("expected no raw Chinese table-name-required text, got %q", err.Error())
 	}
 }
-
 
 func TestClickHouseApplyChangesCatalogKeysExist(t *testing.T) {
 	catalogs, err := i18n.LoadCatalogs()
@@ -636,7 +686,6 @@ func TestClickHouseConnectFailureSummaryUsesCurrentLanguage(t *testing.T) {
 		t.Fatalf("expected no Chinese auto summary, got %q", auto)
 	}
 }
-
 
 func TestClickHouseProtocolFailureCatalogKeysExist(t *testing.T) {
 	catalogs, err := i18n.LoadCatalogs()

--- a/internal/db/custom_impl.go
+++ b/internal/db/custom_impl.go
@@ -419,10 +419,15 @@ func (c *CustomDB) ApplyChanges(tableName string, changes connection.ChangeSet) 
 		return localizedDatabaseRuntimeError("db.backend.error.connection_not_open", nil)
 	}
 
-	tx, err := c.conn.Begin()
+	conn, tx, err := beginPinnedWriteTransaction(c.conn)
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if conn != nil {
+			_ = conn.Close()
+		}
+	}()
 	defer tx.Rollback()
 
 	driver := strings.ToLower(strings.TrimSpace(c.driver))
@@ -546,7 +551,7 @@ func (c *CustomDB) ApplyChanges(tableName string, changes connection.ChangeSet) 
 		return err
 	}
 
-	return tx.Commit()
+	return commitPinnedWriteTransaction(&conn, tx)
 }
 
 func customInsertMaxArgs(isSQLServer, isSQLite bool) int {

--- a/internal/db/duckdb_applychanges_test.go
+++ b/internal/db/duckdb_applychanges_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -13,6 +14,17 @@ import (
 
 	"GoNavi-Wails/internal/connection"
 )
+
+func TestDuckDBApplyChangesMarksCommitFailureOutcomeUnknown(t *testing.T) {
+	commitErr := errors.New("commit response lost")
+	database := openWriteOutcomeTransactionDB(t, &writeOutcomeTransactionState{commitErr: commitErr})
+	err := (&DuckDB{conn: database}).ApplyChanges("users", connection.ChangeSet{
+		Deletes: []map[string]interface{}{{"id": int64(1)}},
+	})
+	if !IsWriteOutcomeUnknown(err) || !errors.Is(err, commitErr) {
+		t.Fatalf("commit error must be outcome unknown, got %v", err)
+	}
+}
 
 const duckdbRecordingDriverName = "gonavi_duckdb_recording"
 

--- a/internal/db/duckdb_impl.go
+++ b/internal/db/duckdb_impl.go
@@ -432,10 +432,15 @@ func (d *DuckDB) ApplyChanges(tableName string, changes connection.ChangeSet) er
 		return duckDBConnectionNotOpenError()
 	}
 
-	tx, err := d.conn.Begin()
+	conn, tx, err := beginPinnedWriteTransaction(d.conn)
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if conn != nil {
+			_ = conn.Close()
+		}
+	}()
 	defer tx.Rollback()
 
 	quoteIdent := func(name string) string {
@@ -520,5 +525,5 @@ func (d *DuckDB) ApplyChanges(tableName string, changes connection.ChangeSet) er
 		return err
 	}
 
-	return tx.Commit()
+	return commitPinnedWriteTransaction(&conn, tx)
 }

--- a/internal/db/duckdb_pool_integration_test.go
+++ b/internal/db/duckdb_pool_integration_test.go
@@ -22,7 +22,7 @@ func TestDuckDBConnectConfiguresBoundedPool(t *testing.T) {
 	if got := client.conn.Stats().MaxOpenConnections; got != duckDBSQLMaxOpenConns {
 		t.Fatalf("expected max open connections %d, got %d", duckDBSQLMaxOpenConns, got)
 	}
-	if _, err := client.Query("SELECT 1"); err != nil {
+	if _, _, err := client.Query("SELECT 1"); err != nil {
 		t.Fatalf("query failed: %v", err)
 	}
 	stats := client.conn.Stats()

--- a/internal/db/write_outcome.go
+++ b/internal/db/write_outcome.go
@@ -101,3 +101,29 @@ func commitWriteTransaction(tx *sql.Tx) error {
 	}
 	return nil
 }
+
+// beginPinnedWriteTransaction keeps the physical connection available until a
+// commit outcome is known, so an ambiguous commit can evict that connection.
+func beginPinnedWriteTransaction(database *sql.DB) (*sql.Conn, *sql.Tx, error) {
+	conn, err := database.Conn(context.Background())
+	if err != nil {
+		return nil, nil, err
+	}
+	tx, err := conn.BeginTx(context.Background(), nil)
+	if err != nil {
+		_ = conn.Close()
+		return nil, nil, err
+	}
+	return conn, tx, nil
+}
+
+func commitPinnedWriteTransaction(connRef **sql.Conn, tx *sql.Tx) error {
+	err := commitWriteTransaction(tx)
+	if !IsWriteOutcomeUnknown(err) {
+		return err
+	}
+	if discardErr := discardSQLConn(connRef); discardErr != nil {
+		return errors.Join(err, fmt.Errorf("事务连接丢弃失败：%w", discardErr))
+	}
+	return err
+}

--- a/internal/db/write_outcome_transaction_test.go
+++ b/internal/db/write_outcome_transaction_test.go
@@ -32,6 +32,7 @@ type writeOutcomeTransactionState struct {
 	rollbackErr error
 	commits     int
 	rollbacks   int
+	closes      int
 }
 
 type writeOutcomeTransactionDriver struct{}
@@ -54,7 +55,12 @@ func (*writeOutcomeTransactionConn) Prepare(string) (driver.Stmt, error) {
 	return nil, driver.ErrSkip
 }
 
-func (*writeOutcomeTransactionConn) Close() error { return nil }
+func (conn *writeOutcomeTransactionConn) Close() error {
+	conn.state.mu.Lock()
+	defer conn.state.mu.Unlock()
+	conn.state.closes++
+	return nil
+}
 
 func (conn *writeOutcomeTransactionConn) Begin() (driver.Tx, error) {
 	return &writeOutcomeTransactionTx{state: conn.state}, nil
@@ -125,6 +131,32 @@ func TestPostgresApplyChangesMarksCommitFailureOutcomeUnknown(t *testing.T) {
 	})
 	if !IsWriteOutcomeUnknown(err) || !errors.Is(err, commitErr) {
 		t.Fatalf("commit error must preserve its cause and mark the outcome unknown, got %v", err)
+	}
+}
+
+func TestLegacyTransactionApplyChangesMarksCommitFailureOutcomeUnknown(t *testing.T) {
+	for name, apply := range map[string]func(*sql.DB) error{
+		"custom": func(database *sql.DB) error {
+			return (&CustomDB{conn: database, driver: "mysql"}).ApplyChanges("users", connection.ChangeSet{
+				Deletes: []map[string]interface{}{{"id": int64(1)}},
+			})
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			commitErr := errors.New("commit response lost")
+			state := &writeOutcomeTransactionState{commitErr: commitErr}
+			database := openWriteOutcomeTransactionDB(t, state)
+			err := apply(database)
+			if !IsWriteOutcomeUnknown(err) || !errors.Is(err, commitErr) {
+				t.Fatalf("commit error must be outcome unknown, got %v", err)
+			}
+			state.mu.Lock()
+			closes := state.closes
+			state.mu.Unlock()
+			if closes != 1 {
+				t.Fatalf("ambiguous commit must discard its physical connection, closes=%d", closes)
+			}
+		})
 	}
 }
 

--- a/internal/sync/change_events.go
+++ b/internal/sync/change_events.go
@@ -59,6 +59,7 @@ type ChangeEventRequest struct {
 type ChangeEventResult struct {
 	Success        bool                  `json:"success"`
 	Cancelled      bool                  `json:"cancelled,omitempty"`
+	OutcomeUnknown bool                  `json:"outcomeUnknown,omitempty"`
 	Message        string                `json:"message,omitempty"`
 	EventsReceived int                   `json:"eventsReceived"`
 	EventsApplied  int                   `json:"eventsApplied"`
@@ -339,6 +340,10 @@ func applyChangeEventBatchWithPolicy(ctx context.Context, targetDB db.Database, 
 			result.BatchesApplied++
 		}
 		return nil
+	}
+	if db.IsWriteOutcomeUnknown(err) {
+		result.OutcomeUnknown = true
+		return err
 	}
 	if ctx.Err() != nil {
 		return ctx.Err()

--- a/internal/sync/change_events_test.go
+++ b/internal/sync/change_events_test.go
@@ -4,6 +4,7 @@ import (
 	"GoNavi-Wails/internal/connection"
 	"GoNavi-Wails/internal/db"
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -119,6 +120,40 @@ func TestRunChangeEventsContextSkipsBadRowByAtomicBatchIsolation(t *testing.T) {
 	}
 	if strings.Contains(result.Message, "customer-password-raw") || strings.Contains(fmt.Sprint(result.RowErrors), "customer-password-raw") {
 		t.Fatalf("sensitive payload leaked in result: %+v", result)
+	}
+}
+
+func TestRunChangeEventsContextDoesNotReplayUnknownWriteWithSkipRow(t *testing.T) {
+	columns := []connection.ColumnDefinition{{Name: "id", Type: "bigint", Nullable: "NO", Key: "PRI"}}
+	target := &watermarkTestDatabase{fakeMigrationDB: fakeMigrationDB{columns: map[string][]connection.ColumnDefinition{"dst.events": columns}}}
+	target.queryFunc = func(string) ([]map[string]interface{}, []string, error) { return nil, nil, nil }
+	applyCalls := 0
+	target.applyFunc = func(string, connection.ChangeSet) error {
+		applyCalls++
+		return db.MarkWriteOutcomeUnknown(errors.New("write response lost"))
+	}
+	useSyncDatabaseFactorySequence(t, syncDatabaseFactoryStep{db: target})
+	request := changeEventBaseRequest(
+		DataChangeEvent{ID: "first", Object: SyncObjectRef{Name: "events"}, Operation: ChangeEventOperationInsert, Key: map[string]interface{}{"id": int64(10)}, After: map[string]interface{}{"id": int64(10)}},
+		DataChangeEvent{ID: "second", Object: SyncObjectRef{Name: "events"}, Operation: ChangeEventOperationInsert, Key: map[string]interface{}{"id": int64(50)}, After: map[string]interface{}{"id": int64(50)}},
+	)
+	request.Sync.BatchSize = 2
+	request.RowErrorPolicy = RowErrorPolicySkipRow
+	callbackCalls := 0
+	request.OnRowError = func(context.Context, ChangeEventRowError) error {
+		callbackCalls++
+		return nil
+	}
+
+	result := NewSyncEngine(Reporter{}).RunChangeEventsContext(context.Background(), request)
+	if result.Success || !result.OutcomeUnknown || result.EventsApplied != 0 || result.EventsSkipped != 0 {
+		t.Fatalf("RunChangeEventsContext() = %+v, want unknown terminal failure", result)
+	}
+	if applyCalls != 1 {
+		t.Fatalf("apply calls = %d, want one unknown batch without split/replay", applyCalls)
+	}
+	if callbackCalls != 0 || len(result.RowErrors) != 0 {
+		t.Fatalf("row-error handling ran after unknown write: callbacks=%d errors=%#v", callbackCalls, result.RowErrors)
 	}
 }
 

--- a/internal/sync/snapshot_row_error.go
+++ b/internal/sync/snapshot_row_error.go
@@ -87,6 +87,12 @@ func (s *SyncEngine) applySnapshotChangesOneByOne(config SyncConfig, res *SyncRe
 			return err
 		}
 		if err := applySyncChangesContext(s.context(), applier, targetTable, change); err != nil {
+			if db.IsWriteOutcomeUnknown(err) {
+				if res != nil {
+					res.OutcomeUnknown = true
+				}
+				return err
+			}
 			if s.contextError() != nil {
 				return s.contextError()
 			}

--- a/internal/sync/snapshot_row_error_test.go
+++ b/internal/sync/snapshot_row_error_test.go
@@ -71,6 +71,46 @@ func TestRunSyncSkipRowAppliesSnapshotRowsIndividuallyFromStart(t *testing.T) {
 	}
 }
 
+func TestRunSyncSkipRowStopsOnUnknownWriteOutcome(t *testing.T) {
+	columns := []connection.ColumnDefinition{{Name: "id", Type: "bigint", Nullable: "NO", Key: "PRI"}}
+	source := &fakeMigrationDB{
+		columns: map[string][]connection.ColumnDefinition{"src.events": columns},
+		queryData: map[string][]map[string]interface{}{
+			"SELECT `id` FROM `src`.`events` ORDER BY `id` ASC LIMIT 2 OFFSET 0": {{"id": int64(1)}, {"id": int64(2)}},
+		},
+	}
+	target := &watermarkTestDatabase{fakeMigrationDB: fakeMigrationDB{columns: map[string][]connection.ColumnDefinition{"dst.events": columns}}}
+	applyCalls := 0
+	target.applyFunc = func(string, connection.ChangeSet) error {
+		applyCalls++
+		return db.MarkWriteOutcomeUnknown(errors.New("write response lost"))
+	}
+	useSyncDatabaseFactorySequence(t,
+		syncDatabaseFactoryStep{db: source},
+		syncDatabaseFactoryStep{db: target},
+	)
+	callbackCalls := 0
+	result := NewSyncEngine(Reporter{}).RunSyncContext(context.Background(), SyncConfig{
+		SourceConfig:   connection.ConnectionConfig{Type: "mysql", Database: "src"},
+		TargetConfig:   connection.ConnectionConfig{Type: "mysql", Database: "dst"},
+		Tables:         []string{"events"},
+		Content:        "data",
+		Mode:           "insert_only",
+		BatchSize:      2,
+		RowErrorPolicy: RowErrorPolicySkipRow,
+		OnRowError: func(context.Context, ChangeEventRowError) error {
+			callbackCalls++
+			return nil
+		},
+	})
+	if result.Success || !result.OutcomeUnknown || result.RowsSkipped != 0 {
+		t.Fatalf("RunSyncContext() = %+v, want unknown terminal failure", result)
+	}
+	if applyCalls != 1 || callbackCalls != 0 {
+		t.Fatalf("unknown write was replayed or skipped: applyCalls=%d callbackCalls=%d", applyCalls, callbackCalls)
+	}
+}
+
 func TestRunSyncSkipRowContinuesAfterSourceQueryProjectionError(t *testing.T) {
 	const sourceSQL = "SELECT external_id, raw_name FROM active_accounts"
 	source := &fakeMigrationDB{queryData: map[string][]map[string]interface{}{

--- a/internal/sync/sync_context.go
+++ b/internal/sync/sync_context.go
@@ -4,6 +4,7 @@ import (
 	"GoNavi-Wails/internal/connection"
 	"GoNavi-Wails/internal/db"
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -106,9 +107,17 @@ func applySyncChangesContext(ctx context.Context, applier db.BatchApplier, table
 		}
 	}
 	if err := applier.ApplyChanges(tableName, changes); err != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return db.MarkWriteOutcomeUnknown(errors.Join(err, contextErr))
+		}
 		return err
 	}
-	return ctx.Err()
+	if err := ctx.Err(); err != nil {
+		// A legacy applier cannot observe cancellation while the call is in
+		// flight. Its write may already have reached the target.
+		return db.MarkWriteOutcomeUnknown(err)
+	}
+	return nil
 }
 
 func executeSyncSQLStatementsContext(ctx context.Context, database db.Database, statements []string) error {

--- a/internal/sync/sync_context_test.go
+++ b/internal/sync/sync_context_test.go
@@ -1,0 +1,41 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"GoNavi-Wails/internal/connection"
+	"GoNavi-Wails/internal/db"
+)
+
+type blockingLegacyBatchApplier struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (a *blockingLegacyBatchApplier) ApplyChanges(string, connection.ChangeSet) error {
+	close(a.started)
+	<-a.release
+	return nil
+}
+
+func TestApplySyncChangesContextMarksLegacyCancellationOutcomeUnknown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	applier := &blockingLegacyBatchApplier{started: make(chan struct{}), release: make(chan struct{})}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- applySyncChangesContext(markSyncDriverContext(ctx), applier, "events", connection.ChangeSet{
+			Inserts: []map[string]interface{}{{"id": 1}},
+		})
+	}()
+
+	<-applier.started
+	cancel()
+	close(applier.release)
+	err := <-errCh
+	if !db.IsWriteOutcomeUnknown(err) || !errors.Is(err, context.Canceled) {
+		t.Fatalf("legacy apply cancellation must be outcome unknown, got %v", err)
+	}
+}

--- a/internal/sync/sync_engine.go
+++ b/internal/sync/sync_engine.go
@@ -58,15 +58,16 @@ type SyncConfig struct {
 
 // SyncResult holds the result of the sync operation
 type SyncResult struct {
-	Success      bool     `json:"success"`
-	Message      string   `json:"message"`
-	Logs         []string `json:"logs"`
-	TablesSynced int      `json:"tablesSynced"`
-	RowsInserted int      `json:"rowsInserted"`
-	RowsUpdated  int      `json:"rowsUpdated"`
-	RowsDeleted  int      `json:"rowsDeleted"`
-	RowsSkipped  int      `json:"rowsSkipped,omitempty"`
-	Cancelled    bool     `json:"cancelled,omitempty"`
+	Success        bool     `json:"success"`
+	Message        string   `json:"message"`
+	Logs           []string `json:"logs"`
+	TablesSynced   int      `json:"tablesSynced"`
+	RowsInserted   int      `json:"rowsInserted"`
+	RowsUpdated    int      `json:"rowsUpdated"`
+	RowsDeleted    int      `json:"rowsDeleted"`
+	RowsSkipped    int      `json:"rowsSkipped,omitempty"`
+	Cancelled      bool     `json:"cancelled,omitempty"`
+	OutcomeUnknown bool     `json:"outcomeUnknown,omitempty"`
 }
 
 type SyncEngine struct {
@@ -783,6 +784,9 @@ func (s *SyncEngine) applyChangesInBatches(jobID string, res *SyncResult, tableN
 				idx+1, len(batches), len(batch.Inserts), len(batch.Updates), len(batch.Deletes)))
 		}
 		if err := applySyncChangesContext(s.context(), applier, tableName, batch); err != nil {
+			if db.IsWriteOutcomeUnknown(err) {
+				res.OutcomeUnknown = true
+			}
 			if len(batches) > 1 {
 				if applied.total() > 0 {
 					return applied, fmt.Errorf(

--- a/internal/sync/watermark_sync.go
+++ b/internal/sync/watermark_sync.go
@@ -75,6 +75,7 @@ type WatermarkSyncResult struct {
 	Success           bool             `json:"success"`
 	Message           string           `json:"message,omitempty"`
 	Cancelled         bool             `json:"cancelled,omitempty"`
+	OutcomeUnknown    bool             `json:"outcomeUnknown,omitempty"`
 	SourceRowsRead    int              `json:"sourceRowsRead"`
 	RowsInserted      int              `json:"rowsInserted"`
 	RowsUpdated       int              `json:"rowsUpdated"`
@@ -235,6 +236,7 @@ func (s *SyncEngine) RunWatermarkSync(ctx context.Context, request WatermarkSync
 		if batchInserted > 0 || batchUpdated > 0 {
 			if err := applySyncChangesContext(runCtx, applier, plan.applyTableName, changeSet); err != nil {
 				result.Cursor = cloneWatermarkCursor(durableCursor)
+				result.OutcomeUnknown = db.IsWriteOutcomeUnknown(err)
 				return failWatermarkSync(result, runCtx, fmt.Errorf("应用 watermark 目标批次失败: %w", err))
 			}
 			result.RowsInserted += batchInserted


### PR DESCRIPTION
## 背景
批写在取消、响应断链或 Commit 失败后可能处于未知状态；此前部分同步重试和 checkpoint 路径会把它当作普通失败处理。

## 修改
- 统一传播未知写入结果，禁止 CDC、snapshot 和 watermark 路径重放或推进不确定 checkpoint。
- 断链 Commit 使用 pinned connection，并在结果未知时逐出连接。
- ClickHouse INSERT、UPDATE、DELETE 的断链统一标记为未知结果。
- 修复 DuckDB 标签测试与 Query 当前返回值签名不匹配的编译问题。

## 验证
- `go test ./internal/sync ./internal/db -run 'Test.*(ApplyChanges|Cancel|Unknown)' -count=1`
- `go test ./internal/sync ./internal/db -count=1 -timeout=10m`
- `go test -tags gonavi_duckdb_driver ./internal/db -run '^$' -count=1`

## 关联
Closes #960