### PR TITLE
🐛 fix(update): 修复更新确认流程与弹窗居中

### DIFF
--- a/frontend/src/App.tool-center.test.ts
+++ b/frontend/src/App.tool-center.test.ts
@@ -70,4 +70,25 @@ describe('settings center tool entries', () => {
       /@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?\.gonavi-settings-center-modal \.ant-btn-loading-icon \.anticon-spin \{[^}]*animation-duration: 1s !important;[^}]*animation-iteration-count: infinite !important;[^}]*\}/,
     );
   });
+
+  it('waits for the unsaved SQL confirmation before continuing an update install request', () => {
+    const quitHandlerStart = appSource.indexOf('const handleApplicationQuitRequest = useCallback(async (');
+    const quitHandlerEnd = appSource.indexOf('const handleInstallUpdateRequest = useCallback', quitHandlerStart);
+    const quitHandlerSource = appSource.slice(quitHandlerStart, quitHandlerEnd);
+
+    expect(quitHandlerStart).toBeGreaterThanOrEqual(0);
+    expect(quitHandlerEnd).toBeGreaterThan(quitHandlerStart);
+    expect(quitHandlerSource).toContain('await new Promise<void>((resolve) => {');
+    expect(quitHandlerSource).toContain('const finish = () => {');
+    expect(quitHandlerSource).toContain('await runConfirmedActionAndFinish();');
+    expect(quitHandlerSource).toContain('centered: true,');
+
+    const installRequestSource = appSource.slice(quitHandlerEnd);
+    const closeInstancesModalStart = installRequestSource.indexOf("title: t('app.about.update_install_confirm.close_instances_title'");
+    const closeInstancesModalSource = installRequestSource.slice(closeInstancesModalStart);
+    expect(closeInstancesModalStart).toBeGreaterThanOrEqual(0);
+    expect(closeInstancesModalSource).toContain('centered: true,');
+    expect(closeInstancesModalSource).toContain('await handleInstallFromProgress(true);');
+    expect(closeInstancesModalSource).not.toContain('await handleApplicationQuitRequest(');
+  });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2873,73 +2873,119 @@ function App() {
       }
 
       const label = buildApplicationQuitUnsavedSQLLabel(targets);
-      let destroyConfirm: (() => void) | null = null;
-      const confirmRef = Modal.confirm({
-          title: t('app.quit.unsaved_sql.title'),
-          content: t(targets.length === 1
-              ? 'app.quit.unsaved_sql.content_single'
-              : 'app.quit.unsaved_sql.content_multiple', { label }),
-          okText: t('app.quit.unsaved_sql.save_exit'),
-          cancelText: t('app.quit.unsaved_sql.cancel'),
+      await new Promise<void>((resolve) => {
+          let finished = false;
+          const finish = () => {
+              if (finished) return;
+              finished = true;
+              resolve();
+          };
+          const runConfirmedActionAndFinish = async () => {
+              try {
+                  await runConfirmedAction();
+              } finally {
+                  finish();
+              }
+          };
+
+          let destroyConfirm: (() => void) | null = null;
+          const confirmRef = Modal.confirm({
+              title: t('app.quit.unsaved_sql.title'),
+              content: t(targets.length === 1
+                  ? 'app.quit.unsaved_sql.content_single'
+                  : 'app.quit.unsaved_sql.content_multiple', { label }),
+              okText: t('app.quit.unsaved_sql.save_exit'),
+              cancelText: t('app.quit.unsaved_sql.cancel'),
+              centered: true,
+              closable: true,
+              maskClosable: false,
+              zIndex: applicationQuitModalZIndex,
+              okButtonProps: { danger: true, type: 'primary' },
+              footer: (_, { OkBtn, CancelBtn }) => (
+                  <>
+                      <Button
+                        onClick={() => {
+                            destroyConfirm?.();
+                            applicationQuitConfirmRef.current = null;
+                            void runConfirmedActionAndFinish();
+                        }}
+                      >
+                          {t('app.quit.unsaved_sql.confirm_exit')}
+                      </Button>
+                      <CancelBtn />
+                      <OkBtn />
+                  </>
+              ),
+              onCancel: () => {
+                  cancelRequest();
+                  finish();
+              },
+              onOk: async () => {
+                  try {
+                      await saveLatestApplicationQuitUnsavedSQLState({
+                          getState: () => {
+                              const latestState = useStore.getState();
+                              return {
+                                  tabs: latestState.tabs,
+                                  savedQueries: latestState.savedQueries,
+                              };
+                          },
+                          updateTabs: (update) => {
+                              useStore.setState((state) => ({ tabs: update(state.tabs) }));
+                          },
+                          saveQuery,
+                      });
+                      message.success(t('app.quit.unsaved_sql.saved'));
+                  } catch (error) {
+                      cancelRequest();
+                      finish();
+                      message.error(t('app.quit.unsaved_sql.save_failed_cancel_exit', {
+                          detail: error instanceof Error ? error.message : String(error),
+                      }));
+                      throw error;
+                  }
+                  await runConfirmedActionAndFinish();
+              },
+          });
+          destroyConfirm = confirmRef.destroy;
+          applicationQuitConfirmRef.current = confirmRef;
+      });
+  }, [applicationQuitModalZIndex, ensureSavedQueriesLoaded, forceQuitApplication, resetApplicationQuitRequest, saveQuery, t]);
+
+  const handleInstallUpdateRequest = useCallback(async () => {
+      let pendingCloseInstanceCount: number | null = null;
+      hideUpdateDownloadProgress();
+      await handleApplicationQuitRequest(
+          () => handleInstallFromProgress(false, (instanceCount) => {
+              pendingCloseInstanceCount = instanceCount;
+          }),
+          () => {
+              if (pendingCloseInstanceCount === null) {
+                  showUpdateDownloadProgress();
+              }
+          },
+      );
+      if (pendingCloseInstanceCount === null) {
+          return;
+      }
+      Modal.confirm({
+          title: t('app.about.update_install_confirm.close_instances_title', { count: pendingCloseInstanceCount }),
+          content: t('app.about.update_install_confirm.close_instances_content'),
+          okText: t('app.about.update_install_confirm.close_instances_ok'),
+          cancelText: t('common.cancel'),
+          centered: true,
           closable: true,
           maskClosable: false,
           zIndex: applicationQuitModalZIndex,
           okButtonProps: { danger: true, type: 'primary' },
-          footer: (_, { OkBtn, CancelBtn }) => (
-              <>
-                  <Button
-                    onClick={() => {
-                        destroyConfirm?.();
-                        applicationQuitConfirmRef.current = null;
-                        void runConfirmedAction();
-                    }}
-                  >
-                      {t('app.quit.unsaved_sql.confirm_exit')}
-                  </Button>
-                  <CancelBtn />
-                  <OkBtn />
-              </>
-          ),
           onCancel: () => {
-              cancelRequest();
+              showUpdateDownloadProgress();
           },
           onOk: async () => {
-              try {
-                  await saveLatestApplicationQuitUnsavedSQLState({
-                      getState: () => {
-                          const latestState = useStore.getState();
-                          return {
-                              tabs: latestState.tabs,
-                              savedQueries: latestState.savedQueries,
-                          };
-                      },
-                      updateTabs: (update) => {
-                          useStore.setState((state) => ({ tabs: update(state.tabs) }));
-                      },
-                      saveQuery,
-                  });
-                  message.success(t('app.quit.unsaved_sql.saved'));
-              } catch (error) {
-                  cancelRequest();
-                  message.error(t('app.quit.unsaved_sql.save_failed_cancel_exit', {
-                      detail: error instanceof Error ? error.message : String(error),
-                  }));
-                  throw error;
-              }
-              await runConfirmedAction();
+              await handleInstallFromProgress(true);
           },
       });
-      destroyConfirm = confirmRef.destroy;
-      applicationQuitConfirmRef.current = confirmRef;
-  }, [applicationQuitModalZIndex, ensureSavedQueriesLoaded, forceQuitApplication, resetApplicationQuitRequest, saveQuery, t]);
-
-  const handleInstallUpdateRequest = useCallback(async () => {
-      hideUpdateDownloadProgress();
-      await handleApplicationQuitRequest(
-          () => handleInstallFromProgress(false),
-          showUpdateDownloadProgress,
-      );
-  }, [handleApplicationQuitRequest, handleInstallFromProgress, hideUpdateDownloadProgress, showUpdateDownloadProgress]);
+  }, [applicationQuitModalZIndex, handleApplicationQuitRequest, handleInstallFromProgress, hideUpdateDownloadProgress, showUpdateDownloadProgress, t]);
 
   useEffect(() => {
       const offBeforeClose = EventsOn('app:before-close-request', () => {

--- a/frontend/src/components/UpdateReleaseNotesModal.test.tsx
+++ b/frontend/src/components/UpdateReleaseNotesModal.test.tsx
@@ -11,9 +11,13 @@ vi.mock('../i18n', () => ({
 }));
 
 vi.mock('./common/ResizableDraggableModal', () => ({
-  default: ({ open, title, children, footer }: any) => (
+  default: ({ open, title, children, footer, centered, style }: any) => (
     open ? (
-      <div data-testid="release-notes-modal">
+      <div
+        data-testid="release-notes-modal"
+        data-centered={centered ? 'true' : 'false'}
+        data-has-top-offset={style?.top == null ? 'false' : 'true'}
+      >
         <div data-testid="release-notes-title">{title}</div>
         <div data-testid="release-notes-body">{children}</div>
         <div data-testid="release-notes-footer">{footer}</div>
@@ -62,6 +66,8 @@ describe('UpdateReleaseNotesModal', () => {
     expect(text).toContain('0.9.0');
     expect(text).toContain('ship in-app release notes');
     expect(text).toContain('app.about.release_notes.modal.open_github');
+    expect(modal.props['data-centered']).toBe('true');
+    expect(modal.props['data-has-top-offset']).toBe('false');
   });
 
   it('shows empty state when notes body is missing', () => {

--- a/frontend/src/components/UpdateReleaseNotesModal.tsx
+++ b/frontend/src/components/UpdateReleaseNotesModal.tsx
@@ -122,7 +122,7 @@ const UpdateReleaseNotesModal: React.FC<UpdateReleaseNotesModalProps> = ({
       onCancel={onClose}
       title={title}
       width={640}
-      style={{ top: 40 }}
+      centered
       zIndex={zIndex}
       styles={{
         body: {

--- a/frontend/src/hooks/useAppUpdateManager.test.tsx
+++ b/frontend/src/hooks/useAppUpdateManager.test.tsx
@@ -701,6 +701,44 @@ describe('useAppUpdateManager', () => {
     expect(messageApi.error).not.toHaveBeenCalled();
   });
 
+  it('returns the Windows instance confirmation request to the GoNavi modal layer', async () => {
+    backendApp.CheckForUpdates.mockResolvedValue({
+      success: true,
+      data: {
+        hasUpdate: true,
+        currentVersion: '0.8.1',
+        latestVersion: '0.8.2',
+        downloaded: true,
+        assetSize: 2048,
+        installMode: 'portable',
+        packageType: 'portable',
+      },
+    });
+    backendApp.InstallUpdateAndRestart.mockResolvedValue({
+      success: false,
+      data: { requiresCloseConfirmation: true, instanceCount: 3 },
+    });
+
+    renderHook();
+    await act(async () => {
+      await hook?.checkForUpdates(false);
+    });
+
+    let requestedInstanceCount: number | null = null;
+    let accepted = true;
+    await act(async () => {
+      accepted = await hook!.handleInstallFromProgress(false, (instanceCount) => {
+        requestedInstanceCount = instanceCount;
+      });
+    });
+
+    expect(accepted).toBe(false);
+    expect(requestedInstanceCount).toBe(3);
+    expect(hook?.updateDownloadProgress.status).toBe('done');
+    expect(hook?.updateDownloadProgress.open).toBe(false);
+    expect(messageApi.error).not.toHaveBeenCalled();
+  });
+
   it('returns false without calling the backend when no update is ready', async () => {
     renderHook();
 

--- a/frontend/src/hooks/useAppUpdateManager.ts
+++ b/frontend/src/hooks/useAppUpdateManager.ts
@@ -396,7 +396,10 @@ export const useAppUpdateManager = ({
   const canShowProgressEntry = (isLatestUpdateDownloaded || isBackgroundProgressForLatestUpdate)
     && updateInstallTriggeredVersionRef.current !== (lastUpdateKey || null);
 
-  const handleInstallFromProgress = useCallback(async (closeAllWindowsInstancesConfirmed = false): Promise<boolean> => {
+  const handleInstallFromProgress = useCallback(async (
+    closeAllWindowsInstancesConfirmed = false,
+    onCloseInstancesConfirmationRequired?: (instanceCount: number) => void,
+  ): Promise<boolean> => {
     const canInstall = updateDownloadProgress.status === 'done'
       || (Boolean(lastUpdateInfo?.hasUpdate) && (Boolean(lastUpdateInfo?.downloaded) || updateDownloadedVersionRef.current === lastUpdateKey));
     if (!canInstall) {
@@ -421,6 +424,21 @@ export const useAppUpdateManager = ({
       res = { success: false, message: error?.message || t('common.unknown') };
     }
     if (!res?.success) {
+      if (res?.data?.requiresCloseConfirmation === true) {
+        const parsedInstanceCount = Number(res?.data?.instanceCount);
+        const instanceCount = Number.isFinite(parsedInstanceCount) && parsedInstanceCount > 0
+          ? Math.floor(parsedInstanceCount)
+          : 1;
+        setUpdateDownloadProgress((prev) => ({
+          ...prev,
+          open: false,
+          status: 'done',
+          percent: 100,
+          message: '',
+        }));
+        onCloseInstancesConfirmationRequired?.(instanceCount);
+        return false;
+      }
       if (res?.data?.cancelled === true) {
         setUpdateDownloadProgress((prev) => ({
           ...prev,

--- a/internal/app/methods_update.go
+++ b/internal/app/methods_update.go
@@ -54,7 +54,6 @@ var (
 	updateLaunchInstallScript          = launchUpdateScript
 	updateFindOtherWindowsInstances    = findOtherWindowsUpdateInstances
 	updateCloseWindowsInstances        = closeWindowsUpdateInstances
-	updateConfirmCloseWindowsInstances = showWindowsUpdateCloseConfirmation
 	updateAcquireWindowsMaintenance    = acquireWindowsUpdateMaintenance
 	updateQuitSleep                    = time.Sleep
 	updateExitProcess                  = os.Exit
@@ -479,30 +478,14 @@ func (a *App) InstallUpdateAndRestart(closeAllWindowsInstancesConfirmed bool) co
 			}
 		}
 		if windowsUpdateCloseConfirmationRequired(stdRuntime.GOOS, closeAllWindowsInstancesConfirmed, len(runningInstances)) {
-			confirmationParams := map[string]any{"count": len(runningInstances)}
-			confirmed, confirmErr := updateConfirmCloseWindowsInstances(
-				a.ctx,
-				a.appText("app.about.update_install_confirm.close_instances_title", confirmationParams),
-				a.appText("app.about.update_install_confirm.close_instances_content", confirmationParams),
-			)
-			if confirmErr != nil {
-				return connection.QueryResult{
-					Success: false,
-					Message: a.appText("app.update.backend.message.install_launch_failed", map[string]any{
-						"detail": confirmErr.Error(),
-					}),
-				}
+			return connection.QueryResult{
+				Success: false,
+				Data: map[string]any{
+					"requiresCloseConfirmation": true,
+					"instanceCount":             len(runningInstances),
+					"runningPids":               otherWindowsUpdateProcessIDs(runningInstances),
+				},
 			}
-			if !confirmed {
-				return connection.QueryResult{
-					Success: false,
-					Data: map[string]any{
-						"cancelled":   true,
-						"runningPids": otherWindowsUpdateProcessIDs(runningInstances),
-					},
-				}
-			}
-			closeAllWindowsInstancesConfirmed = true
 		}
 
 		if staged.InstallMode == updateInstallModePortable {

--- a/internal/app/methods_update_windows_process_test.go
+++ b/internal/app/methods_update_windows_process_test.go
@@ -3,7 +3,6 @@
 package app
 
 import (
-	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -137,7 +136,6 @@ func TestInstallUpdateAndRestartClosesOtherTargetInstances(t *testing.T) {
 	originalResolveInstallTarget := updateResolveInstallTarget
 	originalFindOtherInstances := updateFindOtherWindowsInstances
 	originalCloseInstances := updateCloseWindowsInstances
-	originalConfirmCloseInstances := updateConfirmCloseWindowsInstances
 	originalAcquireMaintenance := updateAcquireWindowsMaintenance
 	originalLaunchInstallScript := updateLaunchInstallScript
 	originalQuitSleep := updateQuitSleep
@@ -146,7 +144,6 @@ func TestInstallUpdateAndRestartClosesOtherTargetInstances(t *testing.T) {
 		updateResolveInstallTarget = originalResolveInstallTarget
 		updateFindOtherWindowsInstances = originalFindOtherInstances
 		updateCloseWindowsInstances = originalCloseInstances
-		updateConfirmCloseWindowsInstances = originalConfirmCloseInstances
 		updateAcquireWindowsMaintenance = originalAcquireMaintenance
 		updateLaunchInstallScript = originalLaunchInstallScript
 		updateQuitSleep = originalQuitSleep
@@ -175,14 +172,6 @@ func TestInstallUpdateAndRestartClosesOtherTargetInstances(t *testing.T) {
 		}
 		return nil, nil
 	}
-	confirmCalls := 0
-	updateConfirmCloseWindowsInstances = func(_ context.Context, title, message string) (bool, error) {
-		confirmCalls++
-		if title == "" || message == "" {
-			t.Fatal("native close confirmation must include a localized title and message")
-		}
-		return true, nil
-	}
 	closed := false
 	updateCloseWindowsInstances = func(processes []windowsUpdateProcess) error {
 		closed = len(processes) == 1 && processes[0].PID == 4321 && processes[0].Executable == newTarget
@@ -197,7 +186,7 @@ func TestInstallUpdateAndRestartClosesOtherTargetInstances(t *testing.T) {
 	updateQuitSleep = func(time.Duration) {}
 	updateExitProcess = func(int) { quitFinished <- struct{}{} }
 
-	result := app.InstallUpdateAndRestart(false)
+	result := app.InstallUpdateAndRestart(true)
 	if !result.Success {
 		t.Fatalf("expected confirmed update to close other instances and launch, got %#v", result)
 	}
@@ -206,9 +195,6 @@ func TestInstallUpdateAndRestartClosesOtherTargetInstances(t *testing.T) {
 	}
 	if !launched {
 		t.Fatal("update launcher did not start after other instances closed")
-	}
-	if confirmCalls != 1 {
-		t.Fatalf("close confirmation calls = %d, want 1", confirmCalls)
 	}
 	if len(checkedTargets) != 2 || checkedTargets[0] != currentTarget || checkedTargets[1] != newTarget {
 		t.Fatalf("checked targets = %#v, want current and final target", checkedTargets)
@@ -245,14 +231,12 @@ func TestInstallUpdateAndRestartRequiresCloseConfirmationOnWindows(t *testing.T)
 	originalResolveTarget := updateResolveInstallTarget
 	originalResolveInstallMode := updateResolveInstallMode
 	originalFindOtherInstances := updateFindOtherWindowsInstances
-	originalConfirmCloseInstances := updateConfirmCloseWindowsInstances
 	originalAcquireMaintenance := updateAcquireWindowsMaintenance
 	originalLaunch := updateLaunchInstallScript
 	t.Cleanup(func() {
 		updateResolveInstallTarget = originalResolveTarget
 		updateResolveInstallMode = originalResolveInstallMode
 		updateFindOtherWindowsInstances = originalFindOtherInstances
-		updateConfirmCloseWindowsInstances = originalConfirmCloseInstances
 		updateAcquireWindowsMaintenance = originalAcquireMaintenance
 		updateLaunchInstallScript = originalLaunch
 	})
@@ -271,11 +255,6 @@ func TestInstallUpdateAndRestartRequiresCloseConfirmationOnWindows(t *testing.T)
 		findCalls++
 		return []windowsUpdateProcess{{PID: 4321, Executable: filepath.Join(dir, "GoNavi.exe")}}, nil
 	}
-	confirmCalls := 0
-	updateConfirmCloseWindowsInstances = func(context.Context, string, string) (bool, error) {
-		confirmCalls++
-		return false, nil
-	}
 	launched := false
 	updateLaunchInstallScript = func(*stagedUpdate) error {
 		launched = true
@@ -290,11 +269,17 @@ func TestInstallUpdateAndRestartRequiresCloseConfirmationOnWindows(t *testing.T)
 		t.Fatal("update launcher must not start before close-all confirmation")
 	}
 	data, ok := result.Data.(map[string]any)
-	if !ok || data["cancelled"] != true {
-		t.Fatalf("cancelled update data = %#v, want cancelled=true", result.Data)
+	if !ok || data["requiresCloseConfirmation"] != true {
+		t.Fatalf("close confirmation data = %#v, want requiresCloseConfirmation=true", result.Data)
 	}
-	if confirmCalls != 1 || findCalls != 1 {
-		t.Fatalf("finder/confirmation calls = %d/%d, want 1/1", findCalls, confirmCalls)
+	if data["instanceCount"] != 1 {
+		t.Fatalf("instanceCount = %#v, want 1", data["instanceCount"])
+	}
+	if runningPids, ok := data["runningPids"].([]uint32); !ok || len(runningPids) != 1 || runningPids[0] != 4321 {
+		t.Fatalf("runningPids = %#v, want [4321]", data["runningPids"])
+	}
+	if findCalls != 1 {
+		t.Fatalf("finder calls = %d, want 1", findCalls)
 	}
 }
 
@@ -319,7 +304,6 @@ func TestInstallUpdateAndRestartSkipsCloseConfirmationForSingleWindowsInstance(t
 	originalResolveTarget := updateResolveInstallTarget
 	originalResolveInstallMode := updateResolveInstallMode
 	originalFindOtherInstances := updateFindOtherWindowsInstances
-	originalConfirmCloseInstances := updateConfirmCloseWindowsInstances
 	originalAcquireMaintenance := updateAcquireWindowsMaintenance
 	originalLaunch := updateLaunchInstallScript
 	originalQuitSleep := updateQuitSleep
@@ -328,7 +312,6 @@ func TestInstallUpdateAndRestartSkipsCloseConfirmationForSingleWindowsInstance(t
 		updateResolveInstallTarget = originalResolveTarget
 		updateResolveInstallMode = originalResolveInstallMode
 		updateFindOtherWindowsInstances = originalFindOtherInstances
-		updateConfirmCloseWindowsInstances = originalConfirmCloseInstances
 		updateAcquireWindowsMaintenance = originalAcquireMaintenance
 		updateLaunchInstallScript = originalLaunch
 		updateQuitSleep = originalQuitSleep
@@ -344,11 +327,6 @@ func TestInstallUpdateAndRestartSkipsCloseConfirmationForSingleWindowsInstance(t
 		}
 		findCalls++
 		return nil, nil
-	}
-	confirmCalls := 0
-	updateConfirmCloseWindowsInstances = func(context.Context, string, string) (bool, error) {
-		confirmCalls++
-		return false, nil
 	}
 	updateAcquireWindowsMaintenance = func(string) (windowsUpdateMaintenanceLease, error) {
 		maintenanceAcquired = true
@@ -367,8 +345,8 @@ func TestInstallUpdateAndRestartSkipsCloseConfirmationForSingleWindowsInstance(t
 	if !result.Success {
 		t.Fatalf("single-instance update should launch without confirmation, got %#v", result)
 	}
-	if findCalls != 1 || confirmCalls != 0 {
-		t.Fatalf("finder/confirmation calls = %d/%d, want 1/0", findCalls, confirmCalls)
+	if findCalls != 1 {
+		t.Fatalf("finder calls = %d, want 1", findCalls)
 	}
 	if !launched {
 		t.Fatal("single-instance update did not launch")

--- a/internal/app/windows_update_process.go
+++ b/internal/app/windows_update_process.go
@@ -1,11 +1,8 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"strings"
-
-	wailsRuntime "github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
 func otherWindowsUpdateProcessIDs(processes []windowsUpdateProcess) []uint32 {
@@ -18,24 +15,6 @@ func otherWindowsUpdateProcessIDs(processes []windowsUpdateProcess) []uint32 {
 
 func windowsUpdateCloseConfirmationRequired(goos string, confirmed bool, otherInstanceCount int) bool {
 	return strings.EqualFold(strings.TrimSpace(goos), "windows") && !confirmed && otherInstanceCount > 0
-}
-
-func showWindowsUpdateCloseConfirmation(ctx context.Context, title, message string) (bool, error) {
-	if ctx == nil {
-		return false, fmt.Errorf("application window is not ready")
-	}
-	response, err := wailsRuntime.MessageDialog(ctx, wailsRuntime.MessageDialogOptions{
-		Type:          wailsRuntime.QuestionDialog,
-		Title:         title,
-		Message:       message,
-		Buttons:       []string{"Yes", "No"},
-		DefaultButton: "No",
-		CancelButton:  "No",
-	})
-	if err != nil {
-		return false, err
-	}
-	return strings.EqualFold(strings.TrimSpace(response), "yes"), nil
 }
 
 func closeOtherWindowsUpdateInstancesForInstall(targetPaths []string, currentPID int) ([]uint32, error) {


### PR DESCRIPTION
## 背景
未保存 SQL 确认框和更新下载页面在不同窗口尺寸下位置不一致；Windows 更新安装前的其他 GoNavi 实例确认由后端原生弹窗处理，界面风格和更新退出流程不统一。

## 变更点
- 将未保存 SQL 确认框、更新日志/下载弹窗改为居中展示。
- Windows 更新首次发现同安装目录的其他 GoNavi 实例时返回实例数量，由前端 GoNavi 弹窗确认。
- 用户确认后重新枚举并关闭其他实例，再启动更新安装；取消时恢复下载完成状态。
- 增加前端和后端回归测试，覆盖退出保护、取消确认、实例数量和关闭流程。

## 影响范围
- 仅影响应用退出保护、更新安装确认和更新日志/下载弹窗定位。
- Windows 多实例更新流程生效；macOS、Linux 及无其他实例的更新流程保持原有行为。
- 不包含 Wails 生成绑定、依赖升级或其他工作区生成物。

## 验证
- `npm test -- --run src/App.tool-center.test.ts src/components/UpdateReleaseNotesModal.test.tsx src/hooks/useAppUpdateManager.test.tsx`：35 passed。
- `npm run build`：通过。
- `go test ./internal/app -run 'Test(InstallUpdateAndRestart|WindowsUpdate|CloseOtherWindowsUpdate|OtherWindowsUpdate)'`：通过。
- `go test ./internal/app`：通过。
- `git diff --check`：通过。