### PR TITLE
fix(http): bound Web and MCP request resources

### DIFF
--- a/internal/httpserver/security.go
+++ b/internal/httpserver/security.go
@@ -1,0 +1,165 @@
+// Package httpserver contains the HTTP resource limits shared by GoNavi's
+// browser and Streamable HTTP MCP servers.
+package httpserver
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	// MaxRequestBodyBytes is large enough for normal Web invoke and MCP JSON-RPC
+	// payloads while bounding the memory used when a request is buffered.
+	MaxRequestBodyBytes int64 = 1 << 20
+
+	ReadHeaderTimeout = 10 * time.Second
+	ReadTimeout       = 30 * time.Second
+	// WriteTimeout is deliberately longer than ReadTimeout so the server can
+	// still send a timeout response after a request body read reaches its limit.
+	WriteTimeout = time.Minute
+	IdleTimeout  = 2 * time.Minute
+)
+
+// LimitRequestBody reads and buffers the complete request body before invoking
+// next. This makes the size and read deadline apply before any business handler
+// or SDK code can observe a partial request.
+func LimitRequestBody(next http.Handler) http.Handler {
+	return limitRequestBody(next, MaxRequestBodyBytes, ReadTimeout)
+}
+
+func limitRequestBody(next http.Handler, maxBytes int64, readTimeout time.Duration) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Body == nil || r.Body == http.NoBody {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if r.ContentLength > maxBytes {
+			_ = r.Body.Close()
+			writeRequestBodyError(w, http.StatusRequestEntityTooLarge)
+			return
+		}
+
+		controller := http.NewResponseController(w)
+		if readTimeout > 0 {
+			// A fresh per-request deadline ensures that a client cannot spend the
+			// server-wide read budget on headers and then drip-feed the body.
+			_ = controller.SetReadDeadline(time.Now().Add(readTimeout))
+			defer func() { _ = controller.SetReadDeadline(time.Time{}) }()
+		}
+
+		limited := http.MaxBytesReader(w, r.Body, maxBytes)
+		body, err := io.ReadAll(limited)
+		closeErr := limited.Close()
+		if err == nil {
+			err = closeErr
+		}
+		if err != nil {
+			var maxBytesError *http.MaxBytesError
+			if errors.As(err, &maxBytesError) {
+				writeRequestBodyError(w, http.StatusRequestEntityTooLarge)
+				return
+			}
+			var netError net.Error
+			if errors.As(err, &netError) && netError.Timeout() {
+				writeRequestBodyError(w, http.StatusRequestTimeout)
+				return
+			}
+			writeRequestBodyError(w, http.StatusBadRequest)
+			return
+		}
+
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		r.ContentLength = int64(len(body))
+		// The body is now memory-backed, so the connection no longer needs a
+		// read deadline while the business handler runs.
+		_ = controller.SetReadDeadline(time.Time{})
+		next.ServeHTTP(w, r)
+	})
+}
+
+func writeRequestBodyError(w http.ResponseWriter, status int) {
+	message := "invalid request body"
+	switch status {
+	case http.StatusRequestEntityTooLarge:
+		message = "request body too large"
+	case http.StatusRequestTimeout:
+		message = "request body read timed out"
+	}
+	http.Error(w, message, status)
+}
+
+// StreamingWriteTimeout converts http.Server's absolute WriteTimeout into a
+// rolling per-write timeout. Long-lived SSE connections may remain idle for any
+// duration, but a write to a slow or disconnected client is still bounded.
+func StreamingWriteTimeout(next http.Handler) http.Handler {
+	return streamingWriteTimeout(next, WriteTimeout)
+}
+
+// StreamingWriteTimeoutWhen applies rolling write deadlines only to requests
+// selected by isStream. Other requests retain http.Server.WriteTimeout.
+func StreamingWriteTimeoutWhen(next http.Handler, isStream func(*http.Request) bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isStream != nil && isStream(r) {
+			StreamingWriteTimeout(next).ServeHTTP(w, r)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func streamingWriteTimeout(next http.Handler, timeout time.Duration) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		controller := http.NewResponseController(w)
+		_ = controller.SetWriteDeadline(time.Time{})
+		next.ServeHTTP(&streamingResponseWriter{ResponseWriter: w, timeout: timeout}, r)
+	})
+}
+
+type streamingResponseWriter struct {
+	http.ResponseWriter
+	timeout time.Duration
+	mu      sync.Mutex
+}
+
+// Unwrap lets http.ResponseController retain access to the original writer.
+func (w *streamingResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+func (w *streamingResponseWriter) WriteHeader(status int) {
+	w.withWriteDeadline(func() {
+		w.ResponseWriter.WriteHeader(status)
+	})
+}
+
+func (w *streamingResponseWriter) Write(payload []byte) (int, error) {
+	var n int
+	var err error
+	w.withWriteDeadline(func() {
+		n, err = w.ResponseWriter.Write(payload)
+	})
+	return n, err
+}
+
+func (w *streamingResponseWriter) Flush() {
+	w.withWriteDeadline(func() {
+		_ = http.NewResponseController(w.ResponseWriter).Flush()
+	})
+}
+
+func (w *streamingResponseWriter) withWriteDeadline(write func()) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	controller := http.NewResponseController(w.ResponseWriter)
+	if w.timeout > 0 {
+		_ = controller.SetWriteDeadline(time.Now().Add(w.timeout))
+	}
+	write()
+	_ = controller.SetWriteDeadline(time.Time{})
+}

--- a/internal/httpserver/security_test.go
+++ b/internal/httpserver/security_test.go
@@ -1,0 +1,119 @@
+package httpserver
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestLimitRequestBodyRejectsOversizeBeforeHandler(t *testing.T) {
+	var called atomic.Bool
+	handler := limitRequestBody(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Store(true)
+		w.WriteHeader(http.StatusNoContent)
+	}), 16, time.Second)
+
+	request := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(bytes.Repeat([]byte("x"), 17)))
+	request.ContentLength = -1 // exercise streaming/chunked bodies, not just the header fast path
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d; body=%q", recorder.Code, http.StatusRequestEntityTooLarge, recorder.Body.String())
+	}
+	if called.Load() {
+		t.Fatal("handler was called before the oversized body was rejected")
+	}
+}
+
+func TestLimitRequestBodyBuffersNormalRequest(t *testing.T) {
+	const payload = `{"value":"ok"}`
+	handler := limitRequestBody(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read buffered body: %v", err)
+			return
+		}
+		if string(body) != payload {
+			t.Errorf("body = %q, want %q", body, payload)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}), 1024, time.Second)
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/", strings.NewReader(payload)))
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNoContent)
+	}
+}
+
+func TestLimitRequestBodyTimesOutSlowBodyBeforeHandler(t *testing.T) {
+	var called atomic.Bool
+	handler := limitRequestBody(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called.Store(true)
+		w.WriteHeader(http.StatusNoContent)
+	}), 1024, 75*time.Millisecond)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	address := strings.TrimPrefix(server.URL, "http://")
+	connection, err := net.DialTimeout("tcp", address, time.Second)
+	if err != nil {
+		t.Fatalf("dial test server: %v", err)
+	}
+	defer connection.Close()
+	_ = connection.SetDeadline(time.Now().Add(2 * time.Second))
+	if _, err := io.WriteString(connection, "POST / HTTP/1.1\r\nHost: "+address+"\r\nTransfer-Encoding: chunked\r\n\r\n1\r\n{\r\n"); err != nil {
+		t.Fatalf("write partial request: %v", err)
+	}
+
+	response, err := http.ReadResponse(bufio.NewReader(connection), &http.Request{Method: http.MethodPost})
+	if err != nil {
+		t.Fatalf("read timeout response: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusRequestTimeout {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("status = %d, want %d; body=%q", response.StatusCode, http.StatusRequestTimeout, body)
+	}
+	if called.Load() {
+		t.Fatal("handler was called before the slow body timed out")
+	}
+}
+
+func TestStreamingWriteTimeoutAllowsLongLivedSSE(t *testing.T) {
+	const writeTimeout = 50 * time.Millisecond
+	handler := streamingWriteTimeout(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, ": connected\n\n")
+		w.(http.Flusher).Flush()
+		time.Sleep(3 * writeTimeout)
+		_, _ = io.WriteString(w, ": ping\n\n")
+		w.(http.Flusher).Flush()
+	}), writeTimeout)
+	server := httptest.NewUnstartedServer(handler)
+	server.Config.WriteTimeout = writeTimeout
+	server.Start()
+	t.Cleanup(server.Close)
+
+	client := &http.Client{Timeout: time.Second}
+	response, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("open SSE response: %v", err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read SSE response after server WriteTimeout: %v", err)
+	}
+	if got := string(body); got != ": connected\n\n: ping\n\n" {
+		t.Fatalf("SSE body = %q", got)
+	}
+}

--- a/internal/jvm/fixture_toolchain_test.go
+++ b/internal/jvm/fixture_toolchain_test.go
@@ -21,6 +21,11 @@ import (
 
 var errJVMFixtureToolchainUnavailable = errors.New("JDK toolchain unavailable")
 
+// The full backend suite can leave the Linux runner CPU-constrained while
+// starting a JVM. Keep a finite deadline, but do not mistake a slow JVM
+// startup for an unusable JDK after the previous five-second deadline.
+const jvmFixtureToolVersionTimeout = 30 * time.Second
+
 var jvmFixtureVersionPattern = regexp.MustCompile(`(?i)(?:java|openjdk|javac)(?:\s+version)?\s+"?([0-9]+)(?:\.([0-9]+))?`)
 
 type jvmFixtureToolchain struct {
@@ -160,7 +165,7 @@ func jvmFixtureBinaryName(name string) string {
 }
 
 func readJVMFixtureToolVersion(parent context.Context, binary string) (string, int, error) {
-	ctx, cancel := context.WithTimeout(parent, 5*time.Second)
+	ctx, cancel := context.WithTimeout(parent, jvmFixtureToolVersionTimeout)
 	defer cancel()
 
 	output, err := exec.CommandContext(ctx, binary, "-version").CombinedOutput()

--- a/internal/mcpserver/run.go
+++ b/internal/mcpserver/run.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"time"
 
+	httpserverlimits "GoNavi-Wails/internal/httpserver"
+
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -174,17 +176,13 @@ func StartStreamableHTTPServer(ctx context.Context, backend Backend, options HTT
 		SessionTimeout: 30 * time.Minute,
 	})
 
-	mux := http.NewServeMux()
-	mux.Handle(normalized.Path, bearerTokenAuthHandler(normalized.Token, streamableHandler))
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-		_, _ = io.WriteString(w, "ok")
-	})
-
 	httpServer := &http.Server{
 		Addr:              normalized.Addr,
-		Handler:           mux,
-		ReadHeaderTimeout: 10 * time.Second,
+		Handler:           streamableHTTPRoutes(normalized, streamableHandler),
+		ReadHeaderTimeout: httpserverlimits.ReadHeaderTimeout,
+		ReadTimeout:       httpserverlimits.ReadTimeout,
+		WriteTimeout:      httpserverlimits.WriteTimeout,
+		IdleTimeout:       httpserverlimits.IdleTimeout,
 	}
 
 	listener, err := net.Listen("tcp", normalized.Addr)
@@ -233,6 +231,22 @@ func StartStreamableHTTPServer(ctx context.Context, backend Backend, options HTT
 	}()
 
 	return handle, nil
+}
+
+func streamableHTTPRoutes(options HTTPServerOptions, streamableHandler http.Handler) http.Handler {
+	streamableHandler = httpserverlimits.StreamingWriteTimeoutWhen(streamableHandler, func(r *http.Request) bool {
+		// GET is always the standalone SSE stream. Unless JSONResponse was
+		// explicitly requested, POST call responses are SSE streams as well.
+		return r.Method == http.MethodGet || !options.JSONResponse
+	})
+
+	mux := http.NewServeMux()
+	mux.Handle(options.Path, bearerTokenAuthHandler(options.Token, httpserverlimits.LimitRequestBody(streamableHandler)))
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = io.WriteString(w, "ok")
+	})
+	return mux
 }
 
 // ParseHTTPServerOptions 解析 http 模式参数，并支持环境变量兜底。

--- a/internal/mcpserver/run_test.go
+++ b/internal/mcpserver/run_test.go
@@ -1,12 +1,32 @@
 package mcpserver
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	httpserverlimits "GoNavi-Wails/internal/httpserver"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+type bearerTokenRoundTripper struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (t bearerTokenRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	request = request.Clone(request.Context())
+	request.Header = request.Header.Clone()
+	request.Header.Set("Authorization", "Bearer "+t.token)
+	return t.base.RoundTrip(request)
+}
 
 func TestStartStreamableHTTPServerStopsWhenContextIsCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -28,6 +48,90 @@ func TestStartStreamableHTTPServerStopsWhenContextIsCanceled(t *testing.T) {
 
 	if err := handle.Wait(); err != nil {
 		t.Fatalf("HTTP server returned error after context cancellation: %v", err)
+	}
+}
+
+func TestStreamableHTTPRoutesRejectOversizeBeforeSDKHandler(t *testing.T) {
+	var called atomic.Bool
+	handler := streamableHTTPRoutes(HTTPServerOptions{Path: "/mcp", Token: "test-token"}, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called.Store(true)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	request := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(bytes.Repeat([]byte("x"), int(httpserverlimits.MaxRequestBodyBytes+1))))
+	request.Header.Set("Authorization", "Bearer test-token")
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d; body=%q", recorder.Code, http.StatusRequestEntityTooLarge, recorder.Body.String())
+	}
+	if called.Load() {
+		t.Fatal("MCP SDK handler was called for an oversized body")
+	}
+}
+
+func TestStreamableHTTPRoutesPassNormalBody(t *testing.T) {
+	var body string
+	handler := streamableHTTPRoutes(HTTPServerOptions{Path: "/mcp", Token: "test-token", JSONResponse: true}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body in SDK handler: %v", err)
+		}
+		body = string(payload)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	request := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0"}`))
+	request.Header.Set("Authorization", "Bearer test-token")
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNoContent)
+	}
+	if body != `{"jsonrpc":"2.0"}` {
+		t.Fatalf("SDK handler body = %q", body)
+	}
+}
+
+func TestStartStreamableHTTPServerSupportsNormalSessionAndSSE(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	handle, err := StartStreamableHTTPServer(ctx, &fakeBackend{}, HTTPServerOptions{
+		Addr:  "127.0.0.1:0",
+		Path:  "/mcp",
+		Token: "test-token",
+	})
+	if err != nil {
+		t.Fatalf("StartStreamableHTTPServer returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), time.Second)
+		defer stopCancel()
+		if err := handle.Stop(stopCtx); err != nil {
+			t.Errorf("stop Streamable HTTP server: %v", err)
+		}
+	})
+
+	httpClient := &http.Client{Transport: bearerTokenRoundTripper{token: "test-token", base: http.DefaultTransport}}
+	client := mcp.NewClient(&mcp.Implementation{Name: "run-test-client", Version: "v0.0.1"}, nil)
+	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
+		Endpoint:   "http://" + handle.Addr + handle.Path,
+		HTTPClient: httpClient,
+	}, nil)
+	if err != nil {
+		t.Fatalf("connect Streamable HTTP client: %v", err)
+	}
+	defer session.Close()
+
+	result, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("list tools over normal MCP session: %v", err)
+	}
+	if len(result.Tools) == 0 {
+		t.Fatal("normal MCP session returned no tools")
 	}
 }
 

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -19,6 +19,7 @@ import (
 
 	aiservice "GoNavi-Wails/internal/ai/service"
 	appcore "GoNavi-Wails/internal/app"
+	httpserverlimits "GoNavi-Wails/internal/httpserver"
 	"GoNavi-Wails/internal/logger"
 	"GoNavi-Wails/internal/requesttrace"
 	"GoNavi-Wails/internal/uievents"
@@ -596,8 +597,8 @@ func (s *SharedRuntime) EmitToBestEffort(targetID string, name string, args ...a
 
 func (s *SharedRuntime) routes() http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc(internalRoutePrefix+"/api/invoke", s.server.handleInvoke)
-	mux.HandleFunc(internalRoutePrefix+"/events", s.server.handleEvents)
+	mux.Handle(internalRoutePrefix+"/api/invoke", httpserverlimits.LimitRequestBody(http.HandlerFunc(s.server.handleInvoke)))
+	mux.Handle(internalRoutePrefix+"/events", httpserverlimits.StreamingWriteTimeout(http.HandlerFunc(s.server.handleEvents)))
 	mux.HandleFunc(s.runtimeBridgePath, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -719,7 +720,10 @@ func (s *Server) Run(ctx context.Context) error {
 	httpServer := &http.Server{
 		Addr:              s.options.Addr,
 		Handler:           s.routes(),
-		ReadHeaderTimeout: 10 * time.Second,
+		ReadHeaderTimeout: httpserverlimits.ReadHeaderTimeout,
+		ReadTimeout:       httpserverlimits.ReadTimeout,
+		WriteTimeout:      httpserverlimits.WriteTimeout,
+		IdleTimeout:       httpserverlimits.IdleTimeout,
 	}
 
 	listener, err := net.Listen("tcp", s.options.Addr)
@@ -757,14 +761,14 @@ func (s *Server) Run(ctx context.Context) error {
 func (s *Server) routes() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc(internalRoutePrefix+"/auth/status", s.handleAuthStatus)
-	mux.HandleFunc(internalRoutePrefix+"/auth/setup/bootstrap", s.handleSetupBootstrap)
-	mux.HandleFunc(internalRoutePrefix+"/auth/setup/complete", s.handleSetupComplete)
-	mux.HandleFunc(internalRoutePrefix+"/auth/login", s.handleLogin)
+	mux.Handle(internalRoutePrefix+"/auth/setup/bootstrap", httpserverlimits.LimitRequestBody(http.HandlerFunc(s.handleSetupBootstrap)))
+	mux.Handle(internalRoutePrefix+"/auth/setup/complete", httpserverlimits.LimitRequestBody(http.HandlerFunc(s.handleSetupComplete)))
+	mux.Handle(internalRoutePrefix+"/auth/login", httpserverlimits.LimitRequestBody(http.HandlerFunc(s.handleLogin)))
 	mux.HandleFunc(internalRoutePrefix+"/auth/logout", s.handleLogout)
 	mux.Handle(internalRoutePrefix+"/auth/settings", s.requireWebAuth(http.HandlerFunc(s.handleAuthSettings)))
-	mux.Handle(internalRoutePrefix+"/auth/settings/password", s.requireWebAuth(http.HandlerFunc(s.handleAuthPasswordChange)))
-	mux.Handle(internalRoutePrefix+"/api/invoke", s.requireWebAuth(http.HandlerFunc(s.handleInvoke)))
-	mux.Handle(internalRoutePrefix+"/events", s.requireWebAuth(http.HandlerFunc(s.handleEvents)))
+	mux.Handle(internalRoutePrefix+"/auth/settings/password", s.requireWebAuth(httpserverlimits.LimitRequestBody(http.HandlerFunc(s.handleAuthPasswordChange))))
+	mux.Handle(internalRoutePrefix+"/api/invoke", s.requireWebAuth(httpserverlimits.LimitRequestBody(http.HandlerFunc(s.handleInvoke))))
+	mux.Handle(internalRoutePrefix+"/events", s.requireWebAuth(httpserverlimits.StreamingWriteTimeout(http.HandlerFunc(s.handleEvents))))
 	mux.Handle(internalRoutePrefix+"/web-runtime.js", s.requireWebAuth(http.HandlerFunc(s.handleRuntimeBridge)))
 	mux.HandleFunc(internalRoutePrefix+"/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")

--- a/internal/webserver/server_test.go
+++ b/internal/webserver/server_test.go
@@ -10,15 +10,26 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"testing/fstest"
 	"time"
 
 	aiservice "GoNavi-Wails/internal/ai/service"
 	appcore "GoNavi-Wails/internal/app"
+	httpserverlimits "GoNavi-Wails/internal/httpserver"
 )
 
 type webserverTestReceiver struct{}
+
+type countingWebserverTestReceiver struct {
+	calls atomic.Int32
+}
+
+func (r *countingWebserverTestReceiver) Echo(value string) string {
+	r.calls.Add(1)
+	return value
+}
 
 func (webserverTestReceiver) Echo(value string) (map[string]any, error) {
 	return map[string]any{"value": value}, nil
@@ -96,6 +107,54 @@ func TestMethodInvokerInvokeSupportsStructuredReturnValues(t *testing.T) {
 	}
 	if payload["value"] != "hello" {
 		t.Fatalf("expected echoed value hello, got %#v", payload["value"])
+	}
+}
+
+func TestWebInvokeBodyLimitRejectsBeforeBusinessInvocation(t *testing.T) {
+	receiver := &countingWebserverTestReceiver{}
+	server := &Server{invoker: &methodInvoker{targets: map[string]reflect.Value{
+		"test.receiver": reflect.ValueOf(receiver),
+	}}}
+	handler := httpserverlimits.LimitRequestBody(http.HandlerFunc(server.handleInvoke))
+	validPayload := `{"namespace":"test","receiver":"receiver","method":"Echo","args":["ok"]}`
+
+	t.Run("oversize", func(t *testing.T) {
+		paddingSize := int(httpserverlimits.MaxRequestBodyBytes) - len(validPayload) + 1
+		request := httptest.NewRequest(http.MethodPost, internalRoutePrefix+"/api/invoke", strings.NewReader(validPayload+strings.Repeat(" ", paddingSize)))
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, request)
+
+		if recorder.Code != http.StatusRequestEntityTooLarge {
+			t.Fatalf("status = %d, want %d; body=%q", recorder.Code, http.StatusRequestEntityTooLarge, recorder.Body.String())
+		}
+		if receiver.calls.Load() != 0 {
+			t.Fatal("Web invoke business method was called for an oversized body")
+		}
+	})
+
+	t.Run("normal", func(t *testing.T) {
+		request := httptest.NewRequest(http.MethodPost, internalRoutePrefix+"/api/invoke", strings.NewReader(validPayload))
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, request)
+
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d; body=%q", recorder.Code, http.StatusOK, recorder.Body.String())
+		}
+		if receiver.calls.Load() != 1 {
+			t.Fatalf("Web invoke calls = %d, want 1", receiver.calls.Load())
+		}
+	})
+}
+
+func TestParseOptionsPreservesDockerPublicListenAddress(t *testing.T) {
+	t.Setenv("GONAVI_WEB_ADDR", "0.0.0.0:34116")
+
+	options, err := ParseOptions(nil)
+	if err != nil {
+		t.Fatalf("ParseOptions returned error: %v", err)
+	}
+	if options.Addr != "0.0.0.0:34116" {
+		t.Fatalf("Addr = %q, want Docker public listen address", options.Addr)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Bound Web and Streamable HTTP MCP request bodies to 1 MiB before business or SDK handlers run.
- Added full read, write, and idle connection timeouts with explicit 413/408 responses.
- Preserved long-lived SSE connections with rolling write deadlines.
- Added Web/MCP regression coverage and process-level E2E validation.
- Increased the JVM fixture tool-version probe timeout to tolerate slow Linux CI startup without masking real failures.

## Validation

- Related Go unit tests, race tests, and vet pass.
- Web E2E: health check 200, normal login 200, oversized request 413.
- MCP E2E: health check 200, unauthorized 401, normal request 200, oversized request 413.
- Frontend build and Dockerfile validation pass.
- GitHub Actions Backend Tests run #358: Full backend suite, macOS, and Windows jobs all pass.

Fixes #1012