### PR TITLE
🐛 fix(mongodb): 放行受保护连接的只读查询

### DIFF
--- a/frontend/src/utils/connectionReadOnly.test.ts
+++ b/frontend/src/utils/connectionReadOnly.test.ts
@@ -117,4 +117,30 @@ describe('connectionReadOnly', () => {
       },
     }, 'SELECT * FROM users;--compact')).toEqual(['--compact']);
   });
+
+  it('allows MongoDB distinct and read-only aggregate shell commands', () => {
+    const config = {
+      type: 'mongodb',
+      protection: { restrictScriptExecution: true },
+    };
+
+    expect(findConnectionMutatingStatements(
+      config,
+      'db.users.distinct("status", { active: true }); db.users.aggregate([{ $match: { active: true } }])',
+    )).toEqual([]);
+  });
+
+  it('keeps aggregate pipelines with write stages protected', () => {
+    const config = {
+      type: 'mongodb',
+      protection: { restrictScriptExecution: true },
+    };
+    const statement = 'db.users.aggregate([{ $match: {} }, { $out: "archive" }])';
+
+    expect(findConnectionMutatingStatements(config, statement)).toEqual([statement]);
+    expect(findConnectionMutatingStatements(
+      config,
+      'db.users.aggregate([{ $match: {} }, { $merge: { into: "archive" } }])',
+    )).toEqual(['db.users.aggregate([{ $match: {} }, { $merge: { into: "archive" } }])']);
+  });
 });

--- a/frontend/src/utils/connectionReadOnly.ts
+++ b/frontend/src/utils/connectionReadOnly.ts
@@ -271,10 +271,26 @@ const isReadOnlyMongoStatement = (statement: string): boolean => {
     if (MONGO_WRITE_COMMANDS.has(commandKey)) {
       return false;
     }
+    if (commandKey === "aggregate" && mongoAggregateHasWriteStage(parsed)) {
+      return false;
+    }
     return MONGO_READ_ONLY_COMMANDS.has(commandKey);
   } catch {
     return false;
   }
+};
+
+const mongoAggregateHasWriteStage = (command: Record<string, unknown>): boolean => {
+  const pipelineEntry = Object.entries(command).find(([key]) => key.trim().toLowerCase() === "pipeline");
+  if (!Array.isArray(pipelineEntry?.[1])) return false;
+  return (pipelineEntry[1] as unknown[]).some((stage) => (
+    !!stage
+    && typeof stage === "object"
+    && !Array.isArray(stage)
+    && Object.keys(stage as Record<string, unknown>).some((key) => (
+      key.trim().toLowerCase() === "$out" || key.trim().toLowerCase() === "$merge"
+    ))
+  ));
 };
 
 const isConnectionReadOnlyStatement = (

--- a/frontend/src/utils/mongodb.test.ts
+++ b/frontend/src/utils/mongodb.test.ts
@@ -55,6 +55,19 @@ describe('convertMongoShellToJsonCommand', () => {
       limit: 0,
     });
   });
+
+  it('converts distinct shell commands to read-only Mongo commands', () => {
+    const result = convertMongoShellToJsonCommand(
+      'db.users.distinct("status", { active: true })',
+    );
+
+    expect(result.recognized).toBe(true);
+    expect(parseCommand(result.command)).toEqual({
+      distinct: 'users',
+      key: 'status',
+      query: { active: true },
+    });
+  });
 });
 
 describe('applyMongoQueryAutoLimit', () => {

--- a/frontend/src/utils/mongodb.ts
+++ b/frontend/src/utils/mongodb.ts
@@ -1334,6 +1334,32 @@ export const convertMongoShellToJsonCommand = (raw: string): ShellConvertResult 
       };
     }
 
+    if (method === 'distinct') {
+      if (args.length === 0) throw new Error('distinct field argument is required');
+      const key = parseMongoJSONValue(args[0]);
+      if (typeof key !== 'string' || !key.trim()) {
+        throw new Error('distinct field argument must be a string');
+      }
+      const query = args.length > 1 ? parseMongoJSONDoc(args[1], 'distinct query argument') : {};
+      const options = args.length > 2 ? parseMongoOptionalDoc(args[2]) : {};
+      for (const item of chain) {
+        if (isNoopMongoChainMethod(item.method)) continue;
+        throw new Error(`Unsupported chain method .${item.method}()`);
+      }
+      const command: Record<string, unknown> = {
+        distinct: collection,
+        key: key.trim(),
+        query,
+      };
+      for (const option of ['collation', 'hint', 'comment', 'maxTimeMS', 'readConcern', 'let']) {
+        if (typeof options[option] !== 'undefined') command[option] = options[option];
+      }
+      return {
+        recognized: true,
+        command: JSON.stringify(command),
+      };
+    }
+
     if (method === 'aggregate') {
       const pipeline = args.length > 0 ? parseMongoJSONPipeline(args[0]) : [];
       const options = args.length > 1 ? parseMongoJSONDoc(args[1], 'aggregate second argument (options)') : {};

--- a/internal/app/connection_readonly_test.go
+++ b/internal/app/connection_readonly_test.go
@@ -42,6 +42,18 @@ func TestEnsureReadOnlyConnectionAllowsQuery(t *testing.T) {
 	if err := ensureConnectionAllowsQuery(mongoConfig, `{"delete":"users","deletes":[{"q":{"active":false},"limit":0}]}`); err == nil {
 		t.Fatal("read-only mongodb connection should block delete")
 	}
+	if err := ensureConnectionAllowsQuery(mongoConfig, `{"distinct":"users","key":"status","query":{}}`); err != nil {
+		t.Fatalf("read-only mongodb connection should allow distinct: %v", err)
+	}
+	if err := ensureConnectionAllowsQuery(mongoConfig, `{"aggregate":"users","pipeline":[{"$match":{}}]}`); err != nil {
+		t.Fatalf("read-only mongodb connection should allow aggregate: %v", err)
+	}
+	if err := ensureConnectionAllowsQuery(mongoConfig, `{"aggregate":"users","pipeline":[{"$out":"archive"}]}`); err == nil {
+		t.Fatal("read-only mongodb connection should block aggregate write stage")
+	}
+	if err := ensureConnectionAllowsQuery(mongoConfig, `{"aggregate":"users","pipeline":[{"$merge":{"into":"archive"}}]}`); err == nil {
+		t.Fatal("read-only mongodb connection should block aggregate merge stage")
+	}
 }
 
 func TestEnsureReadOnlyConnectionAllowsAction(t *testing.T) {

--- a/internal/jvm/fixture_toolchain_test.go
+++ b/internal/jvm/fixture_toolchain_test.go
@@ -163,16 +163,29 @@ func readJVMFixtureToolVersion(parent context.Context, binary string) (string, i
 	ctx, cancel := context.WithTimeout(parent, 5*time.Second)
 	defer cancel()
 
-	output, err := exec.CommandContext(ctx, binary, "-version").CombinedOutput()
-	text := strings.TrimSpace(string(output))
-	if err != nil {
-		return text, 0, fmt.Errorf("%w; output: %s", err, nonEmptyJVMFixtureText(text, "<empty>"))
+	var lastText string
+	var lastErr error
+	for _, argument := range []string{"--version", "-version"} {
+		output, runErr := exec.CommandContext(ctx, binary, argument).CombinedOutput()
+		text := strings.TrimSpace(string(output))
+		lastText = text
+		lastErr = runErr
+
+		major, parseErr := parseJVMFixtureMajorVersion(text)
+		if parseErr == nil {
+			// Some Windows Java launchers return exit status 1 while still
+			// emitting a valid version string. The fixture only needs a
+			// consistent toolchain, so the parsed version is authoritative.
+			return text, major, nil
+		}
+		if runErr == nil {
+			return text, 0, parseErr
+		}
 	}
-	major, err := parseJVMFixtureMajorVersion(text)
-	if err != nil {
-		return text, 0, err
+	if lastErr != nil {
+		return lastText, 0, fmt.Errorf("%w; output: %s", lastErr, nonEmptyJVMFixtureText(lastText, "<empty>"))
 	}
-	return text, major, nil
+	return lastText, 0, fmt.Errorf("unrecognized Java version output: %q", compactJVMFixtureVersion(lastText))
 }
 
 func parseJVMFixtureMajorVersion(output string) (int, error) {


### PR DESCRIPTION
## 问题背景

Issue #1000 中，启用生产环境保护的 MongoDB 连接执行 `distinct` 和只读聚合查询时会被误判为写操作并拦截，导致合法查询无法执行。

## 修复内容

- 支持将 MongoDB `distinct` shell 命令转换为只读 JSON 命令，并保留查询参数和可选只读选项。
- 允许只读聚合管道通过保护检查，同时识别 `$out`、`$merge` 写阶段并继续拦截。
- 补充前端转换、保护判断和 Go 侧保护校验回归测试。
- 兼容 Windows JVM fixture 的 Java 版本探测，优先使用 `--version` 并回退到 `-version`。

## 验证方式

- `go test ./internal/jvm -run 'Test(ParseJVMFixtureMajorVersion|JVMFixtureToolchain)' -count=1`
- `go test ./internal/app -run TestEnsureReadOnlyConnection -count=1`
- `npm --prefix frontend test -- src/utils/connectionReadOnly.test.ts src/utils/mongodb.test.ts`（2 个测试文件，29 项通过）

## 影响与风险

- 产品运行逻辑仅调整 MongoDB 查询命令解析和生产环境保护判断，不改变非 MongoDB 数据源行为。
- JVM 版本探测修改仅用于测试 fixture；聚合中的 `$out` 和 `$merge` 仍按写操作拦截。
- 如需回滚可回退本 PR 提交。

## 关联 Issue

Closes #1000
