### PR TITLE
🐛 fix(mcp): 支持检测以官方 npx 方式安装的 DeepSeek Harness

### DIFF
--- a/internal/ai/service/deepseek_harness_mcp.go
+++ b/internal/ai/service/deepseek_harness_mcp.go
@@ -18,6 +18,8 @@ const (
 )
 
 var deepSeekHarnessConfigPathFunc = resolveDeepSeekHarnessConfigPath
+var deepSeekHarnessHomeDirFunc = resolveDeepSeekHarnessHomeDir
+var deepSeekHarnessNpxPackageDirFunc = resolveDeepSeekHarnessNpxPackageDir
 
 type deepSeekHarnessMCPServerConfig struct {
 	Command string
@@ -36,7 +38,7 @@ func (s *Service) AIInstallDeepSeekHarnessMCP() (ai.MCPClientInstallResult, erro
 			map[string]any{"detail": localizeMCPClientPathDetail(s.serviceText, err)},
 		)
 	}
-	if err := requireLocalMCPClientCommand(deepSeekHarnessClientCommandName, "DeepSeek Harness", s.serviceText); err != nil {
+	if err := requireDeepSeekHarnessClient(s.serviceText); err != nil {
 		return ai.MCPClientInstallResult{}, err
 	}
 	executablePath, err := localMCPExecutablePathFunc()
@@ -68,10 +70,92 @@ func resolveDeepSeekHarnessConfigPath() (string, error) {
 	return filepath.Join(configRoot, "cordis.patch.yml"), nil
 }
 
+func resolveDeepSeekHarnessHomeDir() string {
+	configRoot, err := resolveMCPClientConfigRoot("DSH_HOME", ".dsh")
+	if err != nil {
+		return ""
+	}
+	return configRoot
+}
+
+// resolveDeepSeekHarnessNpxPackageDir locates the @deepseek-ai/dsh package in the
+// npm npx cache. The official quick start (`npx @deepseek-ai/dsh web`) installs
+// the harness into the transient npx cache instead of a PATH directory, so the
+// presence of that package is a reliable "DeepSeek Harness is installed" signal
+// for users who follow the documented setup.
+func resolveDeepSeekHarnessNpxPackageDir() string {
+	cacheRoot := strings.TrimSpace(os.Getenv("npm_config_cache"))
+	if cacheRoot == "" {
+		homeDir, err := resolveMCPClientUserHomeDir()
+		if err != nil {
+			return ""
+		}
+		cacheRoot = filepath.Join(homeDir, ".npm")
+	}
+	npxRoot := filepath.Join(cacheRoot, "_npx")
+	entries, err := os.ReadDir(npxRoot)
+	if err != nil {
+		return ""
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(npxRoot, entry.Name(), "node_modules", "@deepseek-ai", "dsh")
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate
+		}
+	}
+	return ""
+}
+
+// detectDeepSeekHarnessClient reports whether a DeepSeek Harness installation is
+// present and returns the path to surface in the status UI. PATH detection alone
+// misses the officially documented npx quick start (which never puts `dsh` on
+// PATH), so the DSH home directory and the npx package cache are checked as
+// fallbacks before the client is reported as missing.
+func detectDeepSeekHarnessClient() (bool, string) {
+	if detected, path := detectLocalCLICommand(deepSeekHarnessClientCommandName); detected {
+		return true, path
+	}
+	if home := deepSeekHarnessHomeDirFunc(); home != "" && deepSeekHarnessHomeMarkersPresent(home) {
+		return true, home
+	}
+	if packageDir := deepSeekHarnessNpxPackageDirFunc(); packageDir != "" {
+		if info, err := os.Stat(filepath.Join(packageDir, "package.json")); err == nil && !info.IsDir() {
+			return true, packageDir
+		}
+	}
+	return false, ""
+}
+
+// deepSeekHarnessHomeMarkersPresent reports whether the DSH home directory was
+// created by DeepSeek Harness itself (settings.yaml and/or profiles are written
+// on first boot) rather than by an unrelated process.
+func deepSeekHarnessHomeMarkersPresent(home string) bool {
+	for _, marker := range []string{"settings.yaml", "profiles"} {
+		if _, err := os.Stat(filepath.Join(home, marker)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func requireDeepSeekHarnessClient(textFuncs ...mcpClientInstallTextFunc) error {
+	if detected, _ := detectDeepSeekHarnessClient(); detected {
+		return nil
+	}
+	text := firstMCPClientInstallText(textFuncs)
+	return fmt.Errorf("%s", mcpClientInstallText(text, "ai.service.mcp_client.local_client_not_detected", map[string]any{
+		"label":   "DeepSeek Harness",
+		"command": deepSeekHarnessClientCommandName,
+	}))
+}
+
 func inspectDeepSeekHarnessMCPInstallStatus(expectedCommand string, expectedArgs []string, expectedErr error, textFuncs ...mcpClientInstallTextFunc) ai.MCPClientInstallStatus {
 	text := firstMCPClientInstallText(textFuncs)
 	configPath, pathErr := deepSeekHarnessConfigPathFunc()
-	clientDetected, clientPath := detectLocalCLICommand(deepSeekHarnessClientCommandName)
+	clientDetected, clientPath := detectDeepSeekHarnessClient()
 	status := ai.MCPClientInstallStatus{
 		Client:         "deepseek-harness",
 		DisplayName:    "DeepSeek Harness",
@@ -124,7 +208,7 @@ func inspectDeepSeekHarnessMCPInstallStatus(expectedCommand string, expectedArgs
 }
 
 func repairDeepSeekHarnessMCPClientConfig(expectedCommand string, expectedArgs []string, text mcpClientInstallTextFunc) error {
-	if !isLocalMCPClientCommandDetected(deepSeekHarnessClientCommandName) {
+	if detected, _ := detectDeepSeekHarnessClient(); !detected {
 		return nil
 	}
 	configPath, err := deepSeekHarnessConfigPathFunc()

--- a/internal/ai/service/external_mcp_clients_test.go
+++ b/internal/ai/service/external_mcp_clients_test.go
@@ -68,9 +68,26 @@ func mockLocalMCPClientCommandsDetected(t *testing.T) {
 	t.Cleanup(func() { localCLICommandPathFunc = originalCLIPathFunc })
 }
 
+// isolateDeepSeekHarnessClientFallbacks disables the DeepSeek Harness detection
+// fallbacks (DSH home directory and npx cache), so tests exercise the plain
+// PATH-based detection without depending on the developer machine's ~/.dsh or
+// ~/.npm layout.
+func isolateDeepSeekHarnessClientFallbacks(t *testing.T) {
+	t.Helper()
+	originalHomeDirFunc := deepSeekHarnessHomeDirFunc
+	originalNpxPackageDirFunc := deepSeekHarnessNpxPackageDirFunc
+	deepSeekHarnessHomeDirFunc = func() string { return filepath.Join(t.TempDir(), "no-dsh-home") }
+	deepSeekHarnessNpxPackageDirFunc = func() string { return "" }
+	t.Cleanup(func() {
+		deepSeekHarnessHomeDirFunc = originalHomeDirFunc
+		deepSeekHarnessNpxPackageDirFunc = originalNpxPackageDirFunc
+	})
+}
+
 func TestLocalMCPClientInstallersRejectUndetectedClientsWithoutWritingConfig(t *testing.T) {
 	disableLocalCLICommandShellFallback(t)
 	additionalPaths := isolateAdditionalMCPClientConfigs(t)
+	isolateDeepSeekHarnessClientFallbacks(t)
 	openCodePath := isolateOpenCodeMCPConfig(t)
 	originalClaudeConfigPathFunc := claudeCodeConfigPathFunc
 	originalCodexConfigPathFunc := codexConfigPathFunc
@@ -122,6 +139,7 @@ func TestLocalMCPClientInstallersRejectUndetectedClientsWithoutWritingConfig(t *
 func TestDeepSeekHarnessStatusDoesNotReportConnectedWhenClientCommandIsMissing(t *testing.T) {
 	disableLocalCLICommandShellFallback(t)
 	paths := isolateAdditionalMCPClientConfigs(t)
+	isolateDeepSeekHarnessClientFallbacks(t)
 	executablePath := isolateAdditionalMCPClientExecutable(t)
 	originalCLIPathFunc := localCLICommandPathFunc
 	localCLICommandPathFunc = func(string) (string, error) { return "", errors.New("not found") }
@@ -366,5 +384,166 @@ func TestResolveKimiCodeConfigPathHonorsKimiCodeHome(t *testing.T) {
 	}
 	if want := filepath.Join(root, "mcp.json"); path != want {
 		t.Fatalf("Kimi config path = %q, want %q", path, want)
+	}
+}
+
+func TestDeepSeekHarnessClientDetectedViaHomeDir(t *testing.T) {
+	disableLocalCLICommandShellFallback(t)
+	originalCLIPathFunc := localCLICommandPathFunc
+	localCLICommandPathFunc = func(string) (string, error) { return "", errors.New("not found") }
+	t.Cleanup(func() { localCLICommandPathFunc = originalCLIPathFunc })
+
+	home := filepath.Join(t.TempDir(), "dsh-home")
+	if err := os.MkdirAll(filepath.Join(home, "profiles"), 0o755); err != nil {
+		t.Fatalf("MkdirAll DSH home profiles returned error: %v", err)
+	}
+	originalHomeDirFunc := deepSeekHarnessHomeDirFunc
+	deepSeekHarnessHomeDirFunc = func() string { return home }
+	t.Cleanup(func() { deepSeekHarnessHomeDirFunc = originalHomeDirFunc })
+
+	detected, path := detectDeepSeekHarnessClient()
+	if !detected {
+		t.Fatal("expected the DeepSeek Harness client to be detected via its home directory")
+	}
+	if path != home {
+		t.Fatalf("detected client path = %q, want %q", path, home)
+	}
+}
+
+func TestDeepSeekHarnessClientNotDetectedViaEmptyHomeDir(t *testing.T) {
+	disableLocalCLICommandShellFallback(t)
+	originalCLIPathFunc := localCLICommandPathFunc
+	localCLICommandPathFunc = func(string) (string, error) { return "", errors.New("not found") }
+	t.Cleanup(func() { localCLICommandPathFunc = originalCLIPathFunc })
+
+	home := filepath.Join(t.TempDir(), "empty-home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("MkdirAll empty home returned error: %v", err)
+	}
+	originalHomeDirFunc := deepSeekHarnessHomeDirFunc
+	deepSeekHarnessHomeDirFunc = func() string { return home }
+	t.Cleanup(func() { deepSeekHarnessHomeDirFunc = originalHomeDirFunc })
+	originalNpxPackageDirFunc := deepSeekHarnessNpxPackageDirFunc
+	deepSeekHarnessNpxPackageDirFunc = func() string { return "" }
+	t.Cleanup(func() { deepSeekHarnessNpxPackageDirFunc = originalNpxPackageDirFunc })
+
+	if detected, _ := detectDeepSeekHarnessClient(); detected {
+		t.Fatal("an unrelated empty directory must not count as a DeepSeek Harness installation")
+	}
+}
+
+func TestDeepSeekHarnessClientDetectedViaNpxCache(t *testing.T) {
+	disableLocalCLICommandShellFallback(t)
+	originalCLIPathFunc := localCLICommandPathFunc
+	localCLICommandPathFunc = func(string) (string, error) { return "", errors.New("not found") }
+	t.Cleanup(func() { localCLICommandPathFunc = originalCLIPathFunc })
+
+	packageDir := filepath.Join(t.TempDir(), "npx", "hash", "node_modules", "@deepseek-ai", "dsh")
+	if err := os.MkdirAll(packageDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll npx package dir returned error: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(packageDir, "package.json"), []byte(`{"name":"@deepseek-ai/dsh"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile package.json returned error: %v", err)
+	}
+	originalNpxPackageDirFunc := deepSeekHarnessNpxPackageDirFunc
+	deepSeekHarnessNpxPackageDirFunc = func() string { return packageDir }
+	t.Cleanup(func() { deepSeekHarnessNpxPackageDirFunc = originalNpxPackageDirFunc })
+	originalHomeDirFunc := deepSeekHarnessHomeDirFunc
+	deepSeekHarnessHomeDirFunc = func() string { return filepath.Join(t.TempDir(), "no-dsh-home") }
+	t.Cleanup(func() { deepSeekHarnessHomeDirFunc = originalHomeDirFunc })
+
+	detected, path := detectDeepSeekHarnessClient()
+	if !detected {
+		t.Fatal("expected the DeepSeek Harness client to be detected via the npx cache package")
+	}
+	if path != packageDir {
+		t.Fatalf("detected client path = %q, want %q", path, packageDir)
+	}
+}
+
+func TestDeepSeekHarnessInstallSucceedsWhenDetectedViaHomeDir(t *testing.T) {
+	disableLocalCLICommandShellFallback(t)
+	paths := isolateAdditionalMCPClientConfigs(t)
+	executablePath := isolateAdditionalMCPClientExecutable(t)
+	originalCLIPathFunc := localCLICommandPathFunc
+	localCLICommandPathFunc = func(string) (string, error) { return "", errors.New("not found") }
+	t.Cleanup(func() { localCLICommandPathFunc = originalCLIPathFunc })
+
+	home := filepath.Join(t.TempDir(), "dsh-home")
+	if err := os.MkdirAll(filepath.Join(home, "profiles"), 0o755); err != nil {
+		t.Fatalf("MkdirAll DSH home profiles returned error: %v", err)
+	}
+	originalHomeDirFunc := deepSeekHarnessHomeDirFunc
+	deepSeekHarnessHomeDirFunc = func() string { return home }
+	t.Cleanup(func() { deepSeekHarnessHomeDirFunc = originalHomeDirFunc })
+
+	service := NewService()
+	service.AISetLanguage(string(i18n.LanguageEnUS))
+	if _, err := service.AIInstallDeepSeekHarnessMCP(); err != nil {
+		t.Fatalf("AIInstallDeepSeekHarnessMCP should succeed when DSH is detected via its home directory, got error: %v", err)
+	}
+	if _, err := os.Stat(paths.DeepSeekHarness); err != nil {
+		t.Fatalf("DeepSeek Harness config was not written: %v", err)
+	}
+	config, found, err := readDeepSeekHarnessMCPServerConfig(paths.DeepSeekHarness, service.serviceText)
+	if err != nil || !found {
+		t.Fatalf("read DeepSeek Harness GoNavi MCP config = (%#v, %t, %v)", config, found, err)
+	}
+	if config.Command != executablePath || !reflect.DeepEqual(config.Args, []string{"mcp-server"}) {
+		t.Fatalf("unexpected DeepSeek Harness config: %#v", config)
+	}
+}
+
+func TestDeepSeekHarnessStatusConnectedWhenHomeDetectedAndConfigMatches(t *testing.T) {
+	disableLocalCLICommandShellFallback(t)
+	paths := isolateAdditionalMCPClientConfigs(t)
+	executablePath := isolateAdditionalMCPClientExecutable(t)
+	originalCLIPathFunc := localCLICommandPathFunc
+	localCLICommandPathFunc = func(string) (string, error) { return "", errors.New("not found") }
+	t.Cleanup(func() { localCLICommandPathFunc = originalCLIPathFunc })
+
+	home := filepath.Join(t.TempDir(), "dsh-home")
+	if err := os.MkdirAll(filepath.Join(home, "profiles"), 0o755); err != nil {
+		t.Fatalf("MkdirAll DSH home profiles returned error: %v", err)
+	}
+	originalHomeDirFunc := deepSeekHarnessHomeDirFunc
+	deepSeekHarnessHomeDirFunc = func() string { return home }
+	t.Cleanup(func() { deepSeekHarnessHomeDirFunc = originalHomeDirFunc })
+
+	service := NewService()
+	service.AISetLanguage(string(i18n.LanguageEnUS))
+	if err := upsertDeepSeekHarnessMCPServerConfig(paths.DeepSeekHarness, executablePath, []string{"mcp-server"}, service.serviceText); err != nil {
+		t.Fatalf("upsertDeepSeekHarnessMCPServerConfig returned error: %v", err)
+	}
+
+	status := inspectDeepSeekHarnessMCPInstallStatus(executablePath, []string{"mcp-server"}, nil, service.serviceText)
+	if !status.ClientDetected {
+		t.Fatalf("expected the DeepSeek Harness client to be detected via its home directory, got %#v", status)
+	}
+	if !status.Installed || !status.MatchesCurrent {
+		t.Fatalf("expected the DeepSeek Harness config to be reported as connected, got %#v", status)
+	}
+}
+
+func TestResolveDeepSeekHarnessNpxPackageDirScansNpmCache(t *testing.T) {
+	cacheRoot := filepath.Join(t.TempDir(), "npm-cache")
+	t.Setenv("npm_config_cache", cacheRoot)
+	packageDir := filepath.Join(cacheRoot, "_npx", "abc123", "node_modules", "@deepseek-ai", "dsh")
+	if err := os.MkdirAll(packageDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll npx package dir returned error: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(packageDir, "package.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("WriteFile package.json returned error: %v", err)
+	}
+	if got := resolveDeepSeekHarnessNpxPackageDir(); got != packageDir {
+		t.Fatalf("resolveDeepSeekHarnessNpxPackageDir = %q, want %q", got, packageDir)
+	}
+}
+
+func TestResolveDeepSeekHarnessNpxPackageDirEmptyWithoutCache(t *testing.T) {
+	cacheRoot := filepath.Join(t.TempDir(), "empty-cache")
+	t.Setenv("npm_config_cache", cacheRoot)
+	if got := resolveDeepSeekHarnessNpxPackageDir(); got != "" {
+		t.Fatalf("resolveDeepSeekHarnessNpxPackageDir = %q, want empty", got)
 	}
 }


### PR DESCRIPTION
## 问题描述

GoNavi 的 MCP services 对 DeepSeek Harness 的客户端检测仅依赖 PATH 上的 `dsh` 命令（`exec.LookPath` + 登录 shell `command -v` 兜底）。而 DSH 官方 Quick Start 是 `npx @deepseek-ai/dsh web`（见 deepseek-ai/deepseek-harness README），npx 临时安装不会把 `dsh` 放入 PATH。结果是：**按官方文档标准流程使用 DSH 的用户，在 GoNavi 中永远显示 "Client not detected"，无法接入 GoNavi MCP**。

## 根本原因

检测代理指标选错：用"PATH 上是否存在 `dsh` 命令"代表"DSH 是否已安装"，但 DSH 官方安装方式（npx）恰恰不产生 PATH 命令；而 GoNavi 实际写入目标是 `$DSH_HOME/cordis.patch.yml`，与 `dsh` 是否在 PATH 上无关。

## 修复方案

将 DeepSeek Harness 客户端检测从单一 PATH 检测升级为三级兜底，任一命中即认定已安装：

1. **PATH 检测**（原有）：`dsh` 命令可被 `LookPath` 或登录 shell 解析
2. **DSH home 目录**（新增）：`$DSH_HOME`/`~/.dsh` 存在且含 DSH 自建标记（`settings.yaml` 或 `profiles`）
3. **npx 缓存**（新增）：`~/.npm/_npx/*/node_modules/@deepseek-ai/dsh` 存在

同步改造三处检测点：安装门控（`requireDeepSeekHarnessClient`）、状态检查（`inspectDeepSeekHarnessMCPInstallStatus`）、配置修复（`repairDeepSeekHarnessMCPClientConfig`）。

## 变更文件

| 文件 | 修改说明 | 变更行数 |
|---|---|---|
| `internal/ai/service/deepseek_harness_mcp.go` | 检测逻辑增加 home/npx 两级兜底 | +90 -3 |
| `internal/ai/service/external_mcp_clients_test.go` | 新增 7 个测试用例与隔离辅助函数 | +179 |

## 合并注意事项

- **影响功能点**：MCP 接入面板中 DeepSeek Harness 的检测状态、安装与配置修复的门控判断
- **验证方式**：`go test ./internal/ai/service/ -run DeepSeekHarness -count=1`；已在本地按官方 npx 流程验证可检测并写入 `~/.dsh/cordis.patch.yml`
- **回归风险**：低——仅新增两个正向检测分支，原 PATH 检测路径与 i18n 文案（复用既有 key）不变，前端零改动
- **回滚方式**：revert 此 PR 即可
