### PR TITLE
fix(postgres): preserve table comments in exports

### DIFF
--- a/internal/app/methods_db.go
+++ b/internal/app/methods_db.go
@@ -2871,6 +2871,7 @@ func resolveCreateStatementWithFallbackWithText(dbInst db.Database, config conne
 			if columns, err := loadCreateStatementCommentColumns(dbInst, dbType, metadataSchemaName, metadataTableName); err == nil {
 				sqlStr = appendCreateStatementColumnComments(dbType, ddlSchemaName, ddlTableName, sqlStr, columns)
 			}
+			sqlStr = appendCreateStatementTableComment(dbInst, dbType, metadataSchemaName, metadataTableName, ddlSchemaName, ddlTableName, sqlStr)
 			return sqlStr, nil
 		}
 		if isOceanBaseOracleProtocol(config) {
@@ -2920,6 +2921,7 @@ func resolveCreateStatementWithFallbackWithText(dbInst db.Database, config conne
 		}
 		return "", buildErr
 	}
+	fallbackDDL = appendCreateStatementTableComment(dbInst, dbType, metadataSchemaName, metadataTableName, ddlSchemaName, ddlTableName, fallbackDDL)
 	return fallbackDDL, nil
 }
 
@@ -3064,6 +3066,46 @@ func appendCreateStatementColumnComments(dbType string, schemaName string, table
 		trimmedDDL += ";"
 	}
 	return trimmedDDL + "\n" + strings.Join(commentStatements, "\n")
+}
+
+func appendCreateStatementTableComment(
+	dbInst db.Database,
+	dbType string,
+	metadataSchemaName string,
+	metadataTableName string,
+	ddlSchemaName string,
+	ddlTableName string,
+	ddl string,
+) string {
+	if dbType != "postgres" || strings.TrimSpace(ddl) == "" {
+		return ddl
+	}
+	provider, ok := dbInst.(db.TableCommentProvider)
+	if !ok {
+		return ddl
+	}
+
+	comment, err := provider.GetTableComment(metadataSchemaName, metadataTableName)
+	if err != nil || comment == "" {
+		return ddl
+	}
+
+	tableRef := quoteTableIdentByType(dbType, ddlSchemaName, ddlTableName)
+	marker := "COMMENT ON TABLE " + strings.ToUpper(tableRef)
+	if strings.Contains(strings.ToUpper(ddl), marker) {
+		return ddl
+	}
+
+	trimmedDDL := strings.TrimRight(ddl, " \t\r\n")
+	if !strings.HasSuffix(trimmedDDL, ";") {
+		trimmedDDL += ";"
+	}
+	return fmt.Sprintf(
+		"%s\nCOMMENT ON TABLE %s IS '%s';",
+		trimmedDDL,
+		tableRef,
+		escapeSQLStringLiteralBody(dbType, comment),
+	)
 }
 
 func buildFallbackCreateStatementWithText(dbType string, schemaName string, tableName string, columns []connection.ColumnDefinition, indexes []connection.IndexDefinition, text func(string, map[string]any) string) (string, error) {

--- a/internal/app/methods_file_export_test.go
+++ b/internal/app/methods_file_export_test.go
@@ -73,6 +73,15 @@ type fakeSQLDumpExportDB struct {
 	createErr error
 }
 
+type fakePostgresCommentExportDB struct {
+	fakeSQLDumpExportDB
+	tableComment      string
+	tableCommentErr   error
+	commentSchema     string
+	commentTable      string
+	tableCommentCalls int
+}
+
 type captureExportProgressEmitter struct {
 	events []exportProgressPayload
 }
@@ -135,6 +144,13 @@ func (f *fakeSQLDumpExportDB) GetTables(dbName string) ([]string, error) {
 
 func (f *fakeSQLDumpExportDB) GetCreateStatement(dbName, tableName string) (string, error) {
 	return f.createSQL, f.createErr
+}
+
+func (f *fakePostgresCommentExportDB) GetTableComment(dbName, tableName string) (string, error) {
+	f.tableCommentCalls++
+	f.commentSchema = dbName
+	f.commentTable = tableName
+	return f.tableComment, f.tableCommentErr
 }
 
 func (f *fakeStreamExportDB) Query(query string) ([]map[string]interface{}, []string, error) {
@@ -1736,6 +1752,86 @@ func TestDumpTableSQL_PostgresBooleanBackupUsesBooleanLiterals(t *testing.T) {
 	}
 	if strings.Contains(content, "VALUES (1, 0)") {
 		t.Fatalf("PostgreSQL bool 备份不应输出数字布尔值，content=%s", content)
+	}
+}
+
+func TestDumpTableSQL_PostgresBackupExportIncludesEscapedTableComment(t *testing.T) {
+	fake := &fakePostgresCommentExportDB{
+		fakeSQLDumpExportDB: fakeSQLDumpExportDB{
+			fakeExportQueryDB: fakeExportQueryDB{
+				defs: []connection.ColumnDefinition{{Name: "ID", Type: "bigint", Nullable: "NO"}},
+			},
+			createSQL: "-- SHOW CREATE TABLE not fully supported for PostgreSQL in this MVP.",
+		},
+		tableComment: "Owner's archive\\path\n第二行",
+	}
+	var buf bytes.Buffer
+	writer := bufio.NewWriter(&buf)
+
+	err := dumpTableSQL(
+		writer,
+		fake,
+		connection.ConnectionConfig{Type: "postgres"},
+		"app",
+		`"Sales.Schema"."Order.Items"`,
+		true,
+		true,
+		map[string]string{},
+	)
+	if err != nil {
+		t.Fatalf("dumpTableSQL returned error: %v", err)
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("flush exported SQL: %v", err)
+	}
+
+	content := buf.String()
+	for _, want := range []string{
+		`CREATE TABLE "Sales.Schema"."Order.Items"`,
+		"COMMENT ON TABLE \"Sales.Schema\".\"Order.Items\" IS 'Owner''s archive\\path\n第二行';",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("expected PostgreSQL backup export to contain %q, got %s", want, content)
+		}
+	}
+	if fake.tableCommentCalls != 1 || fake.commentSchema != "Sales.Schema" || fake.commentTable != "Order.Items" {
+		t.Fatalf("unexpected table-comment metadata target: calls=%d target=%q.%q", fake.tableCommentCalls, fake.commentSchema, fake.commentTable)
+	}
+}
+
+func TestDumpTableSQL_PostgresSchemaExportOmitsEmptyTableComment(t *testing.T) {
+	fake := &fakePostgresCommentExportDB{
+		fakeSQLDumpExportDB: fakeSQLDumpExportDB{
+			fakeExportQueryDB: fakeExportQueryDB{
+				defs: []connection.ColumnDefinition{{Name: "id", Type: "bigint", Nullable: "NO"}},
+			},
+			createSQL: "-- SHOW CREATE TABLE not fully supported for PostgreSQL in this MVP.",
+		},
+	}
+	var buf bytes.Buffer
+	writer := bufio.NewWriter(&buf)
+
+	if err := dumpTableSQL(
+		writer,
+		fake,
+		connection.ConnectionConfig{Type: "postgres"},
+		"app",
+		"public.orders",
+		true,
+		false,
+		map[string]string{},
+	); err != nil {
+		t.Fatalf("dumpTableSQL returned error: %v", err)
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("flush exported SQL: %v", err)
+	}
+
+	if content := buf.String(); strings.Contains(content, "COMMENT ON TABLE") {
+		t.Fatalf("empty PostgreSQL table comment should not emit DDL, got %s", content)
+	}
+	if fake.tableCommentCalls != 1 {
+		t.Fatalf("expected one table-comment metadata lookup, got %d", fake.tableCommentCalls)
 	}
 }
 

--- a/internal/app/postgres_export_e2e_test.go
+++ b/internal/app/postgres_export_e2e_test.go
@@ -1,0 +1,88 @@
+//go:build gonavi_postgres_e2e
+
+package app
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"GoNavi-Wails/internal/connection"
+	"GoNavi-Wails/internal/db"
+)
+
+func TestPostgresExportTableCommentE2E(t *testing.T) {
+	port := 55432
+	if rawPort := strings.TrimSpace(os.Getenv("GONAVI_E2E_PG_PORT")); rawPort != "" {
+		parsedPort, err := strconv.Atoi(rawPort)
+		if err != nil || parsedPort <= 0 {
+			t.Fatalf("invalid GONAVI_E2E_PG_PORT %q", rawPort)
+		}
+		port = parsedPort
+	}
+
+	config := connection.ConnectionConfig{
+		Type:     "postgres",
+		Host:     envOrDefault("GONAVI_E2E_PG_HOST", "127.0.0.1"),
+		Port:     port,
+		User:     envOrDefault("GONAVI_E2E_PG_USER", "gonavi_e2e"),
+		Password: envOrDefault("GONAVI_E2E_PG_PASSWORD", "gonavi_e2e_pw"),
+		Database: envOrDefault("GONAVI_E2E_PG_DATABASE", "gonavi_e2e"),
+		SSLMode:  "disable",
+		Timeout:  10,
+	}
+
+	client := &db.PostgresDB{}
+	if err := client.Connect(config); err != nil {
+		t.Fatalf("connect to PostgreSQL E2E database: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	for _, statement := range []string{
+		`DROP SCHEMA IF EXISTS "gonavi_e2e" CASCADE`,
+		`CREATE SCHEMA "gonavi_e2e"`,
+		`CREATE TABLE "gonavi_e2e"."orders" (id BIGINT PRIMARY KEY, note TEXT NOT NULL)`,
+		`COMMENT ON TABLE "gonavi_e2e"."orders" IS 'Owner''s archive\path 订单表'`,
+		`INSERT INTO "gonavi_e2e"."orders" (id, note) VALUES (1, 'e2e')`,
+	} {
+		if _, err := client.Exec(statement); err != nil {
+			t.Fatalf("execute PostgreSQL E2E setup statement %q: %v", statement, err)
+		}
+	}
+
+	const tableName = "gonavi_e2e.orders"
+	ddl, err := resolveCreateStatementWithFallback(client, config, config.Database, tableName)
+	if err != nil {
+		t.Fatalf("resolve PostgreSQL create statement: %v", err)
+	}
+
+	var output bytes.Buffer
+	writer := bufio.NewWriter(&output)
+	if err := dumpTableSQL(writer, client, config, config.Database, tableName, true, true, map[string]string{}); err != nil {
+		t.Fatalf("dump PostgreSQL table SQL: %v", err)
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("flush PostgreSQL table SQL: %v", err)
+	}
+
+	wantComment := `COMMENT ON TABLE "gonavi_e2e"."orders" IS 'Owner''s archive\path 订单表';`
+	if !strings.Contains(ddl, wantComment) {
+		t.Fatalf("resolved DDL is missing table comment %q: %s", wantComment, ddl)
+	}
+	if !strings.Contains(output.String(), wantComment) {
+		t.Fatalf("exported SQL is missing table comment %q: %s", wantComment, output.String())
+	}
+	if !strings.Contains(output.String(), `INSERT INTO "gonavi_e2e"."orders"`) {
+		t.Fatalf("exported SQL is missing inserted row: %s", output.String())
+	}
+}
+
+func envOrDefault(name, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+		return value
+	}
+	return fallback
+}

--- a/internal/db/database.go
+++ b/internal/db/database.go
@@ -174,6 +174,12 @@ type DatabaseForeignKeyProvider interface {
 	GetDatabaseForeignKeys(dbName string) (map[string][]connection.ForeignKeyDefinition, error)
 }
 
+// TableCommentProvider is an optional metadata interface for drivers that can
+// load a table-level comment for schema/backup DDL generation.
+type TableCommentProvider interface {
+	GetTableComment(dbName, tableName string) (string, error)
+}
+
 // TableExistsChecker is an optional point lookup for a table's canonical
 // metadata identity. Callers must pass the exact name returned by driver
 // metadata; this interface does not parse arbitrary SQL identifiers.

--- a/internal/db/pg_metadata.go
+++ b/internal/db/pg_metadata.go
@@ -137,6 +137,29 @@ WHERE t.event_object_table = '%s'
 ORDER BY t.trigger_name, t.event_manipulation`, escapePGLikeMetadataLiteral(tableName), buildPGLikeVisibleRelationPredicate("c", schemaName))
 }
 
+func buildPGLikeTableCommentMetadataQuery(schemaName, tableName string) string {
+	return fmt.Sprintf(`
+SELECT pg_catalog.obj_description(c.oid, 'pg_class') AS table_comment
+FROM pg_catalog.pg_class AS c
+JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace
+WHERE c.relkind IN ('r', 'p')
+  AND %s
+  AND c.relname = '%s'
+LIMIT 1`, buildPGLikeVisibleRelationPredicate("c", schemaName), escapePGLikeMetadataLiteral(tableName))
+}
+
+func parsePGLikeTableComment(data []map[string]interface{}) string {
+	for _, row := range data {
+		for key, value := range row {
+			if !strings.EqualFold(key, "table_comment") || value == nil {
+				continue
+			}
+			return fmt.Sprintf("%v", value)
+		}
+	}
+	return ""
+}
+
 func buildPGLikeColumnDefinitions(data []map[string]interface{}) []connection.ColumnDefinition {
 	columns := make([]connection.ColumnDefinition, 0, len(data))
 	for _, row := range data {

--- a/internal/db/pg_metadata_test.go
+++ b/internal/db/pg_metadata_test.go
@@ -72,6 +72,46 @@ func TestBuildPGLikeMetadataQueriesKeepExplicitSchema(t *testing.T) {
 	}
 }
 
+func TestBuildPGLikeTableCommentMetadataQueryEscapesNames(t *testing.T) {
+	t.Parallel()
+
+	query := buildPGLikeTableCommentMetadataQuery("audit'schema", "order'items")
+	for _, want := range []string{
+		"pg_catalog.obj_description(c.oid, 'pg_class') AS table_comment",
+		"n.nspname = 'audit''schema'",
+		"c.relname = 'order''items'",
+	} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("expected table-comment metadata query to contain %q, got %s", want, query)
+		}
+	}
+	if strings.Contains(query, "pg_catalog.pg_table_is_visible") {
+		t.Fatalf("explicit schema table-comment metadata should not use visibility predicate, got %s", query)
+	}
+}
+
+func TestBuildPGLikeTableCommentMetadataQueryUsesVisibleRelationWithoutSchema(t *testing.T) {
+	t.Parallel()
+
+	query := buildPGLikeTableCommentMetadataQuery("", "orders")
+	if !strings.Contains(query, "pg_catalog.pg_table_is_visible(c.oid)") {
+		t.Fatalf("expected visible relation predicate for table-comment metadata, got %s", query)
+	}
+}
+
+func TestParsePGLikeTableCommentHandlesMissingAndSpecialValues(t *testing.T) {
+	t.Parallel()
+
+	if got := parsePGLikeTableComment(nil); got != "" {
+		t.Fatalf("missing table comment = %q, want empty", got)
+	}
+	want := "  Owner's archive\\path\n第二行  "
+	got := parsePGLikeTableComment([]map[string]interface{}{{"TABLE_COMMENT": want}})
+	if got != want {
+		t.Fatalf("special table comment = %q, want %q", got, want)
+	}
+}
+
 func TestBuildPGLikeColumnDefinitionsMarksPrimaryKey(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/postgres_impl.go
+++ b/internal/db/postgres_impl.go
@@ -406,6 +406,19 @@ func (p *PostgresDB) GetCreateStatement(dbName, tableName string) (string, error
 	return fmt.Sprintf("-- SHOW CREATE TABLE not fully supported for PostgreSQL in this MVP.\n-- Table: %s", tableName), nil
 }
 
+func (p *PostgresDB) GetTableComment(dbName, tableName string) (string, error) {
+	schema, table := normalizePGLikeMetadataTable(dbName, tableName)
+	if table == "" {
+		return "", localizedDatabaseRuntimeError("db.backend.error.table_name_required", nil)
+	}
+
+	data, _, err := p.Query(buildPGLikeTableCommentMetadataQuery(schema, table))
+	if err != nil {
+		return "", err
+	}
+	return parsePGLikeTableComment(data), nil
+}
+
 func (p *PostgresDB) GetColumns(dbName, tableName string) ([]connection.ColumnDefinition, error) {
 	schema, table := normalizePGLikeMetadataTable(dbName, tableName)
 	if table == "" {


### PR DESCRIPTION
## Summary

- Preserve PostgreSQL table-level comments in generated DDL and SQL backup exports.
- Read comments through `obj_description` with schema-aware metadata lookup and SQL-literal escaping.
- Add unit coverage plus a real Docker PostgreSQL E2E test for comments containing quotes, backslashes, and Chinese text.

## Validation

- `env GOTOOLCHAIN=auto go test ./internal/app ./internal/db`
- `env GOTOOLCHAIN=auto go test -tags=gonavi_postgres_e2e ./internal/app -run TestPostgresExportTableCommentE2E -count=1`
- `gofmt -d ...`
- `git diff --check`

Fixes #1002