### PR TITLE
fix(mcp): cancel metadata database reads

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -171,6 +171,7 @@ type App struct {
 	connectFailures               map[string]cachedConnectFailure
 	dbConnectGroup                singleflight.Group
 	dbConnectFlights              map[uint64]*databaseConnectFlight
+	metadataSession               *metadataSession
 	nextDBConnectFlightID         uint64
 	dbShuttingDown                bool
 	dbConnectBeforeForgetHook     func()       // Test seam for release/singleflight ordering.
@@ -1278,12 +1279,33 @@ func formatConnSummary(config connection.ConnectionConfig) string {
 }
 
 func (a *App) getDatabaseForcePing(config connection.ConnectionConfig) (db.Database, error) {
-	return a.getDatabaseWithPing(config, true)
+	if a != nil && a.metadataSession != nil {
+		instance, err := a.getDatabaseWithContext(a.metadataSession.ctx, config, true)
+		a.bindMetadataDatabase(instance)
+		return instance, err
+	}
+	instance, err := a.getDatabaseWithPing(config, true)
+	a.bindMetadataDatabase(instance)
+	return instance, err
 }
 
 // Helper: Get or create a database connection
 func (a *App) getDatabase(config connection.ConnectionConfig) (db.Database, error) {
-	return a.getDatabaseWithPing(config, false)
+	if a != nil && a.metadataSession != nil {
+		instance, err := a.getDatabaseWithContext(a.metadataSession.ctx, config, false)
+		a.bindMetadataDatabase(instance)
+		return instance, err
+	}
+	instance, err := a.getDatabaseWithPing(config, false)
+	a.bindMetadataDatabase(instance)
+	return instance, err
+}
+
+func (a *App) bindMetadataDatabase(instance db.Database) {
+	if a == nil || a.metadataSession == nil || instance == nil {
+		return
+	}
+	a.metadataSession.bindDatabase(instance)
 }
 
 type databaseWaitResult struct {

--- a/internal/app/methods_db_metadata_context.go
+++ b/internal/app/methods_db_metadata_context.go
@@ -1,0 +1,216 @@
+package app
+
+import (
+	"context"
+	"sync"
+
+	"GoNavi-Wails/internal/connection"
+	"GoNavi-Wails/internal/db"
+	redisbackend "GoNavi-Wails/internal/redis"
+)
+
+// metadataSession 仅持有一个 MCP 元数据请求的资源。
+// Close 只会在执行请求的协程、元数据方法返回后调用，避免与运行中的查询并发关闭驱动。
+type metadataSession struct {
+	app *App
+	ctx context.Context
+
+	closeOnce sync.Once
+	mu        sync.Mutex
+	closed    bool
+	databases []db.Database
+	redis     []redisbackend.RedisClient
+}
+
+type metadataRedisOpenResult struct {
+	client redisbackend.RedisClient
+	err    error
+}
+
+func newMetadataSession(owner *App, ctx context.Context) *metadataSession {
+	if owner == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	sessionApp := NewAppWithSecretStore(owner.secretStore)
+	sessionApp.ctx = owner.ctx
+	sessionApp.webRuntime = owner.webRuntime
+	sessionApp.headlessRuntime = owner.headlessRuntime
+	sessionApp.startedAt = owner.startedAt
+	sessionApp.configDir = owner.configDir
+	owner.i18nMu.RLock()
+	sessionApp.localizer = owner.localizer
+	owner.i18nMu.RUnlock()
+
+	session := &metadataSession{app: sessionApp, ctx: ctx}
+	sessionApp.metadataSession = session
+	return session
+}
+
+func (s *metadataSession) bindDatabase(database db.Database) {
+	if s == nil || database == nil {
+		return
+	}
+	db.BindMetadataContext(database, s.ctx)
+	s.mu.Lock()
+	s.databases = append(s.databases, database)
+	s.mu.Unlock()
+}
+
+func (s *metadataSession) bindRedisClient(client redisbackend.RedisClient) bool {
+	if s == nil || client == nil {
+		return false
+	}
+	redisbackend.BindMetadataContext(client, s.ctx)
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		redisbackend.ClearMetadataContext(client)
+		return false
+	}
+	s.redis = append(s.redis, client)
+	s.mu.Unlock()
+	return true
+}
+
+func (s *metadataSession) openRedisClient(config connection.ConnectionConfig) (redisbackend.RedisClient, error) {
+	if s == nil || s.app == nil {
+		return nil, context.Canceled
+	}
+	if err := s.ctx.Err(); err != nil {
+		return nil, err
+	}
+	resultCh := make(chan metadataRedisOpenResult, 1)
+	go func() {
+		client, err := s.app.openRedisClientIsolated(config)
+		if err == nil && client != nil && !s.bindRedisClient(client) {
+			_ = client.Close()
+			if ctxErr := s.ctx.Err(); ctxErr != nil {
+				err = ctxErr
+			} else {
+				err = context.Canceled
+			}
+			client = nil
+		}
+		resultCh <- metadataRedisOpenResult{client: client, err: err}
+	}()
+
+	var result metadataRedisOpenResult
+	select {
+	case <-s.ctx.Done():
+		return nil, s.ctx.Err()
+	case result = <-resultCh:
+	}
+	if result.err != nil {
+		return nil, result.err
+	}
+	if err := s.ctx.Err(); err != nil {
+		return nil, err
+	}
+	return result.client, nil
+}
+
+func (s *metadataSession) Close() {
+	if s == nil || s.app == nil {
+		return
+	}
+	s.closeOnce.Do(func() {
+		s.mu.Lock()
+		s.closed = true
+		databases := append([]db.Database(nil), s.databases...)
+		clients := append([]redisbackend.RedisClient(nil), s.redis...)
+		s.databases = nil
+		s.redis = nil
+		s.mu.Unlock()
+
+		for _, database := range databases {
+			db.ClearMetadataContext(database)
+		}
+		for _, client := range clients {
+			redisbackend.ClearMetadataContext(client)
+		}
+		s.app.beginDatabaseShutdown()
+		s.app.closeCachedDatabasesForShutdown()
+		for _, client := range clients {
+			if client != nil {
+				_ = client.Close()
+			}
+		}
+	})
+}
+
+func (a *App) runMetadataWithContext(ctx context.Context, operation func(*App) connection.QueryResult) connection.QueryResult {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+
+	session := newMetadataSession(a, ctx)
+	if session == nil {
+		return connection.QueryResult{Success: false, Message: "元数据会话不可用"}
+	}
+
+	resultCh := make(chan connection.QueryResult, 1)
+	go func() {
+		result := operation(session.app)
+		session.Close()
+		resultCh <- result
+	}()
+
+	select {
+	case result := <-resultCh:
+		if err := ctx.Err(); err != nil {
+			return connection.QueryResult{Success: false, Message: err.Error()}
+		}
+		return result
+	case <-ctx.Done():
+		// 不在此处关闭：Database 未承诺 Close 可与 Query 并发执行。
+		// Query 会收到 ctx，工作协程只在查询返回后关闭资源。
+		return connection.QueryResult{Success: false, Message: ctx.Err().Error()}
+	}
+}
+
+func (a *App) DBGetDatabasesContext(ctx context.Context, config connection.ConnectionConfig) connection.QueryResult {
+	return a.runMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetDatabases(config) })
+}
+
+func (a *App) DBGetTablesContext(ctx context.Context, config connection.ConnectionConfig, dbName string) connection.QueryResult {
+	return a.runMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetTables(config, dbName) })
+}
+
+func (a *App) DBGetViewsContext(ctx context.Context, config connection.ConnectionConfig, dbName string) connection.QueryResult {
+	return a.runMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetViews(config, dbName) })
+}
+
+func (a *App) DBGetObjectsContext(ctx context.Context, config connection.ConnectionConfig, dbName string) connection.QueryResult {
+	return a.runMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetObjects(config, dbName) })
+}
+
+func (a *App) DBGetAllColumnsContext(ctx context.Context, config connection.ConnectionConfig, dbName string) connection.QueryResult {
+	return a.runMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetAllColumns(config, dbName) })
+}
+
+func (a *App) DBGetColumnsContext(ctx context.Context, config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
+	return a.runMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetColumns(config, dbName, tableName) })
+}
+
+func (a *App) DBGetIndexesContext(ctx context.Context, config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
+	return a.runMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetIndexes(config, dbName, tableName) })
+}
+
+func (a *App) DBGetForeignKeysContext(ctx context.Context, config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
+	return a.runMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetForeignKeys(config, dbName, tableName) })
+}
+
+func (a *App) DBGetTriggersContext(ctx context.Context, config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
+	return a.runMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetTriggers(config, dbName, tableName) })
+}
+
+func (a *App) DBShowCreateTableContext(ctx context.Context, config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
+	return a.runMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBShowCreateTable(config, dbName, tableName) })
+}

--- a/internal/app/methods_db_metadata_context_test.go
+++ b/internal/app/methods_db_metadata_context_test.go
@@ -1,0 +1,449 @@
+package app
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"GoNavi-Wails/internal/connection"
+	"GoNavi-Wails/internal/db"
+	redisbackend "GoNavi-Wails/internal/redis"
+)
+
+type contextAwareMetadataDB struct {
+	started   chan context.Context
+	done      chan struct{}
+	release   chan struct{}
+	closeDone chan struct{}
+
+	doneOnce   sync.Once
+	closeOnce  sync.Once
+	closeCalls atomic.Int32
+}
+
+func newContextAwareMetadataDB() *contextAwareMetadataDB {
+	return &contextAwareMetadataDB{
+		started:   make(chan context.Context, 1),
+		done:      make(chan struct{}),
+		release:   make(chan struct{}),
+		closeDone: make(chan struct{}),
+	}
+}
+
+func (f *contextAwareMetadataDB) Connect(connection.ConnectionConfig) error { return nil }
+func (f *contextAwareMetadataDB) Close() error {
+	select {
+	case <-f.done:
+	default:
+		panic("查询尚未退出即关闭数据库")
+	}
+	f.closeCalls.Add(1)
+	f.closeOnce.Do(func() { close(f.closeDone) })
+	return nil
+}
+func (f *contextAwareMetadataDB) Ping() error { return nil }
+func (f *contextAwareMetadataDB) Query(string) ([]map[string]interface{}, []string, error) {
+	ctx := db.MetadataContext(f)
+	f.started <- ctx
+	select {
+	case <-ctx.Done():
+		f.doneOnce.Do(func() { close(f.done) })
+		return nil, nil, ctx.Err()
+	case <-f.release:
+		f.doneOnce.Do(func() { close(f.done) })
+		return []map[string]interface{}{{"name": "orders"}}, []string{"name"}, nil
+	}
+}
+func (f *contextAwareMetadataDB) Exec(string) (int64, error)      { return 0, nil }
+func (f *contextAwareMetadataDB) GetDatabases() ([]string, error) { return nil, nil }
+func (f *contextAwareMetadataDB) GetTables(string) ([]string, error) {
+	_, _, err := f.Query("metadata tables")
+	if err != nil {
+		return nil, err
+	}
+	return []string{"orders"}, nil
+}
+func (f *contextAwareMetadataDB) GetCreateStatement(string, string) (string, error) { return "", nil }
+func (f *contextAwareMetadataDB) GetColumns(string, string) ([]connection.ColumnDefinition, error) {
+	_, _, err := f.Query("metadata columns")
+	if err != nil {
+		return nil, err
+	}
+	return []connection.ColumnDefinition{{Name: "id", Type: "bigint"}}, nil
+}
+func (f *contextAwareMetadataDB) GetAllColumns(string) ([]connection.ColumnDefinitionWithTable, error) {
+	return nil, nil
+}
+func (f *contextAwareMetadataDB) GetIndexes(string, string) ([]connection.IndexDefinition, error) {
+	return nil, nil
+}
+func (f *contextAwareMetadataDB) GetForeignKeys(string, string) ([]connection.ForeignKeyDefinition, error) {
+	return nil, nil
+}
+func (f *contextAwareMetadataDB) GetTriggers(string, string) ([]connection.TriggerDefinition, error) {
+	return nil, nil
+}
+
+var _ db.Database = (*contextAwareMetadataDB)(nil)
+
+type contextAwareMetadataRedisClient struct {
+	capturingRedisClient
+	started    chan context.Context
+	done       chan struct{}
+	closeDone  chan struct{}
+	doneOnce   sync.Once
+	closeOnce  sync.Once
+	closeCalls atomic.Int32
+}
+
+func newContextAwareMetadataRedisClient() *contextAwareMetadataRedisClient {
+	return &contextAwareMetadataRedisClient{
+		started:   make(chan context.Context, 1),
+		done:      make(chan struct{}),
+		closeDone: make(chan struct{}),
+	}
+}
+
+func (c *contextAwareMetadataRedisClient) Close() error {
+	select {
+	case <-c.done:
+	default:
+		panic("Redis 扫描尚未退出即关闭客户端")
+	}
+	c.closeCalls.Add(1)
+	c.closeOnce.Do(func() { close(c.closeDone) })
+	return nil
+}
+
+func (c *contextAwareMetadataRedisClient) ScanKeys(string, uint64, int64) (*redisbackend.RedisScanResult, error) {
+	ctx := redisbackend.MetadataContext(c)
+	c.started <- ctx
+	<-ctx.Done()
+	c.doneOnce.Do(func() { close(c.done) })
+	return nil, ctx.Err()
+}
+
+var _ redisbackend.RedisClient = (*contextAwareMetadataRedisClient)(nil)
+
+type blockingConnectMetadataDB struct {
+	connectStarted chan struct{}
+	releaseConnect chan struct{}
+	closeDone      chan struct{}
+
+	connectOnce sync.Once
+	closeOnce   sync.Once
+	closeCalls  atomic.Int32
+}
+
+func newBlockingConnectMetadataDB() *blockingConnectMetadataDB {
+	return &blockingConnectMetadataDB{
+		connectStarted: make(chan struct{}),
+		releaseConnect: make(chan struct{}),
+		closeDone:      make(chan struct{}),
+	}
+}
+
+func (f *blockingConnectMetadataDB) Connect(connection.ConnectionConfig) error {
+	f.connectOnce.Do(func() { close(f.connectStarted) })
+	<-f.releaseConnect
+	return nil
+}
+
+func (f *blockingConnectMetadataDB) Close() error {
+	f.closeCalls.Add(1)
+	f.closeOnce.Do(func() { close(f.closeDone) })
+	return nil
+}
+
+func (f *blockingConnectMetadataDB) Ping() error { return nil }
+func (f *blockingConnectMetadataDB) Query(string) ([]map[string]interface{}, []string, error) {
+	return nil, nil, context.Canceled
+}
+func (f *blockingConnectMetadataDB) Exec(string) (int64, error)      { return 0, nil }
+func (f *blockingConnectMetadataDB) GetDatabases() ([]string, error) { return nil, nil }
+func (f *blockingConnectMetadataDB) GetTables(string) ([]string, error) {
+	return nil, context.Canceled
+}
+func (f *blockingConnectMetadataDB) GetCreateStatement(string, string) (string, error) {
+	return "", nil
+}
+func (f *blockingConnectMetadataDB) GetColumns(string, string) ([]connection.ColumnDefinition, error) {
+	return nil, nil
+}
+func (f *blockingConnectMetadataDB) GetAllColumns(string) ([]connection.ColumnDefinitionWithTable, error) {
+	return nil, nil
+}
+func (f *blockingConnectMetadataDB) GetIndexes(string, string) ([]connection.IndexDefinition, error) {
+	return nil, nil
+}
+func (f *blockingConnectMetadataDB) GetForeignKeys(string, string) ([]connection.ForeignKeyDefinition, error) {
+	return nil, nil
+}
+func (f *blockingConnectMetadataDB) GetTriggers(string, string) ([]connection.TriggerDefinition, error) {
+	return nil, nil
+}
+
+var _ db.Database = (*blockingConnectMetadataDB)(nil)
+
+type blockingConnectMetadataRedisClient struct {
+	capturingRedisClient
+	connectStarted chan struct{}
+	releaseConnect chan struct{}
+	closeDone      chan struct{}
+
+	connectOnce sync.Once
+	closeOnce   sync.Once
+	closeCalls  atomic.Int32
+	scanCalls   atomic.Int32
+}
+
+func newBlockingConnectMetadataRedisClient() *blockingConnectMetadataRedisClient {
+	return &blockingConnectMetadataRedisClient{
+		connectStarted: make(chan struct{}),
+		releaseConnect: make(chan struct{}),
+		closeDone:      make(chan struct{}),
+	}
+}
+
+func (c *blockingConnectMetadataRedisClient) Connect(connection.ConnectionConfig) error {
+	c.connectOnce.Do(func() { close(c.connectStarted) })
+	<-c.releaseConnect
+	return nil
+}
+
+func (c *blockingConnectMetadataRedisClient) Close() error {
+	c.closeCalls.Add(1)
+	c.closeOnce.Do(func() { close(c.closeDone) })
+	return nil
+}
+
+func (c *blockingConnectMetadataRedisClient) ScanKeys(string, uint64, int64) (*redisbackend.RedisScanResult, error) {
+	c.scanCalls.Add(1)
+	return nil, context.Canceled
+}
+
+var _ redisbackend.RedisClient = (*blockingConnectMetadataRedisClient)(nil)
+
+func installMetadataSessionTestHooks(t *testing.T) {
+	t.Helper()
+	installDatabaseCacheConcurrencyTestHooks(t)
+}
+
+func waitForContext(t *testing.T, contexts <-chan context.Context, message string) context.Context {
+	t.Helper()
+	select {
+	case ctx := <-contexts:
+		return ctx
+	case <-time.After(time.Second):
+		t.Fatal(message)
+		return nil
+	}
+}
+
+func waitForMetadataSignal(t *testing.T, signal <-chan struct{}, message string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(time.Second):
+		t.Fatal(message)
+	}
+}
+
+func TestMetadataContextCancellationReachesQuery(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(*App, context.Context, connection.ConnectionConfig) connection.QueryResult
+	}{
+		{
+			name: "tables",
+			call: func(application *App, ctx context.Context, config connection.ConnectionConfig) connection.QueryResult {
+				return application.DBGetTablesContext(ctx, config, "app")
+			},
+		},
+		{
+			name: "columns",
+			call: func(application *App, ctx context.Context, config connection.ConnectionConfig) connection.QueryResult {
+				return application.DBGetColumnsContext(ctx, config, "app", "orders")
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			installMetadataSessionTestHooks(t)
+			instance := newContextAwareMetadataDB()
+			newDatabaseFunc = func(string) (db.Database, error) { return instance, nil }
+			application := newDatabaseCacheConcurrencyTestApp()
+			config := connection.ConnectionConfig{Type: "postgres", Host: "127.0.0.1", Port: 5432, Database: "app"}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			resultCh := make(chan connection.QueryResult, 1)
+			go func() { resultCh <- testCase.call(application, ctx, config) }()
+			if got := waitForContext(t, instance.started, "元数据查询未启动"); got != ctx {
+				t.Fatalf("查询上下文 = %v，期望请求上下文", got)
+			}
+			cancel()
+
+			select {
+			case result := <-resultCh:
+				if result.Success {
+					t.Fatalf("取消的元数据请求意外成功：%#v", result)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("取消的元数据请求未及时返回")
+			}
+			waitForMetadataSignal(t, instance.done, "查询未因上下文取消而退出")
+			waitForMetadataSignal(t, instance.closeDone, "查询退出后未关闭隔离数据库")
+			if calls := instance.closeCalls.Load(); calls != 1 {
+				t.Fatalf("隔离数据库 Close 调用次数 = %d，期望 1", calls)
+			}
+		})
+	}
+}
+
+func TestCancelledMetadataRequestClosesLateDatabaseConnection(t *testing.T) {
+	installMetadataSessionTestHooks(t)
+	instance := newBlockingConnectMetadataDB()
+	newDatabaseFunc = func(string) (db.Database, error) { return instance, nil }
+	application := newDatabaseCacheConcurrencyTestApp()
+	config := connection.ConnectionConfig{Type: "postgres", Host: "127.0.0.1", Port: 5432, Database: "app"}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resultCh := make(chan connection.QueryResult, 1)
+	go func() { resultCh <- application.DBGetTablesContext(ctx, config, "app") }()
+	waitForMetadataSignal(t, instance.connectStarted, "元数据连接未启动")
+
+	cancel()
+	select {
+	case result := <-resultCh:
+		if result.Success {
+			t.Fatalf("取消的元数据请求意外成功：%#v", result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("阻塞连接的元数据请求未及时返回")
+	}
+
+	close(instance.releaseConnect)
+	waitForMetadataSignal(t, instance.closeDone, "迟到完成的元数据连接未被关闭")
+	if calls := instance.closeCalls.Load(); calls != 1 {
+		t.Fatalf("迟到连接 Close 调用次数 = %d，期望 1", calls)
+	}
+}
+
+func TestCancelledMetadataRequestClosesLateRedisConnection(t *testing.T) {
+	originalNewRedisClientFunc := newRedisClientFunc
+	t.Cleanup(func() { newRedisClientFunc = originalNewRedisClientFunc })
+	client := newBlockingConnectMetadataRedisClient()
+	newRedisClientFunc = func() redisbackend.RedisClient { return client }
+	application := newDatabaseCacheConcurrencyTestApp()
+	config := connection.ConnectionConfig{Type: "redis", Host: "127.0.0.1", Port: 6379}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resultCh := make(chan connection.QueryResult, 1)
+	go func() { resultCh <- application.DBGetTablesContext(ctx, config, "0") }()
+	waitForMetadataSignal(t, client.connectStarted, "Redis 元数据连接未启动")
+
+	cancel()
+	select {
+	case result := <-resultCh:
+		if result.Success {
+			t.Fatalf("取消的 Redis 元数据请求意外成功：%#v", result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("阻塞 Redis 连接的元数据请求未及时返回")
+	}
+
+	close(client.releaseConnect)
+	waitForMetadataSignal(t, client.closeDone, "迟到完成的 Redis 元数据连接未被关闭")
+	if calls := client.closeCalls.Load(); calls != 1 {
+		t.Fatalf("迟到 Redis 连接 Close 调用次数 = %d，期望 1", calls)
+	}
+	if calls := client.scanCalls.Load(); calls != 0 {
+		t.Fatalf("取消后仍执行了 Redis 元数据扫描 %d 次", calls)
+	}
+}
+
+func TestCancelledMetadataRequestDoesNotAffectConcurrentRequest(t *testing.T) {
+	installMetadataSessionTestHooks(t)
+	instances := make(chan *contextAwareMetadataDB, 2)
+	newDatabaseFunc = func(string) (db.Database, error) {
+		instance := newContextAwareMetadataDB()
+		instances <- instance
+		return instance, nil
+	}
+	application := newDatabaseCacheConcurrencyTestApp()
+	config := connection.ConnectionConfig{Type: "postgres", Host: "127.0.0.1", Port: 5432, Database: "app"}
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	defer cancelFirst()
+
+	firstResult := make(chan connection.QueryResult, 1)
+	go func() { firstResult <- application.DBGetTablesContext(firstCtx, config, "app") }()
+	first := <-instances
+	if got := waitForContext(t, first.started, "第一个元数据查询未启动"); got != firstCtx {
+		t.Fatal("第一个查询未接收其请求上下文")
+	}
+
+	secondResult := make(chan connection.QueryResult, 1)
+	go func() { secondResult <- application.DBGetTablesContext(context.Background(), config, "app") }()
+	second := <-instances
+	waitForContext(t, second.started, "第二个元数据查询未启动")
+
+	cancelFirst()
+	select {
+	case result := <-firstResult:
+		if result.Success {
+			t.Fatalf("取消的请求意外成功：%#v", result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("第一个取消请求未返回")
+	}
+	waitForMetadataSignal(t, first.closeDone, "第一个会话未释放")
+	if calls := second.closeCalls.Load(); calls != 0 {
+		t.Fatalf("取消第一个请求时关闭了第二个会话 %d 次", calls)
+	}
+
+	close(second.release)
+	select {
+	case result := <-secondResult:
+		if !result.Success {
+			t.Fatalf("并发请求被无关取消影响：%#v", result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("第二个请求未完成")
+	}
+	waitForMetadataSignal(t, second.closeDone, "第二个会话未释放")
+}
+
+func TestRedisMetadataContextCancellationReachesScan(t *testing.T) {
+	originalNewRedisClientFunc := newRedisClientFunc
+	t.Cleanup(func() { newRedisClientFunc = originalNewRedisClientFunc })
+	client := newContextAwareMetadataRedisClient()
+	newRedisClientFunc = func() redisbackend.RedisClient { return client }
+	application := newDatabaseCacheConcurrencyTestApp()
+	config := connection.ConnectionConfig{Type: "redis", Host: "127.0.0.1", Port: 6379}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resultCh := make(chan connection.QueryResult, 1)
+	go func() { resultCh <- application.DBGetTablesContext(ctx, config, "0") }()
+	if got := waitForContext(t, client.started, "Redis 扫描未启动"); got != ctx {
+		t.Fatal("Redis 扫描未接收请求上下文")
+	}
+	cancel()
+
+	select {
+	case result := <-resultCh:
+		if result.Success {
+			t.Fatalf("取消的 Redis 元数据请求意外成功：%#v", result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("取消的 Redis 元数据请求未及时返回")
+	}
+	waitForMetadataSignal(t, client.done, "Redis 扫描未因上下文取消而退出")
+	waitForMetadataSignal(t, client.closeDone, "Redis 扫描退出后未关闭隔离客户端")
+}

--- a/internal/app/methods_db_metadata_context_test.go
+++ b/internal/app/methods_db_metadata_context_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -18,10 +19,14 @@ type contextAwareMetadataDB struct {
 	release   chan struct{}
 	closeDone chan struct{}
 
-	doneOnce   sync.Once
-	closeOnce  sync.Once
-	closeCalls atomic.Int32
+	doneOnce       sync.Once
+	closeOnce      sync.Once
+	closeCalls     atomic.Int32
+	skipTableQuery bool
+	createErr      error
 }
+
+type metadataRequestContextKey struct{}
 
 func newContextAwareMetadataDB() *contextAwareMetadataDB {
 	return &contextAwareMetadataDB{
@@ -45,8 +50,16 @@ func (f *contextAwareMetadataDB) Close() error {
 }
 func (f *contextAwareMetadataDB) Ping() error { return nil }
 func (f *contextAwareMetadataDB) Query(string) ([]map[string]interface{}, []string, error) {
-	ctx := db.MetadataContext(f)
-	f.started <- ctx
+	return f.queryWithContext(db.MetadataContext(f))
+}
+func (f *contextAwareMetadataDB) QueryContext(ctx context.Context, _ string) ([]map[string]interface{}, []string, error) {
+	return f.queryWithContext(ctx)
+}
+func (f *contextAwareMetadataDB) queryWithContext(ctx context.Context) ([]map[string]interface{}, []string, error) {
+	select {
+	case f.started <- ctx:
+	default:
+	}
 	select {
 	case <-ctx.Done():
 		f.doneOnce.Do(func() { close(f.done) })
@@ -59,13 +72,18 @@ func (f *contextAwareMetadataDB) Query(string) ([]map[string]interface{}, []stri
 func (f *contextAwareMetadataDB) Exec(string) (int64, error)      { return 0, nil }
 func (f *contextAwareMetadataDB) GetDatabases() ([]string, error) { return nil, nil }
 func (f *contextAwareMetadataDB) GetTables(string) ([]string, error) {
+	if f.skipTableQuery {
+		return []string{"orders"}, nil
+	}
 	_, _, err := f.Query("metadata tables")
 	if err != nil {
 		return nil, err
 	}
 	return []string{"orders"}, nil
 }
-func (f *contextAwareMetadataDB) GetCreateStatement(string, string) (string, error) { return "", nil }
+func (f *contextAwareMetadataDB) GetCreateStatement(string, string) (string, error) {
+	return "", f.createErr
+}
 func (f *contextAwareMetadataDB) GetColumns(string, string) ([]connection.ColumnDefinition, error) {
 	_, _, err := f.Query("metadata columns")
 	if err != nil {
@@ -268,6 +286,12 @@ func TestMetadataContextCancellationReachesQuery(t *testing.T) {
 				return application.DBGetColumnsContext(ctx, config, "app", "orders")
 			},
 		},
+		{
+			name: "views",
+			call: func(application *App, ctx context.Context, config connection.ConnectionConfig) connection.QueryResult {
+				return application.DBGetViewsContext(ctx, config, "app")
+			},
+		},
 	}
 
 	for _, testCase := range tests {
@@ -277,13 +301,13 @@ func TestMetadataContextCancellationReachesQuery(t *testing.T) {
 			newDatabaseFunc = func(string) (db.Database, error) { return instance, nil }
 			application := newDatabaseCacheConcurrencyTestApp()
 			config := connection.ConnectionConfig{Type: "postgres", Host: "127.0.0.1", Port: 5432, Database: "app"}
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(context.WithValue(context.Background(), metadataRequestContextKey{}, "metadata-request"))
 			defer cancel()
 
 			resultCh := make(chan connection.QueryResult, 1)
 			go func() { resultCh <- testCase.call(application, ctx, config) }()
-			if got := waitForContext(t, instance.started, "元数据查询未启动"); got != ctx {
-				t.Fatalf("查询上下文 = %v，期望请求上下文", got)
+			if got := waitForContext(t, instance.started, "元数据查询未启动"); got.Value(metadataRequestContextKey{}) != "metadata-request" {
+				t.Fatalf("查询上下文未继承请求上下文值：%v", got)
 			}
 			cancel()
 
@@ -302,6 +326,64 @@ func TestMetadataContextCancellationReachesQuery(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMetadataObjectsFallbackCancellationReachesQuery(t *testing.T) {
+	installMetadataSessionTestHooks(t)
+	instance := newContextAwareMetadataDB()
+	instance.skipTableQuery = true
+	newDatabaseFunc = func(string) (db.Database, error) { return instance, nil }
+	application := newDatabaseCacheConcurrencyTestApp()
+	config := connection.ConnectionConfig{Type: "postgres", Host: "127.0.0.1", Port: 5432, Database: "app"}
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), metadataRequestContextKey{}, "metadata-request"))
+	defer cancel()
+
+	resultCh := make(chan connection.QueryResult, 1)
+	go func() { resultCh <- application.DBGetObjectsContext(ctx, config, "app") }()
+	if got := waitForContext(t, instance.started, "对象后备元数据查询未启动"); got.Value(metadataRequestContextKey{}) != "metadata-request" {
+		t.Fatalf("对象后备查询未继承请求上下文值：%v", got)
+	}
+	cancel()
+
+	select {
+	case result := <-resultCh:
+		if result.Success {
+			t.Fatalf("取消的对象元数据请求意外成功：%#v", result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("取消的对象元数据请求未及时返回")
+	}
+	waitForMetadataSignal(t, instance.done, "对象后备查询未因上下文取消而退出")
+	waitForMetadataSignal(t, instance.closeDone, "对象后备查询退出后未关闭隔离数据库")
+}
+
+func TestMetadataDDLViewFallbackCancellationReachesQuery(t *testing.T) {
+	installMetadataSessionTestHooks(t)
+	instance := newContextAwareMetadataDB()
+	instance.createErr = errors.New("create statement unavailable")
+	newDatabaseFunc = func(string) (db.Database, error) { return instance, nil }
+	application := newDatabaseCacheConcurrencyTestApp()
+	config := connection.ConnectionConfig{Type: "postgres", Host: "127.0.0.1", Port: 5432, Database: "app"}
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), metadataRequestContextKey{}, "metadata-request"))
+	defer cancel()
+
+	resultCh := make(chan connection.QueryResult, 1)
+	go func() { resultCh <- application.DBShowCreateTableContext(ctx, config, "app", "orders") }()
+	if got := waitForContext(t, instance.started, "DDL 视图回退查询未启动"); got.Value(metadataRequestContextKey{}) != "metadata-request" {
+		t.Fatalf("DDL 视图回退查询未继承请求上下文值：%v", got)
+	}
+	cancel()
+
+	select {
+	case result := <-resultCh:
+		if result.Success {
+			t.Fatalf("取消的 DDL 元数据请求意外成功：%#v", result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("取消的 DDL 元数据请求未及时返回")
+	}
+	waitForMetadataSignal(t, instance.done, "DDL 视图回退查询未因上下文取消而退出")
+	waitForMetadataSignal(t, instance.closeDone, "DDL 视图回退查询退出后未关闭隔离数据库")
 }
 
 func TestCancelledMetadataRequestClosesLateDatabaseConnection(t *testing.T) {

--- a/internal/app/methods_file.go
+++ b/internal/app/methods_file.go
@@ -7124,7 +7124,7 @@ func (a *App) ExportQueryWithOptions(config connection.ConnectionConfig, dbName 
 }
 
 func queryDataForExport(dbInst db.Database, config connection.ConnectionConfig, query string) ([]map[string]interface{}, []string, error) {
-	return queryDataForExportWithContext(context.Background(), dbInst, config, query)
+	return queryDataForExportWithContext(db.MetadataContext(dbInst), dbInst, config, query)
 }
 
 // queryDataForExportWithContext is the buffered export fallback. It retains
@@ -7921,7 +7921,7 @@ func newExportFileWriter(f *os.File, options ExportFileOptions) (exportFileWrite
 }
 
 func streamQueryDataForExport(dbInst db.Database, config connection.ConnectionConfig, query string, consumer db.QueryStreamConsumer) error {
-	return streamQueryDataForExportWithContext(context.Background(), dbInst, config, query, consumer)
+	return streamQueryDataForExportWithContext(db.MetadataContext(dbInst), dbInst, config, query, consumer)
 }
 
 // streamQueryDataForExportWithContext preserves the existing streaming and

--- a/internal/app/methods_file_export_test.go
+++ b/internal/app/methods_file_export_test.go
@@ -32,14 +32,17 @@ type fakeExportQueryDB struct {
 	queries            []string
 	lastContextTimeout time.Duration
 	hasContextDeadline bool
+	lastQueryContext   context.Context
 }
 
 type fakeStreamExportDB struct {
 	fakeExportQueryDB
-	streamData []map[string]interface{}
-	streamCols []string
-	streamHits int
-	queryHits  int
+	streamData    []map[string]interface{}
+	streamCols    []string
+	streamHits    int
+	queryHits     int
+	streamStarted chan context.Context
+	streamBlock   bool
 }
 
 type fakeValueStreamExportDB struct {
@@ -57,6 +60,11 @@ type fakeGeneratedValueStreamExportDB struct {
 	streamHits int
 	valueHits  int
 }
+
+type exportContextTestConsumer struct{}
+
+func (exportContextTestConsumer) SetColumns([]string) error               { return nil }
+func (exportContextTestConsumer) ConsumeRow(map[string]interface{}) error { return nil }
 
 type fakeSQLDumpExportDB struct {
 	fakeExportQueryDB
@@ -90,6 +98,7 @@ func (f *fakeExportQueryDB) Query(query string) ([]map[string]interface{}, []str
 func (f *fakeExportQueryDB) QueryContext(ctx context.Context, query string) ([]map[string]interface{}, []string, error) {
 	f.lastQuery = query
 	f.queries = append(f.queries, query)
+	f.lastQueryContext = ctx
 	if deadline, ok := ctx.Deadline(); ok {
 		f.hasContextDeadline = true
 		f.lastContextTimeout = time.Until(deadline)
@@ -142,9 +151,20 @@ func (f *fakeStreamExportDB) StreamQuery(query string, consumer db.QueryStreamCo
 	return f.StreamQueryContext(context.Background(), query, consumer)
 }
 
-func (f *fakeStreamExportDB) StreamQueryContext(_ context.Context, query string, consumer db.QueryStreamConsumer) error {
+func (f *fakeStreamExportDB) StreamQueryContext(ctx context.Context, query string, consumer db.QueryStreamConsumer) error {
 	f.streamHits++
 	f.lastQuery = query
+	f.lastQueryContext = ctx
+	if f.streamStarted != nil {
+		select {
+		case f.streamStarted <- ctx:
+		default:
+		}
+	}
+	if f.streamBlock {
+		<-ctx.Done()
+		return ctx.Err()
+	}
 	if err := consumer.SetColumns(f.streamCols); err != nil {
 		return err
 	}
@@ -619,6 +639,78 @@ func TestQueryDataForExport_UsesMinimumTimeout(t *testing.T) {
 	upperBound := minExportQueryTimeout + 5*time.Second
 	if fake.lastContextTimeout < lowerBound || fake.lastContextTimeout > upperBound {
 		t.Fatalf("导出最小超时异常，want≈%s got=%s", minExportQueryTimeout, fake.lastContextTimeout)
+	}
+}
+
+type exportMetadataContextKey struct{}
+
+func TestQueryDataForExportUsesBoundMetadataContext(t *testing.T) {
+	fake := &fakeExportQueryDB{
+		data: []map[string]interface{}{{"v": 1}},
+		cols: []string{"v"},
+	}
+	parent := context.WithValue(context.Background(), exportMetadataContextKey{}, "metadata-request")
+	db.BindMetadataContext(fake, parent)
+	defer db.ClearMetadataContext(fake)
+
+	if _, _, err := queryDataForExport(fake, connection.ConnectionConfig{Timeout: 10}, "SELECT 1"); err != nil {
+		t.Fatalf("queryDataForExport 返回错误: %v", err)
+	}
+	if got := fake.lastQueryContext.Value(exportMetadataContextKey{}); got != "metadata-request" {
+		t.Fatalf("导出查询未继承元数据请求上下文值，got=%v", got)
+	}
+}
+
+func TestStreamQueryDataForExportUsesBoundMetadataContext(t *testing.T) {
+	fake := &fakeStreamExportDB{
+		fakeExportQueryDB: fakeExportQueryDB{data: []map[string]interface{}{{"v": 1}}, cols: []string{"v"}},
+		streamCols:        []string{"v"},
+		streamData:        []map[string]interface{}{{"v": 1}},
+	}
+	parent := context.WithValue(context.Background(), exportMetadataContextKey{}, "metadata-request")
+	db.BindMetadataContext(fake, parent)
+	defer db.ClearMetadataContext(fake)
+
+	if err := streamQueryDataForExport(fake, connection.ConnectionConfig{Timeout: 10}, "SELECT 1", exportContextTestConsumer{}); err != nil {
+		t.Fatalf("streamQueryDataForExport 返回错误: %v", err)
+	}
+	if got := fake.lastQueryContext.Value(exportMetadataContextKey{}); got != "metadata-request" {
+		t.Fatalf("流式导出查询未继承元数据请求上下文值，got=%v", got)
+	}
+}
+
+func TestStreamQueryDataForExportCancellationUsesBoundMetadataContext(t *testing.T) {
+	fake := &fakeStreamExportDB{
+		fakeExportQueryDB: fakeExportQueryDB{data: []map[string]interface{}{{"v": 1}}, cols: []string{"v"}},
+		streamStarted:     make(chan context.Context, 1),
+		streamBlock:       true,
+	}
+	parent, cancel := context.WithCancel(context.WithValue(context.Background(), exportMetadataContextKey{}, "metadata-request"))
+	defer cancel()
+	db.BindMetadataContext(fake, parent)
+	defer db.ClearMetadataContext(fake)
+
+	resultCh := make(chan error, 1)
+	go func() {
+		resultCh <- streamQueryDataForExport(fake, connection.ConnectionConfig{Timeout: 10}, "SELECT 1", exportContextTestConsumer{})
+	}()
+	select {
+	case queryCtx := <-fake.streamStarted:
+		if queryCtx.Value(exportMetadataContextKey{}) != "metadata-request" {
+			t.Fatalf("流式导出查询未继承元数据请求上下文值，got=%v", queryCtx.Value(exportMetadataContextKey{}))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("流式导出查询未启动")
+	}
+	cancel()
+
+	select {
+	case err := <-resultCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("取消后的流式导出错误 = %v，期望 context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("流式导出查询未因取消而退出")
 	}
 }
 

--- a/internal/app/methods_redis.go
+++ b/internal/app/methods_redis.go
@@ -680,6 +680,10 @@ func importRedisTransferPayload(client redis.RedisClient, payload redisTransferF
 
 // getRedisClient gets or creates a Redis client from cache
 func (a *App) getRedisClient(config connection.ConnectionConfig) (redis.RedisClient, error) {
+	if a != nil && a.metadataSession != nil {
+		return a.metadataSession.openRedisClient(config)
+	}
+
 	resolvedConfig, err := a.resolveConnectionSecrets(config)
 	if err != nil {
 		wrapped := wrapConnectError(config, err)

--- a/internal/db/chroma_impl.go
+++ b/internal/db/chroma_impl.go
@@ -114,7 +114,7 @@ func (c *ChromaDB) Ping() error {
 	if c.client == nil {
 		return fmt.Errorf("连接未打开")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(c), 10*time.Second)
 	defer cancel()
 
 	if err := c.detectVersion(ctx); err != nil {
@@ -124,7 +124,7 @@ func (c *ChromaDB) Ping() error {
 }
 
 func (c *ChromaDB) Query(query string) ([]map[string]interface{}, []string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultChromaQueryTimeout)
+	ctx, cancel := context.WithTimeout(metadataContextFor(c), defaultChromaQueryTimeout)
 	defer cancel()
 	return c.QueryContext(ctx, query)
 }
@@ -203,7 +203,7 @@ func (c *ChromaDB) GetDatabases() ([]string, error) {
 	if c.client == nil {
 		return nil, fmt.Errorf("连接未打开")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(c), 10*time.Second)
 	defer cancel()
 	if err := c.ensureVersion(ctx); err != nil {
 		return nil, err
@@ -231,7 +231,7 @@ func (c *ChromaDB) GetDatabases() ([]string, error) {
 }
 
 func (c *ChromaDB) GetTables(dbName string) ([]string, error) {
-	collections, err := c.listCollections(context.Background(), dbName)
+	collections, err := c.listCollections(metadataContextFor(c), dbName)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +246,7 @@ func (c *ChromaDB) GetTables(dbName string) ([]string, error) {
 }
 
 func (c *ChromaDB) GetCreateStatement(dbName, tableName string) (string, error) {
-	coll, err := c.resolveCollection(context.Background(), dbName, tableName)
+	coll, err := c.resolveCollection(metadataContextFor(c), dbName, tableName)
 	if err != nil {
 		return "", err
 	}
@@ -258,7 +258,7 @@ func (c *ChromaDB) GetColumns(dbName, tableName string) ([]connection.ColumnDefi
 	// Chroma does not expose a collection-level schema for arbitrary metadata keys.
 	// Keep metadata inspection side-effect free: sampling documents would implicitly
 	// expose user data and embeddings while opening the fields node.
-	if _, err := c.resolveCollection(context.Background(), dbName, tableName); err != nil {
+	if _, err := c.resolveCollection(metadataContextFor(c), dbName, tableName); err != nil {
 		return nil, err
 	}
 	return []connection.ColumnDefinition{

--- a/internal/db/clickhouse_impl.go
+++ b/internal/db/clickhouse_impl.go
@@ -958,18 +958,7 @@ func (c *ClickHouseDB) QueryContext(ctx context.Context, query string) ([]map[st
 }
 
 func (c *ClickHouseDB) Query(query string) ([]map[string]interface{}, []string, error) {
-	if c.legacyHTTP != nil {
-		return c.legacyHTTP.Query(context.Background(), query)
-	}
-	if c.conn == nil {
-		return nil, nil, fmt.Errorf("连接未打开")
-	}
-	rows, err := c.conn.Query(query)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer rows.Close()
-	return scanRows(rows)
+	return c.QueryContext(metadataContextFor(c), query)
 }
 
 func (c *ClickHouseDB) StreamQueryContext(ctx context.Context, query string, consumer QueryStreamConsumer) error {

--- a/internal/db/custom_impl.go
+++ b/internal/db/custom_impl.go
@@ -110,7 +110,7 @@ func (c *CustomDB) Query(query string) ([]map[string]interface{}, []string, erro
 		return nil, nil, localizedDatabaseRuntimeError("db.backend.error.connection_not_open", nil)
 	}
 
-	rows, err := c.conn.Query(query)
+	rows, err := c.conn.QueryContext(metadataContextFor(c), query)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/db/dameng_impl.go
+++ b/internal/db/dameng_impl.go
@@ -184,7 +184,7 @@ func (d *DamengDB) Query(query string) ([]map[string]interface{}, []string, erro
 		return nil, nil, fmt.Errorf("连接未打开")
 	}
 
-	rows, err := d.conn.Query(query)
+	rows, err := d.conn.QueryContext(metadataContextFor(d), query)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/db/database.go
+++ b/internal/db/database.go
@@ -7,10 +7,74 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
 )
+
+// metadataContexts 让元数据入口复用既有驱动实现，同时把请求上下文传给 Query。
+// 元数据请求使用独立的 Database 实例，因此不会与常规缓存连接的操作重叠。
+var metadataContexts sync.Map
+
+type metadataContextKey struct {
+	typ reflect.Type
+	ptr uintptr
+}
+
+type metadataContextChildBinder interface {
+	bindMetadataContext(context.Context)
+	clearMetadataContext()
+}
+
+func metadataContextKeyFor(database any) (metadataContextKey, bool) {
+	value := reflect.ValueOf(database)
+	if !value.IsValid() || value.Kind() != reflect.Ptr || value.IsNil() {
+		return metadataContextKey{}, false
+	}
+	return metadataContextKey{typ: value.Type(), ptr: value.Pointer()}, true
+}
+
+// BindMetadataContext 将独立数据库实例与元数据请求上下文关联。
+// 请求结束后必须调用 ClearMetadataContext。
+func BindMetadataContext(database Database, ctx context.Context) {
+	key, ok := metadataContextKeyFor(database)
+	if !ok || ctx == nil {
+		return
+	}
+	metadataContexts.Store(key, ctx)
+	if child, ok := database.(metadataContextChildBinder); ok {
+		child.bindMetadataContext(ctx)
+	}
+}
+
+// ClearMetadataContext 移除由 BindMetadataContext 建立的关联。
+func ClearMetadataContext(database Database) {
+	if key, ok := metadataContextKeyFor(database); ok {
+		metadataContexts.Delete(key)
+	}
+	if child, ok := database.(metadataContextChildBinder); ok {
+		child.clearMetadataContext()
+	}
+}
+
+// MetadataContext 返回绑定到隔离元数据连接的请求上下文。
+func MetadataContext(database Database) context.Context {
+	return metadataContextFor(database)
+}
+
+// metadataContextFor 返回隔离元数据数据库关联的请求上下文。
+// 常规查询路径保持原有的 Background 上下文行为。
+func metadataContextFor(database any) context.Context {
+	if key, ok := metadataContextKeyFor(database); ok {
+		if ctx, ok := metadataContexts.Load(key); ok {
+			if requestCtx, ok := ctx.(context.Context); ok && requestCtx != nil {
+				return requestCtx
+			}
+		}
+	}
+	return context.Background()
+}
 
 // Database 定义了统一的数据源访问接口。
 // 所有数据库驱动（MySQL、PostgreSQL、Oracle 等）均需实现此接口。

--- a/internal/db/database.go
+++ b/internal/db/database.go
@@ -79,6 +79,11 @@ func metadataContextFor(database any) context.Context {
 // Database 定义了统一的数据源访问接口。
 // 所有数据库驱动（MySQL、PostgreSQL、Oracle 等）均需实现此接口。
 // 方法调用方可通过 NewDatabase 工厂函数获取对应驱动的实例。
+//
+// 取消契约：MCP 元数据请求通过 BindMetadataContext 把请求上下文绑定到隔离的
+// Database 实例，驱动实现必须在底层调用中传递 metadataContextFor 返回的上下文
+// （如 QueryContext / HTTP request context）。若驱动忽略该上下文，取消将退化为
+// 等待查询自然结束，连接与 goroutine 会残留至查询完成。
 type Database interface {
 	// Connect 根据连接配置建立数据库连接。
 	Connect(config connection.ConnectionConfig) error

--- a/internal/db/diros_impl.go
+++ b/internal/db/diros_impl.go
@@ -3,6 +3,7 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -22,6 +23,14 @@ const (
 // DirosDB 使用独立 driver 名称（diros）接入，底层协议兼容 MySQL（对外显示为 Doris）。
 type DirosDB struct {
 	MySQLDB
+}
+
+func (d *DirosDB) bindMetadataContext(ctx context.Context) {
+	BindMetadataContext(&d.MySQLDB, ctx)
+}
+
+func (d *DirosDB) clearMetadataContext() {
+	ClearMetadataContext(&d.MySQLDB)
 }
 
 func init() {

--- a/internal/db/duckdb_impl.go
+++ b/internal/db/duckdb_impl.go
@@ -116,7 +116,7 @@ func (d *DuckDB) Query(query string) ([]map[string]interface{}, []string, error)
 	if d.conn == nil {
 		return nil, nil, duckDBConnectionNotOpenError()
 	}
-	rows, err := d.conn.Query(query)
+	rows, err := d.conn.QueryContext(metadataContextFor(d), query)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/db/elasticsearch_helpers.go
+++ b/internal/db/elasticsearch_helpers.go
@@ -1083,7 +1083,7 @@ func parseSearchResponseJSON(body []byte) ([]map[string]interface{}, []string, e
 
 // esFetchIndexAliases 获取指定索引关联的所有别名。
 func (e *ElasticsearchDB) esFetchIndexAliases(indexName string) []string {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(e), 10*time.Second)
 	defer cancel()
 
 	res, err := e.client.Indices.GetAlias(
@@ -1133,7 +1133,7 @@ func (e *ElasticsearchDB) esFetchIndexMapping(indexName string) (map[string]inte
 		return nil, fmt.Errorf("连接未打开")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(e), 10*time.Second)
 	defer cancel()
 
 	res, err := e.client.Indices.GetMapping(

--- a/internal/db/elasticsearch_impl.go
+++ b/internal/db/elasticsearch_impl.go
@@ -717,7 +717,7 @@ func (e *ElasticsearchDB) TableExists(dbName, tableName string) (bool, error) {
 		return false, fmt.Errorf("未指定索引名")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultEsPingTimeout)
+	ctx, cancel := context.WithTimeout(metadataContextFor(e), defaultEsPingTimeout)
 	defer cancel()
 	res, err := e.client.Indices.Exists(
 		[]string{indexName},

--- a/internal/db/elasticsearch_impl.go
+++ b/internal/db/elasticsearch_impl.go
@@ -344,7 +344,7 @@ func (e *ElasticsearchDB) Ping() error {
 
 // Query 执行 Elasticsearch 查询，支持 JSON DSL 和 query_string 两种模式。
 func (e *ElasticsearchDB) Query(query string) ([]map[string]interface{}, []string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultEsQueryTimeout)
+	ctx, cancel := context.WithTimeout(metadataContextFor(e), defaultEsQueryTimeout)
 	defer cancel()
 	return e.queryWithContext(ctx, query)
 }
@@ -562,7 +562,7 @@ func (e *ElasticsearchDB) GetDatabases() ([]string, error) {
 		catTimeout = totalTimeout
 	}
 
-	catCtx, cancelCat := context.WithTimeout(context.Background(), catTimeout)
+	catCtx, cancelCat := context.WithTimeout(metadataContextFor(e), catTimeout)
 	indices, catErr := e.getDatabasesViaCat(catCtx)
 	cancelCat()
 	if catErr == nil {
@@ -575,7 +575,7 @@ func (e *ElasticsearchDB) GetDatabases() ([]string, error) {
 		return nil, fmt.Errorf("获取索引列表失败：CAT Indices API: %v；Alias API: 总超时 %s 已耗尽", catErr, totalTimeout)
 	}
 
-	aliasCtx, cancelAlias := context.WithTimeout(context.Background(), remaining)
+	aliasCtx, cancelAlias := context.WithTimeout(metadataContextFor(e), remaining)
 	indices, aliasErr := e.getDatabasesViaAlias(aliasCtx)
 	cancelAlias()
 	if aliasErr == nil {
@@ -753,7 +753,7 @@ func (e *ElasticsearchDB) GetCreateStatement(dbName, tableName string) (string, 
 		return "", fmt.Errorf("未指定索引名")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(e), 10*time.Second)
 	defer cancel()
 
 	res, err := e.client.Indices.Get(
@@ -843,7 +843,7 @@ func (e *ElasticsearchDB) GetIndexes(dbName, tableName string) ([]connection.Ind
 		return nil, fmt.Errorf("未指定索引名")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(e), 10*time.Second)
 	defer cancel()
 
 	res, err := e.client.Indices.GetSettings(

--- a/internal/db/gaussdb_impl.go
+++ b/internal/db/gaussdb_impl.go
@@ -3,6 +3,7 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"net"
@@ -25,6 +26,14 @@ const defaultGaussDBPort = 5432
 // 元数据与大多数 SQL 行为按 PG-like 路径复用。
 type GaussDB struct {
 	PostgresDB
+}
+
+func (g *GaussDB) bindMetadataContext(ctx context.Context) {
+	BindMetadataContext(&g.PostgresDB, ctx)
+}
+
+func (g *GaussDB) clearMetadataContext() {
+	ClearMetadataContext(&g.PostgresDB)
 }
 
 func applyGaussDBURI(config connection.ConnectionConfig) connection.ConnectionConfig {

--- a/internal/db/highgo_impl.go
+++ b/internal/db/highgo_impl.go
@@ -187,7 +187,7 @@ func (h *HighGoDB) Query(query string) ([]map[string]interface{}, []string, erro
 		return nil, nil, fmt.Errorf("连接未打开")
 	}
 
-	rows, err := h.conn.Query(query)
+	rows, err := h.conn.QueryContext(metadataContextFor(h), query)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/db/iotdb_impl.go
+++ b/internal/db/iotdb_impl.go
@@ -188,7 +188,7 @@ func (i *IoTDBDB) Ping() error {
 }
 
 func (i *IoTDBDB) Query(query string) ([]map[string]interface{}, []string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultIoTDBQueryTimeout)
+	ctx, cancel := context.WithTimeout(metadataContextFor(i), defaultIoTDBQueryTimeout)
 	defer cancel()
 	return i.QueryContext(ctx, query)
 }

--- a/internal/db/iris_impl.go
+++ b/internal/db/iris_impl.go
@@ -174,7 +174,7 @@ func (i *IrisDB) QueryMulti(query string) ([]connection.ResultSetData, error) {
 	if i.conn == nil {
 		return nil, fmt.Errorf("连接未打开")
 	}
-	rows, err := i.conn.Query(query)
+	rows, err := i.conn.QueryContext(metadataContextFor(i), query)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +210,7 @@ func (i *IrisDB) Query(query string) ([]map[string]interface{}, []string, error)
 	if i.conn == nil {
 		return nil, nil, fmt.Errorf("连接未打开")
 	}
-	rows, err := i.conn.Query(query)
+	rows, err := i.conn.QueryContext(metadataContextFor(i), query)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/db/kafka_impl.go
+++ b/internal/db/kafka_impl.go
@@ -178,13 +178,13 @@ func (k *KafkaDB) Ping() error {
 	if k.runtime == nil {
 		return fmt.Errorf("连接未打开")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(k), 10*time.Second)
 	defer cancel()
 	return k.runtime.Ping(ctx)
 }
 
 func (k *KafkaDB) Query(query string) ([]map[string]interface{}, []string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultKafkaQueryTimeout)
+	ctx, cancel := context.WithTimeout(metadataContextFor(k), defaultKafkaQueryTimeout)
 	defer cancel()
 	return k.QueryContext(ctx, query)
 }
@@ -297,7 +297,7 @@ func (k *KafkaDB) GetTables(dbName string) ([]string, error) {
 	if k.runtime == nil {
 		return nil, fmt.Errorf("连接未打开")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(k), 10*time.Second)
 	defer cancel()
 	topics, err := k.runtime.ListTopics(ctx, false)
 	if err != nil {
@@ -317,7 +317,7 @@ func (k *KafkaDB) GetCreateStatement(dbName, tableName string) (string, error) {
 	if k.runtime == nil {
 		return "", fmt.Errorf("连接未打开")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(k), 10*time.Second)
 	defer cancel()
 	description, err := k.runtime.DescribeTopic(ctx, kafkaResolveTopic(tableName, k.defaultTopic))
 	if err != nil {
@@ -377,7 +377,7 @@ func (k *KafkaDB) GetIndexes(dbName, tableName string) ([]connection.IndexDefini
 	if k.runtime == nil {
 		return nil, fmt.Errorf("连接未打开")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(k), 10*time.Second)
 	defer cancel()
 	description, err := k.runtime.DescribeTopic(ctx, kafkaResolveTopic(tableName, k.defaultTopic))
 	if err != nil {

--- a/internal/db/kingbase_impl.go
+++ b/internal/db/kingbase_impl.go
@@ -232,7 +232,7 @@ func (k *KingbaseDB) getSearchPathStr() string {
 		  AND nspname NOT LIKE 'pg|_%' ESCAPE '|'
 		ORDER BY nspname`
 
-	rows, err := k.conn.Query(query)
+	rows, err := k.conn.QueryContext(metadataContextFor(k), query)
 	if err != nil {
 		logger.Warnf("人大金仓查询用户 schema 失败，跳过 search_path 设置：%v", err)
 		return ""
@@ -317,7 +317,7 @@ func (k *KingbaseDB) Query(query string) ([]map[string]interface{}, []string, er
 		return nil, nil, fmt.Errorf("连接未打开")
 	}
 
-	rows, err := k.conn.Query(query)
+	rows, err := k.conn.QueryContext(metadataContextFor(k), query)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/db/mariadb_impl.go
+++ b/internal/db/mariadb_impl.go
@@ -94,7 +94,7 @@ func (m *MariaDB) QueryMulti(query string) ([]connection.ResultSetData, error) {
 	if m.conn == nil {
 		return nil, fmt.Errorf("连接未打开")
 	}
-	rows, err := m.conn.Query(query)
+	rows, err := m.conn.QueryContext(metadataContextFor(m), query)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (m *MariaDB) Query(query string) ([]map[string]interface{}, []string, error
 		return nil, nil, fmt.Errorf("连接未打开")
 	}
 
-	rows, err := m.conn.Query(query)
+	rows, err := m.conn.QueryContext(metadataContextFor(m), query)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/db/metadata_context_test.go
+++ b/internal/db/metadata_context_test.go
@@ -154,3 +154,19 @@ func TestMySQLMetadataColumnsQueryUsesRequestContext(t *testing.T) {
 		t.Fatal("MySQL 列元数据查询未因取消而退出")
 	}
 }
+
+func TestDamengTransactionalMetadataContextBindsInnerDriver(t *testing.T) {
+	inner := &OptionalDriverAgentDB{driverType: "dameng"}
+	database := &optionalDriverAgentTransactionalDB{OptionalDriverAgentDB: inner}
+	ctx := context.WithValue(context.Background(), struct{}{}, "dameng-metadata")
+
+	BindMetadataContext(database, ctx)
+	if got := MetadataContext(inner); got != ctx {
+		t.Fatalf("Dameng 事务代理内层上下文 = %v，期望请求上下文", got)
+	}
+
+	ClearMetadataContext(database)
+	if got := MetadataContext(inner); got.Value(struct{}{}) != nil {
+		t.Fatalf("Dameng 事务代理清理后内层仍保留元数据上下文：%v", got)
+	}
+}

--- a/internal/db/metadata_context_test.go
+++ b/internal/db/metadata_context_test.go
@@ -1,0 +1,156 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+const metadataContextDriverName = "gonavi_metadata_context_test"
+
+var (
+	registerMetadataContextDriver sync.Once
+	metadataContextDriverState    struct {
+		sync.Mutex
+		contexts chan context.Context
+	}
+)
+
+type metadataContextDriver struct{}
+
+func (metadataContextDriver) Open(string) (driver.Conn, error) {
+	return metadataContextConn{}, nil
+}
+
+type metadataContextConn struct{}
+
+func (metadataContextConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("不支持 Prepare")
+}
+
+func (metadataContextConn) Close() error { return nil }
+
+func (metadataContextConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("不支持事务")
+}
+
+func (metadataContextConn) QueryContext(ctx context.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+	metadataContextDriverState.Lock()
+	contexts := metadataContextDriverState.contexts
+	metadataContextDriverState.Unlock()
+	if contexts != nil {
+		contexts <- ctx
+	}
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+var _ driver.QueryerContext = metadataContextConn{}
+
+func TestMySQLMetadataQueryUsesRequestContext(t *testing.T) {
+	registerMetadataContextDriver.Do(func() {
+		sql.Register(metadataContextDriverName, metadataContextDriver{})
+	})
+
+	contexts := make(chan context.Context, 1)
+	metadataContextDriverState.Lock()
+	metadataContextDriverState.contexts = contexts
+	metadataContextDriverState.Unlock()
+	t.Cleanup(func() {
+		metadataContextDriverState.Lock()
+		metadataContextDriverState.contexts = nil
+		metadataContextDriverState.Unlock()
+	})
+
+	conn, err := sql.Open(metadataContextDriverName, "")
+	if err != nil {
+		t.Fatalf("打开测试连接失败：%v", err)
+	}
+	defer conn.Close()
+	database := &MySQLDB{conn: conn}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	BindMetadataContext(database, ctx)
+	defer ClearMetadataContext(database)
+
+	resultCh := make(chan error, 1)
+	go func() {
+		_, queryErr := database.GetTables("app")
+		resultCh <- queryErr
+	}()
+
+	select {
+	case queryCtx := <-contexts:
+		if queryCtx != ctx {
+			t.Fatal("MySQL 元数据查询未使用请求上下文")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("MySQL 元数据查询未到达 QueryContext")
+	}
+
+	cancel()
+	select {
+	case queryErr := <-resultCh:
+		if !errors.Is(queryErr, context.Canceled) {
+			t.Fatalf("取消后的查询错误 = %v，期望 context.Canceled", queryErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("MySQL 元数据查询未因取消而退出")
+	}
+}
+
+func TestMySQLMetadataColumnsQueryUsesRequestContext(t *testing.T) {
+	registerMetadataContextDriver.Do(func() {
+		sql.Register(metadataContextDriverName, metadataContextDriver{})
+	})
+
+	contexts := make(chan context.Context, 1)
+	metadataContextDriverState.Lock()
+	metadataContextDriverState.contexts = contexts
+	metadataContextDriverState.Unlock()
+	t.Cleanup(func() {
+		metadataContextDriverState.Lock()
+		metadataContextDriverState.contexts = nil
+		metadataContextDriverState.Unlock()
+	})
+
+	conn, err := sql.Open(metadataContextDriverName, "")
+	if err != nil {
+		t.Fatalf("打开测试连接失败：%v", err)
+	}
+	defer conn.Close()
+	database := &MySQLDB{conn: conn}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	BindMetadataContext(database, ctx)
+	defer ClearMetadataContext(database)
+
+	resultCh := make(chan error, 1)
+	go func() {
+		_, queryErr := database.GetColumns("app", "orders")
+		resultCh <- queryErr
+	}()
+
+	select {
+	case queryCtx := <-contexts:
+		if queryCtx != ctx {
+			t.Fatal("MySQL 列元数据查询未使用请求上下文")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("MySQL 列元数据查询未到达 QueryContext")
+	}
+
+	cancel()
+	select {
+	case queryErr := <-resultCh:
+		if !errors.Is(queryErr, context.Canceled) {
+			t.Fatalf("取消后的列元数据查询错误 = %v，期望 context.Canceled", queryErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("MySQL 列元数据查询未因取消而退出")
+	}
+}

--- a/internal/db/milvus_impl.go
+++ b/internal/db/milvus_impl.go
@@ -107,7 +107,7 @@ func (m *MilvusDB) Ping() error {
 	if m.client == nil {
 		return fmt.Errorf("connection is not open")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(m), 10*time.Second)
 	defer cancel()
 	_, err := m.listCollections(ctx, m.database)
 	return err
@@ -196,7 +196,7 @@ func (m *MilvusDB) GetDatabases() ([]string, error) {
 	if m.client == nil {
 		return nil, fmt.Errorf("connection is not open")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(m), 10*time.Second)
 	defer cancel()
 
 	var raw interface{}
@@ -215,11 +215,11 @@ func (m *MilvusDB) GetDatabases() ([]string, error) {
 }
 
 func (m *MilvusDB) GetTables(dbName string) ([]string, error) {
-	return m.listCollections(context.Background(), m.databaseName(dbName))
+	return m.listCollections(metadataContextFor(m), m.databaseName(dbName))
 }
 
 func (m *MilvusDB) GetCreateStatement(dbName, tableName string) (string, error) {
-	info, err := m.getCollectionInfo(context.Background(), m.databaseName(dbName), tableNameOrDB(dbName, tableName))
+	info, err := m.getCollectionInfo(metadataContextFor(m), m.databaseName(dbName), tableNameOrDB(dbName, tableName))
 	if err != nil {
 		return "", err
 	}
@@ -228,7 +228,7 @@ func (m *MilvusDB) GetCreateStatement(dbName, tableName string) (string, error) 
 }
 
 func (m *MilvusDB) GetColumns(dbName, tableName string) ([]connection.ColumnDefinition, error) {
-	info, err := m.getCollectionInfo(context.Background(), m.databaseName(dbName), tableNameOrDB(dbName, tableName))
+	info, err := m.getCollectionInfo(metadataContextFor(m), m.databaseName(dbName), tableNameOrDB(dbName, tableName))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +287,7 @@ func (m *MilvusDB) GetAllColumns(dbName string) ([]connection.ColumnDefinitionWi
 }
 
 func (m *MilvusDB) GetIndexes(dbName, tableName string) ([]connection.IndexDefinition, error) {
-	info, err := m.getCollectionInfo(context.Background(), m.databaseName(dbName), tableNameOrDB(dbName, tableName))
+	info, err := m.getCollectionInfo(metadataContextFor(m), m.databaseName(dbName), tableNameOrDB(dbName, tableName))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/mongodb_impl.go
+++ b/internal/db/mongodb_impl.go
@@ -1158,7 +1158,7 @@ func (m *MongoDB) GetDatabases() ([]string, error) {
 		return nil, fmt.Errorf("连接未打开")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(m), 10*time.Second)
 	defer cancel()
 
 	dbs, err := m.client.ListDatabaseNames(ctx, bson.M{})
@@ -1178,7 +1178,7 @@ func (m *MongoDB) GetTables(dbName string) ([]string, error) {
 		targetDB = m.database
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(m), 10*time.Second)
 	defer cancel()
 
 	collections, err := m.client.Database(targetDB).ListCollectionNames(ctx, bson.M{})
@@ -1214,7 +1214,7 @@ func (m *MongoDB) GetIndexes(dbName, tableName string) ([]connection.IndexDefini
 		targetDB = m.database
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(m), 10*time.Second)
 	defer cancel()
 
 	collection := m.client.Database(targetDB).Collection(tableName)

--- a/internal/db/mysql_impl.go
+++ b/internal/db/mysql_impl.go
@@ -918,7 +918,7 @@ func (m *MySQLDB) QueryMulti(query string) ([]connection.ResultSetData, error) {
 	if m.conn == nil {
 		return nil, fmt.Errorf("连接未打开")
 	}
-	rows, err := m.conn.Query(query)
+	rows, err := m.conn.QueryContext(metadataContextFor(m), query)
 	if err != nil {
 		return nil, err
 	}
@@ -957,7 +957,7 @@ func (m *MySQLDB) Query(query string) ([]map[string]interface{}, []string, error
 		return nil, nil, fmt.Errorf("连接未打开")
 	}
 
-	rows, err := m.conn.Query(query)
+	rows, err := m.conn.QueryContext(metadataContextFor(m), query)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/db/oceanbase_impl.go
+++ b/internal/db/oceanbase_impl.go
@@ -824,6 +824,14 @@ func (o *OceanBaseDB) activeDatabase() Database {
 	return &o.MySQLDB
 }
 
+func (o *OceanBaseDB) bindMetadataContext(ctx context.Context) {
+	BindMetadataContext(o.activeDatabase(), ctx)
+}
+
+func (o *OceanBaseDB) clearMetadataContext() {
+	ClearMetadataContext(o.activeDatabase())
+}
+
 func (o *OceanBaseDB) Close() error {
 	if o.oracle != nil {
 		err := o.oracle.Close()

--- a/internal/db/opengauss_impl.go
+++ b/internal/db/opengauss_impl.go
@@ -3,6 +3,7 @@
 package db
 
 import (
+	"context"
 	"net"
 	"strconv"
 	"strings"
@@ -15,6 +16,14 @@ const defaultOpenGaussPort = 5432
 // OpenGaussDB 使用 PostgreSQL wire protocol 兼容链路，通过独立 agent 类型暴露。
 type OpenGaussDB struct {
 	PostgresDB
+}
+
+func (o *OpenGaussDB) bindMetadataContext(ctx context.Context) {
+	BindMetadataContext(&o.PostgresDB, ctx)
+}
+
+func (o *OpenGaussDB) clearMetadataContext() {
+	ClearMetadataContext(&o.PostgresDB)
 }
 
 func applyOpenGaussURI(config connection.ConnectionConfig) connection.ConnectionConfig {

--- a/internal/db/optional_driver_agent_impl.go
+++ b/internal/db/optional_driver_agent_impl.go
@@ -419,11 +419,18 @@ func optionalAgentContextError(driverType, method string, err error) error {
 }
 
 func (c *optionalDriverAgentClient) callWithTimeout(req optionalAgentRequest, out interface{}, fields *[]string, messages *[]string, rowsAffected *int64, timeout time.Duration) error {
+	return c.callWithContext(context.Background(), req, out, fields, messages, rowsAffected, timeout)
+}
+
+func (c *optionalDriverAgentClient) callWithContext(ctx context.Context, req optionalAgentRequest, out interface{}, fields *[]string, messages *[]string, rowsAffected *int64, timeout time.Duration) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if timeout <= 0 {
-		return c.call(req, out, fields, messages, rowsAffected)
+		return c.callContext(ctx, req, out, fields, messages, rowsAffected)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	err := c.callContext(ctx, req, out, fields, messages, rowsAffected)
 	if errors.Is(err, context.DeadlineExceeded) && req.Method == optionalAgentMethodMetadata {
@@ -801,25 +808,12 @@ func (d *OptionalDriverAgentDB) QueryContextWithMessages(ctx context.Context, qu
 }
 
 func (d *OptionalDriverAgentDB) Query(query string) ([]map[string]interface{}, []string, error) {
-	data, fields, _, err := d.QueryWithMessages(query)
+	data, fields, _, err := d.QueryContextWithMessages(metadataContextFor(d), query)
 	return data, fields, err
 }
 
 func (d *OptionalDriverAgentDB) QueryWithMessages(query string) ([]map[string]interface{}, []string, []string, error) {
-	client, err := d.requireClient()
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	var data []map[string]interface{}
-	var fields []string
-	var messages []string
-	if err := client.call(optionalAgentRequest{
-		Method: optionalAgentMethodQuery,
-		Query:  query,
-	}, &data, &fields, &messages, nil); err != nil {
-		return nil, nil, nil, err
-	}
-	return data, fields, messages, nil
+	return d.QueryContextWithMessages(metadataContextFor(d), query)
 }
 
 func (d *OptionalDriverAgentDB) QueryMulti(query string) ([]connection.ResultSetData, error) {
@@ -1180,7 +1174,7 @@ func (d *OptionalDriverAgentDB) GetDatabases() ([]string, error) {
 		return nil, err
 	}
 	var dbs []string
-	if err := client.callWithTimeout(optionalAgentRequest{
+	if err := client.callWithContext(metadataContextFor(d), optionalAgentRequest{
 		Method: optionalAgentMethodGetDatabases,
 	}, &dbs, nil, nil, nil, optionalAgentControlCallTimeout); err != nil {
 		return nil, err
@@ -1194,7 +1188,7 @@ func (d *OptionalDriverAgentDB) GetTables(dbName string) ([]string, error) {
 		return nil, err
 	}
 	var tables []string
-	if err := client.callWithTimeout(optionalAgentRequest{
+	if err := client.callWithContext(metadataContextFor(d), optionalAgentRequest{
 		Method: optionalAgentMethodGetTables,
 		DBName: dbName,
 	}, &tables, nil, nil, nil, optionalAgentControlCallTimeout); err != nil {
@@ -1209,7 +1203,7 @@ func (d *OptionalDriverAgentDB) TableExists(dbName, tableName string) (bool, err
 		return false, err
 	}
 	var exists bool
-	err = client.callWithTimeout(optionalAgentRequest{
+	err = client.callWithContext(metadataContextFor(d), optionalAgentRequest{
 		Method:    optionalAgentMethodTableExists,
 		DBName:    dbName,
 		TableName: tableName,
@@ -1262,7 +1256,7 @@ func (d *OptionalDriverAgentDB) GetCreateStatement(dbName, tableName string) (st
 		return "", err
 	}
 	var sqlText string
-	if err := client.callWithTimeout(optionalAgentRequest{
+	if err := client.callWithContext(metadataContextFor(d), optionalAgentRequest{
 		Method:    optionalAgentMethodGetCreateStmt,
 		DBName:    dbName,
 		TableName: tableName,
@@ -1278,7 +1272,7 @@ func (d *OptionalDriverAgentDB) GetColumns(dbName, tableName string) ([]connecti
 		return nil, err
 	}
 	var columns []connection.ColumnDefinition
-	if err := client.callWithTimeout(optionalAgentRequest{
+	if err := client.callWithContext(metadataContextFor(d), optionalAgentRequest{
 		Method:    optionalAgentMethodGetColumns,
 		DBName:    dbName,
 		TableName: tableName,
@@ -1294,7 +1288,7 @@ func (d *OptionalDriverAgentDB) GetAllColumns(dbName string) ([]connection.Colum
 		return nil, err
 	}
 	var columns []connection.ColumnDefinitionWithTable
-	if err := client.callWithTimeout(optionalAgentRequest{
+	if err := client.callWithContext(metadataContextFor(d), optionalAgentRequest{
 		Method: optionalAgentMethodGetAllColumns,
 		DBName: dbName,
 	}, &columns, nil, nil, nil, optionalAgentControlCallTimeout); err != nil {
@@ -1309,7 +1303,7 @@ func (d *OptionalDriverAgentDB) GetIndexes(dbName, tableName string) ([]connecti
 		return nil, err
 	}
 	var indexes []connection.IndexDefinition
-	if err := client.callWithTimeout(optionalAgentRequest{
+	if err := client.callWithContext(metadataContextFor(d), optionalAgentRequest{
 		Method:    optionalAgentMethodGetIndexes,
 		DBName:    dbName,
 		TableName: tableName,
@@ -1325,7 +1319,7 @@ func (d *OptionalDriverAgentDB) GetForeignKeys(dbName, tableName string) ([]conn
 		return nil, err
 	}
 	var keys []connection.ForeignKeyDefinition
-	if err := client.callWithTimeout(optionalAgentRequest{
+	if err := client.callWithContext(metadataContextFor(d), optionalAgentRequest{
 		Method:    optionalAgentMethodGetForeignKeys,
 		DBName:    dbName,
 		TableName: tableName,
@@ -1341,7 +1335,7 @@ func (d *OptionalDriverAgentDB) GetTriggers(dbName, tableName string) ([]connect
 		return nil, err
 	}
 	var triggers []connection.TriggerDefinition
-	if err := client.callWithTimeout(optionalAgentRequest{
+	if err := client.callWithContext(metadataContextFor(d), optionalAgentRequest{
 		Method:    optionalAgentMethodGetTriggers,
 		DBName:    dbName,
 		TableName: tableName,

--- a/internal/db/optional_driver_agent_impl.go
+++ b/internal/db/optional_driver_agent_impl.go
@@ -649,6 +649,20 @@ type optionalDriverAgentTransactionalDB struct {
 	*OptionalDriverAgentDB
 }
 
+func (d *optionalDriverAgentTransactionalDB) bindMetadataContext(ctx context.Context) {
+	if d == nil || d.OptionalDriverAgentDB == nil {
+		return
+	}
+	BindMetadataContext(d.OptionalDriverAgentDB, ctx)
+}
+
+func (d *optionalDriverAgentTransactionalDB) clearMetadataContext() {
+	if d == nil || d.OptionalDriverAgentDB == nil {
+		return
+	}
+	ClearMetadataContext(d.OptionalDriverAgentDB)
+}
+
 type optionalDriverAgentSession struct {
 	client    *optionalDriverAgentClient
 	driver    string

--- a/internal/db/oracle_impl.go
+++ b/internal/db/oracle_impl.go
@@ -280,7 +280,7 @@ func (o *OracleDB) Query(query string) ([]map[string]interface{}, []string, erro
 		return nil, nil, fmt.Errorf("连接未打开")
 	}
 
-	rows, err := o.conn.Query(query)
+	rows, err := o.conn.QueryContext(metadataContextFor(o), query)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -293,7 +293,7 @@ func (o *OracleDB) queryUnbounded(query string) ([]map[string]interface{}, []str
 		return nil, nil, fmt.Errorf("连接未打开")
 	}
 
-	rows, err := o.conn.Query(query)
+	rows, err := o.conn.QueryContext(metadataContextFor(o), query)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -484,7 +484,7 @@ func (o *OracleDB) inferOracleColumnsFromSelect(dbName string, tableName string)
 	var firstErr error
 	for _, candidate := range oracleMetadataNamePairs(dbName, tableName) {
 		query := "SELECT * FROM " + quoteOracleTableRef(candidate.schema, candidate.table) + " WHERE 1 = 0"
-		rows, err := o.conn.Query(query)
+		rows, err := o.conn.QueryContext(metadataContextFor(o), query)
 		if err != nil {
 			if firstErr == nil {
 				firstErr = err

--- a/internal/db/postgres_impl.go
+++ b/internal/db/postgres_impl.go
@@ -246,7 +246,7 @@ func (p *PostgresDB) Query(query string) ([]map[string]interface{}, []string, er
 		return nil, nil, fmt.Errorf("连接未打开")
 	}
 
-	rows, err := p.conn.Query(query)
+	rows, err := p.conn.QueryContext(metadataContextFor(p), query)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -255,7 +255,7 @@ func (p *PostgresDB) Query(query string) ([]map[string]interface{}, []string, er
 }
 
 func (p *PostgresDB) QueryWithMessages(query string) ([]map[string]interface{}, []string, []string, error) {
-	return p.QueryContextWithMessages(context.Background(), query)
+	return p.QueryContextWithMessages(metadataContextFor(p), query)
 }
 
 func (p *PostgresDB) ExecBatchContext(ctx context.Context, query string) (int64, error) {
@@ -621,7 +621,7 @@ func (p *PostgresDB) queryUserSchemas() []string {
 		  AND nspname NOT LIKE 'pg|_%' ESCAPE '|'
 		ORDER BY nspname`
 
-	rows, err := p.conn.Query(query)
+	rows, err := p.conn.QueryContext(metadataContextFor(p), query)
 	if err != nil {
 		logger.Warnf("PostgreSQL 查询用户 schema 失败：%v", err)
 		return nil

--- a/internal/db/qdrant_impl.go
+++ b/internal/db/qdrant_impl.go
@@ -221,7 +221,7 @@ func (q *QdrantDB) GetDatabases() ([]string, error) {
 }
 
 func (q *QdrantDB) GetTables(dbName string) ([]string, error) {
-	collections, err := q.listCollections(context.Background())
+	collections, err := q.listCollections(metadataContextFor(q))
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +236,7 @@ func (q *QdrantDB) GetTables(dbName string) ([]string, error) {
 }
 
 func (q *QdrantDB) GetCreateStatement(dbName, tableName string) (string, error) {
-	info, err := q.getCollectionInfo(context.Background(), tableNameOrDB(dbName, tableName))
+	info, err := q.getCollectionInfo(metadataContextFor(q), tableNameOrDB(dbName, tableName))
 	if err != nil {
 		return "", err
 	}
@@ -245,7 +245,7 @@ func (q *QdrantDB) GetCreateStatement(dbName, tableName string) (string, error) 
 }
 
 func (q *QdrantDB) GetColumns(dbName, tableName string) ([]connection.ColumnDefinition, error) {
-	info, err := q.getCollectionInfo(context.Background(), tableNameOrDB(dbName, tableName))
+	info, err := q.getCollectionInfo(metadataContextFor(q), tableNameOrDB(dbName, tableName))
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +285,7 @@ func (q *QdrantDB) GetIndexes(dbName, tableName string) ([]connection.IndexDefin
 	indexes := []connection.IndexDefinition{
 		{Name: "PRIMARY", ColumnName: "id", NonUnique: 0, SeqInIndex: 1, IndexType: "PRIMARY"},
 	}
-	info, err := q.getCollectionInfo(context.Background(), tableNameOrDB(dbName, tableName))
+	info, err := q.getCollectionInfo(metadataContextFor(q), tableNameOrDB(dbName, tableName))
 	if err == nil {
 		indexes = append(indexes, qdrantVectorIndexes(info)...)
 		indexes = append(indexes, qdrantPayloadIndexes(info)...)

--- a/internal/db/rabbitmq_impl.go
+++ b/internal/db/rabbitmq_impl.go
@@ -318,7 +318,7 @@ func (r *RabbitMQDB) GetDatabases() ([]string, error) {
 	if r.client == nil {
 		return nil, fmt.Errorf("连接未打开")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(r), 10*time.Second)
 	defer cancel()
 
 	items, err := r.listVHosts(ctx, 0)
@@ -342,7 +342,7 @@ func (r *RabbitMQDB) GetTables(dbName string) ([]string, error) {
 	if r.client == nil {
 		return nil, fmt.Errorf("连接未打开")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(r), 10*time.Second)
 	defer cancel()
 
 	vhost := rabbitmqResolveVHost(dbName, r.defaultVHost)
@@ -369,7 +369,7 @@ func (r *RabbitMQDB) GetCreateStatement(dbName, tableName string) (string, error
 	if queue == "" {
 		return "", fmt.Errorf("RabbitMQ queue 不能为空")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(r), 10*time.Second)
 	defer cancel()
 
 	info, err := r.getQueueInfo(ctx, vhost, queue)

--- a/internal/db/rocketmq_impl.go
+++ b/internal/db/rocketmq_impl.go
@@ -343,7 +343,7 @@ func (r *RocketMQDB) GetTables(dbName string) ([]string, error) {
 	if r.runtime == nil {
 		return nil, fmt.Errorf("连接未打开")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(r), 10*time.Second)
 	defer cancel()
 	topics, err := r.runtime.ListTopics(ctx, false)
 	if err != nil {
@@ -363,7 +363,7 @@ func (r *RocketMQDB) GetCreateStatement(dbName, tableName string) (string, error
 	if r.runtime == nil {
 		return "", fmt.Errorf("连接未打开")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(r), 10*time.Second)
 	defer cancel()
 	topic := rocketmqResolveTopic(tableName, r.defaultTopic)
 	if topic == "" {

--- a/internal/db/sphinx_impl.go
+++ b/internal/db/sphinx_impl.go
@@ -3,6 +3,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -16,6 +17,14 @@ const sphinxDefaultDatabaseName = "default"
 type SphinxDB struct {
 	MySQLDB
 	fallbackDatabase string
+}
+
+func (s *SphinxDB) bindMetadataContext(ctx context.Context) {
+	BindMetadataContext(&s.MySQLDB, ctx)
+}
+
+func (s *SphinxDB) clearMetadataContext() {
+	ClearMetadataContext(&s.MySQLDB)
 }
 
 func isSphinxUnsupportedFeatureError(err error) bool {

--- a/internal/db/sqlite_impl.go
+++ b/internal/db/sqlite_impl.go
@@ -217,7 +217,7 @@ func (s *SQLiteDB) Query(query string) ([]map[string]interface{}, []string, erro
 		return nil, nil, fmt.Errorf("连接未打开")
 	}
 
-	rows, err := s.conn.Query(query)
+	rows, err := s.conn.QueryContext(metadataContextFor(s), query)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/db/sqlserver_impl.go
+++ b/internal/db/sqlserver_impl.go
@@ -297,7 +297,7 @@ func (s *SqlServerDB) Query(query string) ([]map[string]interface{}, []string, e
 }
 
 func (s *SqlServerDB) QueryWithMessages(query string) ([]map[string]interface{}, []string, []string, error) {
-	return s.QueryContextWithMessages(context.Background(), query)
+	return s.QueryContextWithMessages(metadataContextFor(s), query)
 }
 
 func (s *SqlServerDB) ExecContext(ctx context.Context, query string) (int64, error) {

--- a/internal/db/starrocks_impl.go
+++ b/internal/db/starrocks_impl.go
@@ -3,6 +3,7 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -22,6 +23,14 @@ const (
 // StarRocksDB 使用独立 driver 名称接入，底层协议兼容 MySQL。
 type StarRocksDB struct {
 	MySQLDB
+}
+
+func (s *StarRocksDB) bindMetadataContext(ctx context.Context) {
+	BindMetadataContext(&s.MySQLDB, ctx)
+}
+
+func (s *StarRocksDB) clearMetadataContext() {
+	ClearMetadataContext(&s.MySQLDB)
 }
 
 func init() {

--- a/internal/db/tdengine_impl.go
+++ b/internal/db/tdengine_impl.go
@@ -169,7 +169,7 @@ func (t *TDengineDB) Query(query string) ([]map[string]interface{}, []string, er
 		return nil, nil, fmt.Errorf("连接未打开")
 	}
 
-	rows, err := t.conn.Query(query)
+	rows, err := t.conn.QueryContext(metadataContextFor(t), query)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/db/trino_impl.go
+++ b/internal/db/trino_impl.go
@@ -417,7 +417,7 @@ func (t *TrinoDB) QueryContext(ctx context.Context, query string) ([]map[string]
 }
 
 func (t *TrinoDB) Query(query string) ([]map[string]interface{}, []string, error) {
-	return t.QueryContext(context.Background(), query)
+	return t.QueryContext(metadataContextFor(t), query)
 }
 
 func (t *TrinoDB) StreamQueryContext(ctx context.Context, query string, consumer QueryStreamConsumer) error {

--- a/internal/db/vastbase_impl.go
+++ b/internal/db/vastbase_impl.go
@@ -164,7 +164,7 @@ func (v *VastbaseDB) Query(query string) ([]map[string]interface{}, []string, er
 		return nil, nil, fmt.Errorf("连接未打开")
 	}
 
-	rows, err := v.conn.Query(query)
+	rows, err := v.conn.QueryContext(metadataContextFor(v), query)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/mcpserver/backend.go
+++ b/internal/mcpserver/backend.go
@@ -19,16 +19,16 @@ type Backend interface {
 	Close(context.Context) error
 	GetSavedConnections() ([]connection.SavedConnectionView, error)
 	GetEditableSavedConnection(id string) (connection.SavedConnectionView, error)
-	DBGetDatabases(config connection.ConnectionConfig) connection.QueryResult
-	DBGetTables(config connection.ConnectionConfig, dbName string) connection.QueryResult
-	DBGetViews(config connection.ConnectionConfig, dbName string) connection.QueryResult
-	DBGetObjects(config connection.ConnectionConfig, dbName string) connection.QueryResult
-	DBGetAllColumns(config connection.ConnectionConfig, dbName string) connection.QueryResult
-	DBGetColumns(config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult
-	DBGetIndexes(config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult
-	DBGetForeignKeys(config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult
-	DBGetTriggers(config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult
-	DBShowCreateTable(config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult
+	DBGetDatabases(context.Context, connection.ConnectionConfig) connection.QueryResult
+	DBGetTables(context.Context, connection.ConnectionConfig, string) connection.QueryResult
+	DBGetViews(context.Context, connection.ConnectionConfig, string) connection.QueryResult
+	DBGetObjects(context.Context, connection.ConnectionConfig, string) connection.QueryResult
+	DBGetAllColumns(context.Context, connection.ConnectionConfig, string) connection.QueryResult
+	DBGetColumns(context.Context, connection.ConnectionConfig, string, string) connection.QueryResult
+	DBGetIndexes(context.Context, connection.ConnectionConfig, string, string) connection.QueryResult
+	DBGetForeignKeys(context.Context, connection.ConnectionConfig, string, string) connection.QueryResult
+	DBGetTriggers(context.Context, connection.ConnectionConfig, string, string) connection.QueryResult
+	DBShowCreateTable(context.Context, connection.ConnectionConfig, string, string) connection.QueryResult
 	ExecuteSQLFromMCP(context.Context, connection.ConnectionConfig, string, string) connection.QueryResult
 	InspectSQL(dbType string, sql string) appcore.SQLInspection
 	GetSQLSafetyLevel() ai.SQLPermissionLevel
@@ -82,44 +82,44 @@ func (b *AppBackend) GetEditableSavedConnection(id string) (connection.SavedConn
 	return b.app.GetEditableSavedConnection(id)
 }
 
-func (b *AppBackend) DBGetDatabases(config connection.ConnectionConfig) connection.QueryResult {
-	return b.app.DBGetDatabases(config)
+func (b *AppBackend) DBGetDatabases(ctx context.Context, config connection.ConnectionConfig) connection.QueryResult {
+	return b.app.DBGetDatabasesContext(ctx, config)
 }
 
-func (b *AppBackend) DBGetTables(config connection.ConnectionConfig, dbName string) connection.QueryResult {
-	return b.app.DBGetTables(config, dbName)
+func (b *AppBackend) DBGetTables(ctx context.Context, config connection.ConnectionConfig, dbName string) connection.QueryResult {
+	return b.app.DBGetTablesContext(ctx, config, dbName)
 }
 
-func (b *AppBackend) DBGetViews(config connection.ConnectionConfig, dbName string) connection.QueryResult {
-	return b.app.DBGetViews(config, dbName)
+func (b *AppBackend) DBGetViews(ctx context.Context, config connection.ConnectionConfig, dbName string) connection.QueryResult {
+	return b.app.DBGetViewsContext(ctx, config, dbName)
 }
 
-func (b *AppBackend) DBGetObjects(config connection.ConnectionConfig, dbName string) connection.QueryResult {
-	return b.app.DBGetObjects(config, dbName)
+func (b *AppBackend) DBGetObjects(ctx context.Context, config connection.ConnectionConfig, dbName string) connection.QueryResult {
+	return b.app.DBGetObjectsContext(ctx, config, dbName)
 }
 
-func (b *AppBackend) DBGetAllColumns(config connection.ConnectionConfig, dbName string) connection.QueryResult {
-	return b.app.DBGetAllColumns(config, dbName)
+func (b *AppBackend) DBGetAllColumns(ctx context.Context, config connection.ConnectionConfig, dbName string) connection.QueryResult {
+	return b.app.DBGetAllColumnsContext(ctx, config, dbName)
 }
 
-func (b *AppBackend) DBGetColumns(config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
-	return b.app.DBGetColumns(config, dbName, tableName)
+func (b *AppBackend) DBGetColumns(ctx context.Context, config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
+	return b.app.DBGetColumnsContext(ctx, config, dbName, tableName)
 }
 
-func (b *AppBackend) DBGetIndexes(config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
-	return b.app.DBGetIndexes(config, dbName, tableName)
+func (b *AppBackend) DBGetIndexes(ctx context.Context, config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
+	return b.app.DBGetIndexesContext(ctx, config, dbName, tableName)
 }
 
-func (b *AppBackend) DBGetForeignKeys(config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
-	return b.app.DBGetForeignKeys(config, dbName, tableName)
+func (b *AppBackend) DBGetForeignKeys(ctx context.Context, config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
+	return b.app.DBGetForeignKeysContext(ctx, config, dbName, tableName)
 }
 
-func (b *AppBackend) DBGetTriggers(config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
-	return b.app.DBGetTriggers(config, dbName, tableName)
+func (b *AppBackend) DBGetTriggers(ctx context.Context, config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
+	return b.app.DBGetTriggersContext(ctx, config, dbName, tableName)
 }
 
-func (b *AppBackend) DBShowCreateTable(config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
-	return b.app.DBShowCreateTable(config, dbName, tableName)
+func (b *AppBackend) DBShowCreateTable(ctx context.Context, config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
+	return b.app.DBShowCreateTableContext(ctx, config, dbName, tableName)
 }
 
 // ExecuteAuthorizedSQLFromMCP resolves the saved connection and checks its

--- a/internal/mcpserver/service.go
+++ b/internal/mcpserver/service.go
@@ -222,7 +222,6 @@ func (s *Service) GetConnections(ctx context.Context, req *mcp.CallToolRequest, 
 }
 
 func (s *Service) GetDatabases(ctx context.Context, req *mcp.CallToolRequest, args connectionIDArgs) (*mcp.CallToolResult, getDatabasesResult, error) {
-	_ = ctx
 	_ = req
 
 	view, errResult := s.resolveConnection(args.ConnectionID)
@@ -230,7 +229,7 @@ func (s *Service) GetDatabases(ctx context.Context, req *mcp.CallToolRequest, ar
 		return errResult, getDatabasesResult{}, nil
 	}
 
-	queryResult := s.backend.DBGetDatabases(view.Config)
+	queryResult := s.backend.DBGetDatabases(ctx, view.Config)
 	if !queryResult.Success {
 		return toolError("获取数据库列表失败: %s", strings.TrimSpace(queryResult.Message)), getDatabasesResult{}, nil
 	}
@@ -247,7 +246,6 @@ func (s *Service) GetDatabases(ctx context.Context, req *mcp.CallToolRequest, ar
 }
 
 func (s *Service) GetTables(ctx context.Context, req *mcp.CallToolRequest, args databaseArgs) (*mcp.CallToolResult, getTablesResult, error) {
-	_ = ctx
 	_ = req
 
 	view, errResult := s.resolveConnection(args.ConnectionID)
@@ -256,7 +254,7 @@ func (s *Service) GetTables(ctx context.Context, req *mcp.CallToolRequest, args 
 	}
 
 	dbName := effectiveDBName(args.DBName, view.Config)
-	queryResult := s.backend.DBGetTables(view.Config, dbName)
+	queryResult := s.backend.DBGetTables(ctx, view.Config, dbName)
 	if !queryResult.Success {
 		return toolError("获取表列表失败: %s", strings.TrimSpace(queryResult.Message)), getTablesResult{}, nil
 	}
@@ -265,9 +263,15 @@ func (s *Service) GetTables(ctx context.Context, req *mcp.CallToolRequest, args 
 	if err != nil {
 		return toolError("解析表列表失败: %v", err), getTablesResult{}, nil
 	}
+	if err := ctx.Err(); err != nil {
+		return toolError("获取表列表失败: %s", err), getTablesResult{}, nil
+	}
 
 	views := []string{}
-	viewResult := s.backend.DBGetViews(view.Config, dbName)
+	viewResult := s.backend.DBGetViews(ctx, view.Config, dbName)
+	if err := ctx.Err(); err != nil {
+		return toolError("获取表列表失败: %s", err), getTablesResult{}, nil
+	}
 	if viewResult.Success {
 		if decodedViews, decodeErr := decodeNamedStringSlice(viewResult.Data, "View", "view", "name"); decodeErr == nil {
 			views = decodedViews
@@ -289,7 +293,6 @@ func (s *Service) GetTables(ctx context.Context, req *mcp.CallToolRequest, args 
 }
 
 func (s *Service) GetViews(ctx context.Context, req *mcp.CallToolRequest, args databaseArgs) (*mcp.CallToolResult, getViewsResult, error) {
-	_ = ctx
 	_ = req
 
 	view, errResult := s.resolveConnection(args.ConnectionID)
@@ -298,7 +301,7 @@ func (s *Service) GetViews(ctx context.Context, req *mcp.CallToolRequest, args d
 	}
 
 	dbName := effectiveDBName(args.DBName, view.Config)
-	queryResult := s.backend.DBGetViews(view.Config, dbName)
+	queryResult := s.backend.DBGetViews(ctx, view.Config, dbName)
 	if !queryResult.Success {
 		return toolError("获取视图列表失败: %s", strings.TrimSpace(queryResult.Message)), getViewsResult{}, nil
 	}
@@ -316,7 +319,6 @@ func (s *Service) GetViews(ctx context.Context, req *mcp.CallToolRequest, args d
 }
 
 func (s *Service) GetObjects(ctx context.Context, req *mcp.CallToolRequest, args objectsArgs) (*mcp.CallToolResult, getObjectsResult, error) {
-	_ = ctx
 	_ = req
 
 	view, errResult := s.resolveConnection(args.ConnectionID)
@@ -325,7 +327,7 @@ func (s *Service) GetObjects(ctx context.Context, req *mcp.CallToolRequest, args
 	}
 
 	dbName := effectiveDBName(args.DBName, view.Config)
-	queryResult := s.backend.DBGetObjects(view.Config, dbName)
+	queryResult := s.backend.DBGetObjects(ctx, view.Config, dbName)
 	if !queryResult.Success {
 		output := getObjectsResult{
 			ConnectionID:      view.ID,
@@ -379,7 +381,6 @@ func objectMetadataWarnings(result connection.QueryResult) []string {
 }
 
 func (s *Service) GetAllColumns(ctx context.Context, req *mcp.CallToolRequest, args databaseArgs) (*mcp.CallToolResult, getAllColumnsResult, error) {
-	_ = ctx
 	_ = req
 
 	view, errResult := s.resolveConnection(args.ConnectionID)
@@ -392,7 +393,7 @@ func (s *Service) GetAllColumns(ctx context.Context, req *mcp.CallToolRequest, a
 		return toolError("dbName 不能为空"), getAllColumnsResult{}, nil
 	}
 
-	queryResult := s.backend.DBGetAllColumns(view.Config, dbName)
+	queryResult := s.backend.DBGetAllColumns(ctx, view.Config, dbName)
 	if !queryResult.Success {
 		return toolError("获取全库字段摘要失败: %s", strings.TrimSpace(queryResult.Message)), getAllColumnsResult{}, nil
 	}
@@ -410,7 +411,6 @@ func (s *Service) GetAllColumns(ctx context.Context, req *mcp.CallToolRequest, a
 }
 
 func (s *Service) GetColumns(ctx context.Context, req *mcp.CallToolRequest, args tableArgs) (*mcp.CallToolResult, getColumnsResult, error) {
-	_ = ctx
 	_ = req
 
 	view, errResult := s.resolveConnection(args.ConnectionID)
@@ -424,7 +424,7 @@ func (s *Service) GetColumns(ctx context.Context, req *mcp.CallToolRequest, args
 	}
 
 	dbName := effectiveDBName(args.DBName, view.Config)
-	queryResult := s.backend.DBGetColumns(view.Config, dbName, tableName)
+	queryResult := s.backend.DBGetColumns(ctx, view.Config, dbName, tableName)
 	if !queryResult.Success {
 		return toolError("获取字段列表失败: %s", strings.TrimSpace(queryResult.Message)), getColumnsResult{}, nil
 	}
@@ -443,7 +443,6 @@ func (s *Service) GetColumns(ctx context.Context, req *mcp.CallToolRequest, args
 }
 
 func (s *Service) GetIndexes(ctx context.Context, req *mcp.CallToolRequest, args tableArgs) (*mcp.CallToolResult, getIndexesResult, error) {
-	_ = ctx
 	_ = req
 
 	view, errResult := s.resolveConnection(args.ConnectionID)
@@ -457,7 +456,7 @@ func (s *Service) GetIndexes(ctx context.Context, req *mcp.CallToolRequest, args
 	}
 
 	dbName := effectiveDBName(args.DBName, view.Config)
-	queryResult := s.backend.DBGetIndexes(view.Config, dbName, tableName)
+	queryResult := s.backend.DBGetIndexes(ctx, view.Config, dbName, tableName)
 	if !queryResult.Success {
 		return toolError("获取索引定义失败: %s", strings.TrimSpace(queryResult.Message)), getIndexesResult{}, nil
 	}
@@ -476,7 +475,6 @@ func (s *Service) GetIndexes(ctx context.Context, req *mcp.CallToolRequest, args
 }
 
 func (s *Service) GetForeignKeys(ctx context.Context, req *mcp.CallToolRequest, args tableArgs) (*mcp.CallToolResult, getForeignKeysResult, error) {
-	_ = ctx
 	_ = req
 
 	view, errResult := s.resolveConnection(args.ConnectionID)
@@ -490,7 +488,7 @@ func (s *Service) GetForeignKeys(ctx context.Context, req *mcp.CallToolRequest, 
 	}
 
 	dbName := effectiveDBName(args.DBName, view.Config)
-	queryResult := s.backend.DBGetForeignKeys(view.Config, dbName, tableName)
+	queryResult := s.backend.DBGetForeignKeys(ctx, view.Config, dbName, tableName)
 	if !queryResult.Success {
 		return toolError("获取外键关系失败: %s", strings.TrimSpace(queryResult.Message)), getForeignKeysResult{}, nil
 	}
@@ -509,7 +507,6 @@ func (s *Service) GetForeignKeys(ctx context.Context, req *mcp.CallToolRequest, 
 }
 
 func (s *Service) GetTriggers(ctx context.Context, req *mcp.CallToolRequest, args tableArgs) (*mcp.CallToolResult, getTriggersResult, error) {
-	_ = ctx
 	_ = req
 
 	view, errResult := s.resolveConnection(args.ConnectionID)
@@ -523,7 +520,7 @@ func (s *Service) GetTriggers(ctx context.Context, req *mcp.CallToolRequest, arg
 	}
 
 	dbName := effectiveDBName(args.DBName, view.Config)
-	queryResult := s.backend.DBGetTriggers(view.Config, dbName, tableName)
+	queryResult := s.backend.DBGetTriggers(ctx, view.Config, dbName, tableName)
 	if !queryResult.Success {
 		return toolError("获取触发器定义失败: %s", strings.TrimSpace(queryResult.Message)), getTriggersResult{}, nil
 	}
@@ -542,7 +539,6 @@ func (s *Service) GetTriggers(ctx context.Context, req *mcp.CallToolRequest, arg
 }
 
 func (s *Service) GetTableDDL(ctx context.Context, req *mcp.CallToolRequest, args tableArgs) (*mcp.CallToolResult, getTableDDLResult, error) {
-	_ = ctx
 	_ = req
 
 	view, errResult := s.resolveConnection(args.ConnectionID)
@@ -556,7 +552,7 @@ func (s *Service) GetTableDDL(ctx context.Context, req *mcp.CallToolRequest, arg
 	}
 
 	dbName := effectiveDBName(args.DBName, view.Config)
-	queryResult := s.backend.DBShowCreateTable(view.Config, dbName, tableName)
+	queryResult := s.backend.DBShowCreateTable(ctx, view.Config, dbName, tableName)
 	if !queryResult.Success {
 		return toolError("获取建表语句失败: %s", strings.TrimSpace(queryResult.Message)), getTableDDLResult{}, nil
 	}

--- a/internal/mcpserver/service_test.go
+++ b/internal/mcpserver/service_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"GoNavi-Wails/internal/ai"
 	appcore "GoNavi-Wails/internal/app"
@@ -39,6 +41,52 @@ type fakeBackend struct {
 	events              []string
 }
 
+type cancellableTablesBackend struct {
+	*fakeBackend
+	started chan struct{}
+	calls   atomic.Int32
+}
+
+func (b *cancellableTablesBackend) DBGetTables(ctx context.Context, _ connection.ConnectionConfig, _ string) connection.QueryResult {
+	if b.calls.Add(1) > 1 {
+		return b.tablesResult
+	}
+	select {
+	case b.started <- struct{}{}:
+	default:
+	}
+	<-ctx.Done()
+	return connection.QueryResult{Success: false, Message: ctx.Err().Error()}
+}
+
+type cancellableViewsBackend struct {
+	*fakeBackend
+	started chan struct{}
+}
+
+type cancellableColumnsBackend struct {
+	*fakeBackend
+	started chan struct{}
+}
+
+func (b *cancellableViewsBackend) DBGetViews(ctx context.Context, _ connection.ConnectionConfig, _ string) connection.QueryResult {
+	select {
+	case b.started <- struct{}{}:
+	default:
+	}
+	<-ctx.Done()
+	return connection.QueryResult{Success: false, Message: ctx.Err().Error()}
+}
+
+func (b *cancellableColumnsBackend) DBGetColumns(ctx context.Context, _ connection.ConnectionConfig, _ string, _ string) connection.QueryResult {
+	select {
+	case b.started <- struct{}{}:
+	default:
+	}
+	<-ctx.Done()
+	return connection.QueryResult{Success: false, Message: ctx.Err().Error()}
+}
+
 func (f *fakeBackend) Close(context.Context) error {
 	return nil
 }
@@ -51,43 +99,43 @@ func (f *fakeBackend) GetEditableSavedConnection(id string) (connection.SavedCon
 	return f.editableConnection, f.editableErr
 }
 
-func (f *fakeBackend) DBGetDatabases(config connection.ConnectionConfig) connection.QueryResult {
+func (f *fakeBackend) DBGetDatabases(context.Context, connection.ConnectionConfig) connection.QueryResult {
 	return f.databasesResult
 }
 
-func (f *fakeBackend) DBGetTables(config connection.ConnectionConfig, dbName string) connection.QueryResult {
+func (f *fakeBackend) DBGetTables(context.Context, connection.ConnectionConfig, string) connection.QueryResult {
 	return f.tablesResult
 }
 
-func (f *fakeBackend) DBGetViews(config connection.ConnectionConfig, dbName string) connection.QueryResult {
+func (f *fakeBackend) DBGetViews(context.Context, connection.ConnectionConfig, string) connection.QueryResult {
 	return f.viewsResult
 }
 
-func (f *fakeBackend) DBGetObjects(config connection.ConnectionConfig, dbName string) connection.QueryResult {
+func (f *fakeBackend) DBGetObjects(context.Context, connection.ConnectionConfig, string) connection.QueryResult {
 	return f.objectsResult
 }
 
-func (f *fakeBackend) DBGetAllColumns(config connection.ConnectionConfig, dbName string) connection.QueryResult {
+func (f *fakeBackend) DBGetAllColumns(context.Context, connection.ConnectionConfig, string) connection.QueryResult {
 	return f.allColumnsResult
 }
 
-func (f *fakeBackend) DBGetColumns(config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
+func (f *fakeBackend) DBGetColumns(context.Context, connection.ConnectionConfig, string, string) connection.QueryResult {
 	return f.columnsResult
 }
 
-func (f *fakeBackend) DBGetIndexes(config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
+func (f *fakeBackend) DBGetIndexes(context.Context, connection.ConnectionConfig, string, string) connection.QueryResult {
 	return f.indexesResult
 }
 
-func (f *fakeBackend) DBGetForeignKeys(config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
+func (f *fakeBackend) DBGetForeignKeys(context.Context, connection.ConnectionConfig, string, string) connection.QueryResult {
 	return f.foreignKeysResult
 }
 
-func (f *fakeBackend) DBGetTriggers(config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
+func (f *fakeBackend) DBGetTriggers(context.Context, connection.ConnectionConfig, string, string) connection.QueryResult {
 	return f.triggersResult
 }
 
-func (f *fakeBackend) DBShowCreateTable(config connection.ConnectionConfig, dbName string, tableName string) connection.QueryResult {
+func (f *fakeBackend) DBShowCreateTable(context.Context, connection.ConnectionConfig, string, string) connection.QueryResult {
 	return f.ddlResult
 }
 
@@ -115,6 +163,160 @@ func (f *fakeBackend) AuthorizeSQLConnection(config connection.ConnectionConfig,
 	f.authorizedSQL = sql
 	f.events = append(f.events, "authorize")
 	return f.authorizeErr
+}
+
+func TestGetTablesForwardsCancellationWithoutAffectingConcurrentRequests(t *testing.T) {
+	backend := &cancellableTablesBackend{
+		fakeBackend: &fakeBackend{
+			editableConnection: connection.SavedConnectionView{
+				ID:     "mysql-main",
+				Config: connection.ConnectionConfig{Type: "mysql", Database: "app"},
+			},
+			tablesResult: connection.QueryResult{
+				Success: true,
+				Data:    []map[string]string{{"Table": "users"}},
+			},
+		},
+		started: make(chan struct{}, 1),
+	}
+	service := NewService(backend)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	type callResult struct {
+		result *mcp.CallToolResult
+		output getTablesResult
+		err    error
+	}
+	firstResult := make(chan callResult, 1)
+	go func() {
+		result, output, err := service.GetTables(ctx, nil, databaseArgs{ConnectionID: "mysql-main", DBName: "app"})
+		firstResult <- callResult{result: result, output: output, err: err}
+	}()
+
+	select {
+	case <-backend.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetTables did not reach the cancellable backend")
+	}
+
+	secondResult, secondOutput, secondErr := service.GetTables(context.Background(), nil, databaseArgs{ConnectionID: "mysql-main", DBName: "app"})
+	if secondErr != nil || secondResult == nil || secondResult.IsError {
+		t.Fatalf("concurrent GetTables failed: result=%#v err=%v", secondResult, secondErr)
+	}
+	if len(secondOutput.Tables) != 1 || secondOutput.Tables[0] != "users" {
+		t.Fatalf("unexpected concurrent GetTables output: %#v", secondOutput)
+	}
+
+	cancel()
+	select {
+	case received := <-firstResult:
+		if received.err != nil {
+			t.Fatalf("cancelled GetTables returned transport error: %v", received.err)
+		}
+		if received.result == nil || !received.result.IsError {
+			t.Fatalf("cancelled GetTables should return a tool error, got %#v", received.result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancelled GetTables did not return")
+	}
+}
+
+func TestGetTablesReturnsCancellationWhenViewLookupIsCancelled(t *testing.T) {
+	backend := &cancellableViewsBackend{
+		fakeBackend: &fakeBackend{
+			editableConnection: connection.SavedConnectionView{
+				ID:     "mysql-main",
+				Config: connection.ConnectionConfig{Type: "mysql", Database: "app"},
+			},
+			tablesResult: connection.QueryResult{
+				Success: true,
+				Data:    []map[string]string{{"Table": "users"}},
+			},
+		},
+		started: make(chan struct{}, 1),
+	}
+	service := NewService(backend)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	type callResult struct {
+		result *mcp.CallToolResult
+		output getTablesResult
+		err    error
+	}
+	results := make(chan callResult, 1)
+	go func() {
+		result, output, err := service.GetTables(ctx, nil, databaseArgs{ConnectionID: "mysql-main", DBName: "app"})
+		results <- callResult{result: result, output: output, err: err}
+	}()
+
+	select {
+	case <-backend.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetTables did not reach the cancellable view lookup")
+	}
+	cancel()
+
+	select {
+	case received := <-results:
+		if received.err != nil {
+			t.Fatalf("cancelled GetTables returned transport error: %v", received.err)
+		}
+		if received.result == nil || !received.result.IsError {
+			t.Fatalf("cancelled view lookup should return a tool error, got %#v", received.result)
+		}
+		if len(received.output.Tables) != 0 || len(received.output.Views) != 0 {
+			t.Fatalf("cancelled view lookup returned partial metadata: %#v", received.output)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancelled view lookup did not return")
+	}
+}
+
+func TestGetColumnsForwardsCancellation(t *testing.T) {
+	backend := &cancellableColumnsBackend{
+		fakeBackend: &fakeBackend{
+			editableConnection: connection.SavedConnectionView{
+				ID:     "mysql-main",
+				Config: connection.ConnectionConfig{Type: "mysql", Database: "app"},
+			},
+		},
+		started: make(chan struct{}, 1),
+	}
+	service := NewService(backend)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	type callResult struct {
+		result *mcp.CallToolResult
+		output getColumnsResult
+		err    error
+	}
+	results := make(chan callResult, 1)
+	go func() {
+		result, output, err := service.GetColumns(ctx, nil, tableArgs{ConnectionID: "mysql-main", DBName: "app", TableName: "orders"})
+		results <- callResult{result: result, output: output, err: err}
+	}()
+
+	select {
+	case <-backend.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetColumns 未到达可取消后端")
+	}
+	cancel()
+
+	select {
+	case received := <-results:
+		if received.err != nil {
+			t.Fatalf("取消的 GetColumns 返回传输错误：%v", received.err)
+		}
+		if received.result == nil || !received.result.IsError {
+			t.Fatalf("取消的 GetColumns 应返回工具错误，实际为 %#v", received.result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("取消的 GetColumns 未返回")
+	}
 }
 
 func TestGetConnectionsReturnsSavedConnectionSummaries(t *testing.T) {

--- a/internal/redis/redis.go
+++ b/internal/redis/redis.go
@@ -1,6 +1,59 @@
 package redis
 
-import "GoNavi-Wails/internal/connection"
+import (
+	"context"
+	"reflect"
+	"sync"
+
+	"GoNavi-Wails/internal/connection"
+)
+
+var metadataContexts sync.Map
+
+type metadataContextKey struct {
+	typ reflect.Type
+	ptr uintptr
+}
+
+func metadataContextKeyFor(client any) (metadataContextKey, bool) {
+	value := reflect.ValueOf(client)
+	if !value.IsValid() || value.Kind() != reflect.Ptr || value.IsNil() {
+		return metadataContextKey{}, false
+	}
+	return metadataContextKey{typ: value.Type(), ptr: value.Pointer()}, true
+}
+
+// BindMetadataContext 将独立 Redis 客户端与请求上下文关联。
+func BindMetadataContext(client RedisClient, ctx context.Context) {
+	key, ok := metadataContextKeyFor(client)
+	if !ok || ctx == nil {
+		return
+	}
+	metadataContexts.Store(key, ctx)
+}
+
+// ClearMetadataContext 移除元数据调用创建的上下文关联。
+func ClearMetadataContext(client RedisClient) {
+	if key, ok := metadataContextKeyFor(client); ok {
+		metadataContexts.Delete(key)
+	}
+}
+
+// MetadataContext 返回绑定到隔离元数据客户端的请求上下文。
+func MetadataContext(client RedisClient) context.Context {
+	return metadataContextFor(client)
+}
+
+func metadataContextFor(client any) context.Context {
+	if key, ok := metadataContextKeyFor(client); ok {
+		if ctx, ok := metadataContexts.Load(key); ok {
+			if requestCtx, ok := ctx.(context.Context); ok && requestCtx != nil {
+				return requestCtx
+			}
+		}
+	}
+	return context.Background()
+}
 
 // RedisValue represents a Redis value with its type and metadata
 type RedisValue struct {

--- a/internal/redis/redis_impl.go
+++ b/internal/redis/redis_impl.go
@@ -588,13 +588,13 @@ func (r *RedisClientImpl) ScanKeys(pattern string, cursor uint64, count int64) (
 		maxDuration = redisSearchMaxDuration
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), maxDuration+5*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(r), maxDuration+5*time.Second)
 	defer cancel()
 
 	// 集群模式：逐 master 节点 SCAN 后合并去重
 	if r.isCluster && r.clusterClient != nil {
 		if isSearchPattern && !isExactPattern {
-			searchCtx, searchCancel := context.WithTimeout(context.Background(), maxDuration)
+			searchCtx, searchCancel := context.WithTimeout(metadataContextFor(r), maxDuration)
 			defer searchCancel()
 
 			keys := make([]string, 0, int(targetCount))
@@ -1782,7 +1782,7 @@ func (r *RedisClientImpl) GetDatabases() ([]RedisDBInfo, error) {
 	if r.client == nil {
 		return nil, fmt.Errorf("Redis 客户端未连接")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(r), 10*time.Second)
 	defer cancel()
 
 	if r.isCluster && r.clusterClient != nil {


### PR DESCRIPTION
## Summary
- Propagate the MCP request context through the metadata call chain: Backend interface methods now take `context.Context`, and the App layer gains `DBGet*Context` variants that bind the request context to isolated driver instances (`BindMetadataContext` / `metadataContextFor`).
- Driver metadata queries now use `QueryContext` / HTTP request context (MySQL, PostgreSQL, ClickHouse, Kafka, Elasticsearch, Redis, optional-driver agent, etc.), so cancelling GetTables/GetColumns stops the underlying query and releases the connection instead of only abandoning the MCP response wait.
- Each metadata request runs in an isolated session/App instance; cancellation closes only that session and does not affect concurrent requests.
- Close remaining cancellation gaps: export/object fallback queries, dameng transactional wrapper context bridging, Elasticsearch `TableExists`; document the driver cancellation contract on the `Database` interface.

## Verification
- `go build -tags dev ./...`
- `go test ./internal/mcpserver ./internal/db ./internal/redis`
- New regression tests cover: cancellation reaching the driver layer, concurrent-request isolation, metadata fallback paths, and updated fake backend success paths.

Closes #957