### PR TITLE
🐛 fix(change-preview): 修复跨方言字符串与时间字面量预览

### DIFF
--- a/internal/app/methods_file.go
+++ b/internal/app/methods_file.go
@@ -4888,7 +4888,7 @@ func buildChangePreview(dbInst db.Database, config connection.ConnectionConfig, 
 	dbType := resolveDDLDBType(config)
 	quoter := func(s string) string { return quoteIdentByType(dbType, s) }
 	tableQuoter := func(s string) string { return quoteQualifiedIdentByType(dbType, s) }
-	deletes, updates, inserts := db.GenerateChangePreviewWithTableQuoter(tableName, changes, quoter, tableQuoter)
+	deletes, updates, inserts := db.GenerateChangePreviewWithDialect(tableName, changes, dbType, quoter, tableQuoter)
 	return ChangePreview{Deletes: deletes, Updates: updates, Inserts: inserts}
 }
 

--- a/internal/app/methods_file_apply_changes_test.go
+++ b/internal/app/methods_file_apply_changes_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"GoNavi-Wails/internal/connection"
 	"GoNavi-Wails/internal/db"
@@ -145,11 +146,12 @@ func TestBuildChangePreviewUsesDialectStringLiteralRules(t *testing.T) {
 		name      string
 		dbType    string
 		wantValue string
+		wantTime  string
 	}{
-		{name: "mysql", dbType: "mysql", wantValue: `'O''Reilly \\docs'`},
-		{name: "postgres", dbType: "postgres", wantValue: `'O''Reilly \docs'`},
-		{name: "oracle", dbType: "oracle", wantValue: `'O''Reilly \docs'`},
-		{name: "sqlserver", dbType: "sqlserver", wantValue: `'O''Reilly \docs'`},
+		{name: "mysql", dbType: "mysql", wantValue: `'O''Reilly \\docs'`, wantTime: `'2026-08-21 13:14:15.123456'`},
+		{name: "postgres", dbType: "postgres", wantValue: `'O''Reilly \docs'`, wantTime: `TIMESTAMP '2026-08-21 13:14:15.123456'`},
+		{name: "oracle", dbType: "oracle", wantValue: `'O''Reilly \docs'`, wantTime: `TO_TIMESTAMP('2026-08-21 13:14:15.123456', 'YYYY-MM-DD HH24:MI:SS.FF6')`},
+		{name: "sqlserver", dbType: "sqlserver", wantValue: `'O''Reilly \docs'`, wantTime: `CONVERT(datetime2(7), '2026-08-21T13:14:15.123456', 126)`},
 	}
 
 	for _, test := range tests {
@@ -159,12 +161,15 @@ func TestBuildChangePreviewUsesDialectStringLiteralRules(t *testing.T) {
 				connection.ConnectionConfig{Type: test.dbType},
 				"users",
 				connection.ChangeSet{Updates: []connection.UpdateRow{{
-					Keys:   map[string]interface{}{"id": int64(1)},
-					Values: map[string]interface{}{"name": "O'Reilly \\docs"},
+					Keys: map[string]interface{}{"id": int64(1)},
+					Values: map[string]interface{}{
+						"name": "O'Reilly \\docs",
+						"when": time.Date(2026, 8, 21, 13, 14, 15, 123456000, time.UTC),
+					},
 				}}},
 			)
-			if len(preview.Updates) != 1 || !strings.Contains(preview.Updates[0], test.wantValue) {
-				t.Fatalf("dialect preview = %#v, want value literal %q", preview.Updates, test.wantValue)
+			if len(preview.Updates) != 1 || !strings.Contains(preview.Updates[0], test.wantValue) || !strings.Contains(preview.Updates[0], test.wantTime) {
+				t.Fatalf("dialect preview = %#v, want value literal %q and time literal %q", preview.Updates, test.wantValue, test.wantTime)
 			}
 		})
 	}

--- a/internal/app/methods_file_apply_changes_test.go
+++ b/internal/app/methods_file_apply_changes_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"strings"
 	"testing"
 
 	"GoNavi-Wails/internal/connection"
@@ -136,6 +137,36 @@ func TestBuildChangePreviewQuotesQualifiedOracleTargetBySegment(t *testing.T) {
 	want := `UPDATE "APP"."USERS" SET "STATUS" = '0' WHERE "ID" = 7;`
 	if len(preview.Updates) != 1 || preview.Updates[0] != want {
 		t.Fatalf("qualified Oracle preview = %#v, want %q", preview.Updates, want)
+	}
+}
+
+func TestBuildChangePreviewUsesDialectStringLiteralRules(t *testing.T) {
+	tests := []struct {
+		name      string
+		dbType    string
+		wantValue string
+	}{
+		{name: "mysql", dbType: "mysql", wantValue: `'O''Reilly \\docs'`},
+		{name: "postgres", dbType: "postgres", wantValue: `'O''Reilly \docs'`},
+		{name: "oracle", dbType: "oracle", wantValue: `'O''Reilly \docs'`},
+		{name: "sqlserver", dbType: "sqlserver", wantValue: `'O''Reilly \docs'`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			preview := buildChangePreview(
+				&fakeBatchWriteDB{},
+				connection.ConnectionConfig{Type: test.dbType},
+				"users",
+				connection.ChangeSet{Updates: []connection.UpdateRow{{
+					Keys:   map[string]interface{}{"id": int64(1)},
+					Values: map[string]interface{}{"name": "O'Reilly \\docs"},
+				}}},
+			)
+			if len(preview.Updates) != 1 || !strings.Contains(preview.Updates[0], test.wantValue) {
+				t.Fatalf("dialect preview = %#v, want value literal %q", preview.Updates, test.wantValue)
+			}
+		})
 	}
 }
 

--- a/internal/db/change_preview.go
+++ b/internal/db/change_preview.go
@@ -151,14 +151,41 @@ func formatLiteralForDialect(dbType string, v interface{}) string {
 func formatPreviewTemporalLiteral(dbType string, value time.Time) string {
 	switch dbType {
 	case "postgres":
-		return fmt.Sprintf("TIMESTAMP '%s'", value.Format("2006-01-02 15:04:05"))
+		return fmt.Sprintf("TIMESTAMP '%s'", formatPreviewTimestamp(value, 6))
 	case "oracle":
-		return fmt.Sprintf("TO_TIMESTAMP('%s', 'YYYY-MM-DD HH24:MI:SS')", value.Format("2006-01-02 15:04:05"))
+		text, precision := formatPreviewTimestampWithPrecision(value, 9)
+		if precision == 0 {
+			return fmt.Sprintf("TO_TIMESTAMP('%s', 'YYYY-MM-DD HH24:MI:SS')", text)
+		}
+		return fmt.Sprintf("TO_TIMESTAMP('%s', 'YYYY-MM-DD HH24:MI:SS.FF%d')", text, precision)
 	case "sqlserver":
-		return fmt.Sprintf("CONVERT(datetime2, '%s', 126)", value.Format("2006-01-02T15:04:05"))
+		return fmt.Sprintf("CONVERT(datetime2(7), '%s', 126)", strings.Replace(formatPreviewTimestamp(value, 7), " ", "T", 1))
 	default:
-		return fmt.Sprintf("'%s'", value.Format("2006-01-02 15:04:05"))
+		return fmt.Sprintf("'%s'", formatPreviewTimestamp(value, 6))
 	}
+}
+
+// formatPreviewTimestamp 将小数秒限制在目标方言可表达的精度内，并保留原始本地时间值。
+func formatPreviewTimestamp(value time.Time, maxPrecision int) string {
+	text, _ := formatPreviewTimestampWithPrecision(value, maxPrecision)
+	return text
+}
+
+func formatPreviewTimestampWithPrecision(value time.Time, maxPrecision int) (string, int) {
+	text := value.Format("2006-01-02 15:04:05")
+	if value.Nanosecond() == 0 || maxPrecision <= 0 {
+		return text, 0
+	}
+
+	fraction := strings.TrimRight(fmt.Sprintf("%09d", value.Nanosecond()), "0")
+	if len(fraction) > maxPrecision {
+		fraction = fraction[:maxPrecision]
+	}
+	fraction = strings.TrimRight(fraction, "0")
+	if fraction == "" {
+		return text, 0
+	}
+	return text + "." + fraction, len(fraction)
 }
 
 func formatLiteralWithEscaper(v interface{}, escapeString func(string) string, escapeDefault func(string) string) string {

--- a/internal/db/change_preview.go
+++ b/internal/db/change_preview.go
@@ -23,6 +23,29 @@ func GenerateChangePreviewWithTableQuoter(
 	quoteIdent func(string) string,
 	quoteTable func(string) string,
 ) (deletes, updates, inserts []string) {
+	return generateChangePreview(tableName, changes, quoteIdent, quoteTable, formatLiteral)
+}
+
+// GenerateChangePreviewWithDialect 按目标方言格式化值字面量，同时保留现有标识符引用钩子。
+func GenerateChangePreviewWithDialect(
+	tableName string,
+	changes connection.ChangeSet,
+	dbType string,
+	quoteIdent func(string) string,
+	quoteTable func(string) string,
+) (deletes, updates, inserts []string) {
+	return generateChangePreview(tableName, changes, quoteIdent, quoteTable, func(v interface{}) string {
+		return formatLiteralForDialect(dbType, v)
+	})
+}
+
+func generateChangePreview(
+	tableName string,
+	changes connection.ChangeSet,
+	quoteIdent func(string) string,
+	quoteTable func(string) string,
+	format func(interface{}) string,
+) (deletes, updates, inserts []string) {
 	if quoteTable == nil {
 		quoteTable = quoteIdent
 	}
@@ -32,7 +55,7 @@ func GenerateChangePreviewWithTableQuoter(
 		var conds []string
 		for _, k := range sortedKeys(pk) {
 			v := pk[k]
-			conds = append(conds, fmt.Sprintf("%s = %s", quoteIdent(k), formatLiteral(v)))
+			conds = append(conds, fmt.Sprintf("%s = %s", quoteIdent(k), format(v)))
 		}
 		if len(conds) > 0 {
 			deletes = append(deletes, fmt.Sprintf("DELETE FROM %s WHERE %s;", quoteTable(tableName), strings.Join(conds, " AND ")))
@@ -44,7 +67,7 @@ func GenerateChangePreviewWithTableQuoter(
 		var sets []string
 		for _, k := range sortedKeys(row.Values) {
 			v := row.Values[k]
-			sets = append(sets, fmt.Sprintf("%s = %s", quoteIdent(k), formatLiteral(v)))
+			sets = append(sets, fmt.Sprintf("%s = %s", quoteIdent(k), format(v)))
 		}
 		if len(sets) == 0 {
 			continue
@@ -52,7 +75,7 @@ func GenerateChangePreviewWithTableQuoter(
 		var conds []string
 		for _, k := range sortedKeys(row.Keys) {
 			v := row.Keys[k]
-			conds = append(conds, fmt.Sprintf("%s = %s", quoteIdent(k), formatLiteral(v)))
+			conds = append(conds, fmt.Sprintf("%s = %s", quoteIdent(k), format(v)))
 		}
 		if len(conds) == 0 {
 			continue
@@ -70,7 +93,7 @@ func GenerateChangePreviewWithTableQuoter(
 				continue
 			}
 			cols = append(cols, quoteIdent(k))
-			vals = append(vals, formatLiteral(v))
+			vals = append(vals, format(v))
 		}
 		if len(cols) == 0 {
 			continue
@@ -93,14 +116,58 @@ func sortedKeys(m map[string]interface{}) []string {
 
 // formatLiteral 将 Go 值转为 SQL 字面量字符串。
 func formatLiteral(v interface{}) string {
+	return formatLiteralWithEscaper(v, func(value string) string {
+		escaped := strings.ReplaceAll(value, "\\", "\\\\")
+		return strings.ReplaceAll(escaped, "'", "\\'")
+	}, func(value string) string {
+		return strings.ReplaceAll(value, "'", "\\'")
+	})
+}
+
+func formatLiteralForDialect(dbType string, v interface{}) string {
+	normalizedType := strings.ToLower(strings.TrimSpace(dbType))
+	switch normalizedType {
+	case "postgresql":
+		normalizedType = "postgres"
+	case "mssql", "sql_server", "sql-server":
+		normalizedType = "sqlserver"
+	}
+	if temporal, ok := v.(time.Time); ok {
+		return formatPreviewTemporalLiteral(normalizedType, temporal)
+	}
+	return formatLiteralWithEscaper(v, func(value string) string {
+		if dialectEscapesBackslashInPreviewLiteral(normalizedType) {
+			value = strings.ReplaceAll(value, "\\", "\\\\")
+		}
+		return strings.ReplaceAll(value, "'", "''")
+	}, func(value string) string {
+		if dialectEscapesBackslashInPreviewLiteral(normalizedType) {
+			value = strings.ReplaceAll(value, "\\", "\\\\")
+		}
+		return strings.ReplaceAll(value, "'", "''")
+	})
+}
+
+func formatPreviewTemporalLiteral(dbType string, value time.Time) string {
+	switch dbType {
+	case "postgres":
+		return fmt.Sprintf("TIMESTAMP '%s'", value.Format("2006-01-02 15:04:05"))
+	case "oracle":
+		return fmt.Sprintf("TO_TIMESTAMP('%s', 'YYYY-MM-DD HH24:MI:SS')", value.Format("2006-01-02 15:04:05"))
+	case "sqlserver":
+		return fmt.Sprintf("CONVERT(datetime2, '%s', 126)", value.Format("2006-01-02T15:04:05"))
+	default:
+		return fmt.Sprintf("'%s'", value.Format("2006-01-02 15:04:05"))
+	}
+}
+
+func formatLiteralWithEscaper(v interface{}, escapeString func(string) string, escapeDefault func(string) string) string {
 	if v == nil {
 		return "NULL"
 	}
 	switch t := v.(type) {
 	case string:
-		escaped := strings.ReplaceAll(t, "\\", "\\\\")
-		escaped = strings.ReplaceAll(escaped, "'", "\\'")
-		return fmt.Sprintf("'%s'", escaped)
+		return fmt.Sprintf("'%s'", escapeString(t))
 	case float64:
 		return formatNumber(t)
 	case float32:
@@ -133,10 +200,20 @@ func formatLiteral(v interface{}) string {
 		}
 		return "FALSE"
 	case []byte:
-		return formatLiteral(string(t))
+		return fmt.Sprintf("'%s'", escapeString(string(t)))
 	default:
-		escaped := strings.ReplaceAll(fmt.Sprintf("%v", t), "'", "\\'")
-		return fmt.Sprintf("'%s'", escaped)
+		return fmt.Sprintf("'%s'", escapeDefault(fmt.Sprintf("%v", t)))
+	}
+}
+
+// dialectEscapesBackslashInPreviewLiteral reports dialects whose default string
+// literal parser treats backslash as an escape character.
+func dialectEscapesBackslashInPreviewLiteral(dbType string) bool {
+	switch dbType {
+	case "mysql", "mariadb", "tidb", "oceanbase", "diros", "doris", "starrocks", "sphinx", "clickhouse", "tdengine", "taos":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/db/change_preview_test.go
+++ b/internal/db/change_preview_test.go
@@ -117,7 +117,7 @@ func TestGenerateChangePreviewWithDialectEscapesStringLiterals(t *testing.T) {
 			Keys: map[string]interface{}{"id": int64(1)},
 			Values: map[string]interface{}{
 				"text": "O'Reilly \\docs",
-				"when": time.Date(2026, 8, 21, 13, 14, 15, 0, time.UTC),
+				"when": time.Date(2026, 8, 21, 13, 14, 15, 123456000, time.UTC),
 			},
 		}},
 	}
@@ -127,11 +127,11 @@ func TestGenerateChangePreviewWithDialectEscapesStringLiterals(t *testing.T) {
 		dbType string
 		want   string
 	}{
-		{name: "mysql", dbType: "mysql", want: "UPDATE `users` SET `text` = 'O''Reilly \\\\docs', `when` = '2026-08-21 13:14:15' WHERE `id` = 1;"},
-		{name: "postgres", dbType: "postgres", want: `UPDATE "users" SET "text" = 'O''Reilly \docs', "when" = TIMESTAMP '2026-08-21 13:14:15' WHERE "id" = 1;`},
-		{name: "oracle", dbType: "oracle", want: `UPDATE "users" SET "text" = 'O''Reilly \docs', "when" = TO_TIMESTAMP('2026-08-21 13:14:15', 'YYYY-MM-DD HH24:MI:SS') WHERE "id" = 1;`},
-		{name: "sqlserver", dbType: "sqlserver", want: "UPDATE [users] SET [text] = 'O''Reilly \\docs', [when] = CONVERT(datetime2, '2026-08-21T13:14:15', 126) WHERE [id] = 1;"},
-		{name: "sphinx", dbType: "sphinx", want: "UPDATE `users` SET `text` = 'O''Reilly \\\\docs', `when` = '2026-08-21 13:14:15' WHERE `id` = 1;"},
+		{name: "mysql", dbType: "mysql", want: "UPDATE `users` SET `text` = 'O''Reilly \\\\docs', `when` = '2026-08-21 13:14:15.123456' WHERE `id` = 1;"},
+		{name: "postgres", dbType: "postgres", want: `UPDATE "users" SET "text" = 'O''Reilly \docs', "when" = TIMESTAMP '2026-08-21 13:14:15.123456' WHERE "id" = 1;`},
+		{name: "oracle", dbType: "oracle", want: `UPDATE "users" SET "text" = 'O''Reilly \docs', "when" = TO_TIMESTAMP('2026-08-21 13:14:15.123456', 'YYYY-MM-DD HH24:MI:SS.FF6') WHERE "id" = 1;`},
+		{name: "sqlserver", dbType: "sqlserver", want: "UPDATE [users] SET [text] = 'O''Reilly \\docs', [when] = CONVERT(datetime2(7), '2026-08-21T13:14:15.123456', 126) WHERE [id] = 1;"},
+		{name: "sphinx", dbType: "sphinx", want: "UPDATE `users` SET `text` = 'O''Reilly \\\\docs', `when` = '2026-08-21 13:14:15.123456' WHERE `id` = 1;"},
 	}
 
 	for _, test := range tests {
@@ -149,6 +149,27 @@ func TestGenerateChangePreviewWithDialectEscapesStringLiterals(t *testing.T) {
 			_, updates, _ := GenerateChangePreviewWithDialect("users", changes, test.dbType, quote, quote)
 			if len(updates) != 1 || updates[0] != test.want {
 				t.Fatalf("preview = %#v, want %q", updates, test.want)
+			}
+		})
+	}
+}
+
+func TestFormatPreviewTemporalLiteralRetainsDialectPrecision(t *testing.T) {
+	value := time.Date(2026, 8, 21, 13, 14, 15, 123456789, time.UTC)
+	tests := []struct {
+		dbType string
+		want   string
+	}{
+		{dbType: "mysql", want: `'2026-08-21 13:14:15.123456'`},
+		{dbType: "postgres", want: `TIMESTAMP '2026-08-21 13:14:15.123456'`},
+		{dbType: "oracle", want: `TO_TIMESTAMP('2026-08-21 13:14:15.123456789', 'YYYY-MM-DD HH24:MI:SS.FF9')`},
+		{dbType: "sqlserver", want: `CONVERT(datetime2(7), '2026-08-21T13:14:15.1234567', 126)`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.dbType, func(t *testing.T) {
+			if got := formatPreviewTemporalLiteral(test.dbType, value); got != test.want {
+				t.Fatalf("formatPreviewTemporalLiteral(%q) = %q, want %q", test.dbType, got, test.want)
 			}
 		})
 	}

--- a/internal/db/change_preview_test.go
+++ b/internal/db/change_preview_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"GoNavi-Wails/internal/connection"
 )
@@ -107,6 +108,49 @@ func TestFormatLiteral(t *testing.T) {
 		if got != c.expected {
 			t.Errorf("formatLiteral(%v): got %s, want %s", c.val, got, c.expected)
 		}
+	}
+}
+
+func TestGenerateChangePreviewWithDialectEscapesStringLiterals(t *testing.T) {
+	changes := connection.ChangeSet{
+		Updates: []connection.UpdateRow{{
+			Keys: map[string]interface{}{"id": int64(1)},
+			Values: map[string]interface{}{
+				"text": "O'Reilly \\docs",
+				"when": time.Date(2026, 8, 21, 13, 14, 15, 0, time.UTC),
+			},
+		}},
+	}
+
+	tests := []struct {
+		name   string
+		dbType string
+		want   string
+	}{
+		{name: "mysql", dbType: "mysql", want: "UPDATE `users` SET `text` = 'O''Reilly \\\\docs', `when` = '2026-08-21 13:14:15' WHERE `id` = 1;"},
+		{name: "postgres", dbType: "postgres", want: `UPDATE "users" SET "text" = 'O''Reilly \docs', "when" = TIMESTAMP '2026-08-21 13:14:15' WHERE "id" = 1;`},
+		{name: "oracle", dbType: "oracle", want: `UPDATE "users" SET "text" = 'O''Reilly \docs', "when" = TO_TIMESTAMP('2026-08-21 13:14:15', 'YYYY-MM-DD HH24:MI:SS') WHERE "id" = 1;`},
+		{name: "sqlserver", dbType: "sqlserver", want: "UPDATE [users] SET [text] = 'O''Reilly \\docs', [when] = CONVERT(datetime2, '2026-08-21T13:14:15', 126) WHERE [id] = 1;"},
+		{name: "sphinx", dbType: "sphinx", want: "UPDATE `users` SET `text` = 'O''Reilly \\\\docs', `when` = '2026-08-21 13:14:15' WHERE `id` = 1;"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			quote := func(s string) string {
+				switch test.dbType {
+				case "mysql", "sphinx":
+					return "`" + s + "`"
+				case "sqlserver":
+					return "[" + s + "]"
+				default:
+					return `"` + s + `"`
+				}
+			}
+			_, updates, _ := GenerateChangePreviewWithDialect("users", changes, test.dbType, quote, quote)
+			if len(updates) != 1 || updates[0] != test.want {
+				t.Fatalf("preview = %#v, want %q", updates, test.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 问题背景

变更预览此前将所有字符串按 MySQL 风格反斜杠转义。PostgreSQL、Oracle 和 SQL Server 对反斜杠与单引号的处理不同，带特殊字符的预览 SQL 可能无法解析或改变值含义；时间值也缺少方言确定的转换表达式和小数秒精度。

## 修复内容

- 为默认变更预览增加方言感知的值字面量格式化，并保留原有标识符引用逻辑。
- MySQL 协议方言按反斜杠语义转义，PostgreSQL、Oracle 和 SQL Server 使用双单引号并保持反斜杠字面含义。
- PostgreSQL、Oracle 和 SQL Server 使用各自确定性的时间表达式；保留各方言可表达的小数秒精度。
- 补充生成器和应用层对单引号、反斜杠、时间值及 Sphinx 兼容性的回归测试。

## 验证方式

- `D:\Develop\Go\go1.25.12\bin\go.exe test ./internal/db -run 'Test(GenerateChangePreview|FormatLiteral|FormatPreviewTemporalLiteral)' -count=1 -timeout=30m`
- `D:\Develop\Go\go1.25.12\bin\go.exe test ./internal/app -run 'Test(BuildChangePreviewUsesDialectStringLiteralRules|BuildChangePreviewQuotesQualifiedOracleTargetBySegment|ApplyChanges)' -count=1 -timeout=30m`

## 影响与风险

- 仅修改提交前的 SQL 预览文本；`ApplyChanges` 仍将原始 `ChangeSet` 传给驱动，参数化实际写入路径不变。
- 未连接真实 MySQL、PostgreSQL、Oracle 或 SQL Server 实例做解析回读；回归测试验证各方言的生成 SQL 文本。
- 回滚可直接回退本 PR 的两个提交。

## 关联 Issue

Closes #1008
