### PR TITLE
🐛 fix(db): 修复特殊对象名元数据查询

### DIFF
--- a/internal/db/mariadb_impl.go
+++ b/internal/db/mariadb_impl.go
@@ -269,12 +269,7 @@ func (m *MariaDB) GetColumns(dbName, tableName string) ([]connection.ColumnDefin
 }
 
 func (m *MariaDB) GetIndexes(dbName, tableName string) ([]connection.IndexDefinition, error) {
-	query := fmt.Sprintf("SHOW INDEX FROM `%s`.`%s`", dbName, tableName)
-	if dbName == "" {
-		query = fmt.Sprintf("SHOW INDEX FROM `%s`", tableName)
-	}
-
-	data, _, err := m.Query(query)
+	data, _, err := m.Query(buildMySQLShowIndexQuery(dbName, tableName))
 	if err != nil {
 		return nil, err
 	}
@@ -322,11 +317,8 @@ func (m *MariaDB) GetIndexes(dbName, tableName string) ([]connection.IndexDefini
 }
 
 func (m *MariaDB) GetForeignKeys(dbName, tableName string) ([]connection.ForeignKeyDefinition, error) {
-	query := fmt.Sprintf(`SELECT CONSTRAINT_NAME, COLUMN_NAME, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME
-              FROM information_schema.KEY_COLUMN_USAGE
-              WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s' AND REFERENCED_TABLE_NAME IS NOT NULL`, dbName, tableName)
-
-	data, _, err := m.Query(query)
+	schema, table := mysqlMetadataTableParts(dbName, tableName)
+	data, _, err := queryMetadataRowsWithArgs(m.conn, metadataContextFor(m), "mariadb", buildMySQLForeignKeysQuery(), schema, table)
 	if err != nil {
 		return nil, err
 	}
@@ -346,8 +338,8 @@ func (m *MariaDB) GetForeignKeys(dbName, tableName string) ([]connection.Foreign
 }
 
 func (m *MariaDB) GetTriggers(dbName, tableName string) ([]connection.TriggerDefinition, error) {
-	query := fmt.Sprintf("SHOW TRIGGERS FROM `%s` WHERE `Table` = '%s'", dbName, tableName)
-	data, _, err := m.Query(query)
+	schema, table := mysqlMetadataTableParts(dbName, tableName)
+	data, _, err := queryMetadataRowsWithArgs(m.conn, metadataContextFor(m), "mariadb", buildMySQLShowTriggersQuery(schema), table)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/mariadb_metadata_quoting_test.go
+++ b/internal/db/mariadb_metadata_quoting_test.go
@@ -1,0 +1,28 @@
+//go:build gonavi_full_drivers || gonavi_mariadb_driver
+
+package db
+
+import (
+	"database/sql"
+	"testing"
+)
+
+func TestMariaDBMetadataQueriesQuoteIdentifiersAndBindNames(t *testing.T) {
+	const schema = "app`prod"
+	const table = "order'items"
+
+	capture := &mysqlMetadataQuotingCapture{}
+	conn := sql.OpenDB(mysqlMetadataQuotingConnector{capture: capture})
+	t.Cleanup(func() { _ = conn.Close() })
+	db := &MariaDB{conn: conn}
+	if _, err := db.GetIndexes(schema, table); err != nil {
+		t.Fatalf("GetIndexes returned error: %v", err)
+	}
+	if _, err := db.GetForeignKeys(schema, table); err != nil {
+		t.Fatalf("GetForeignKeys returned error: %v", err)
+	}
+	if _, err := db.GetTriggers(schema, table); err != nil {
+		t.Fatalf("GetTriggers returned error: %v", err)
+	}
+	assertMySQLCompatibleMetadataQueryCapture(t, capture, schema, table)
+}

--- a/internal/db/mysql_impl.go
+++ b/internal/db/mysql_impl.go
@@ -1066,7 +1066,7 @@ func quoteMySQLIdentifier(ident string) string {
 	return "`" + strings.ReplaceAll(normalizeMySQLIdentifierPart(ident), "`", "``") + "`"
 }
 
-func mysqlQualifiedTableIdentifier(dbName, tableName string) string {
+func mysqlMetadataTableParts(dbName, tableName string) (string, string) {
 	schema := normalizeMySQLIdentifierPart(dbName)
 	table := strings.TrimSpace(tableName)
 	if parsedSchema, parsedTable := SplitSQLQualifiedName(table); parsedTable != "" {
@@ -1077,7 +1077,11 @@ func mysqlQualifiedTableIdentifier(dbName, tableName string) string {
 	} else {
 		table = normalizeMySQLIdentifierPart(table)
 	}
+	return schema, table
+}
 
+func mysqlQualifiedTableIdentifier(dbName, tableName string) string {
+	schema, table := mysqlMetadataTableParts(dbName, tableName)
 	if schema != "" {
 		return quoteMySQLIdentifier(schema) + "." + quoteMySQLIdentifier(table)
 	}
@@ -1090,6 +1094,37 @@ func buildMySQLShowCreateTableQuery(dbName, tableName string) string {
 
 func buildMySQLShowFullColumnsQuery(dbName, tableName string) string {
 	return "SHOW FULL COLUMNS FROM " + mysqlQualifiedTableIdentifier(dbName, tableName)
+}
+
+func buildMySQLShowIndexQuery(dbName, tableName string) string {
+	return "SHOW INDEX FROM " + mysqlQualifiedTableIdentifier(dbName, tableName)
+}
+
+func buildMySQLForeignKeysQuery() string {
+	return `SELECT CONSTRAINT_NAME, COLUMN_NAME, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME
+              FROM information_schema.KEY_COLUMN_USAGE
+              WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND REFERENCED_TABLE_NAME IS NOT NULL`
+}
+
+func buildMySQLShowTriggersQuery(dbName string) string {
+	schema := normalizeMySQLIdentifierPart(dbName)
+	query := "SHOW TRIGGERS"
+	if schema != "" {
+		query += " FROM " + quoteMySQLIdentifier(schema)
+	}
+	return query + " WHERE `Table` = ?"
+}
+
+func queryMetadataRowsWithArgs(conn *sql.DB, ctx context.Context, dialect, query string, args ...interface{}) ([]map[string]interface{}, []string, error) {
+	if conn == nil {
+		return nil, nil, fmt.Errorf("连接未打开")
+	}
+	rows, err := conn.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+	return scanRowsForDialect(rows, dialect)
 }
 
 func (m *MySQLDB) GetCreateStatement(dbName, tableName string) (string, error) {
@@ -1145,12 +1180,7 @@ func (m *MySQLDB) GetColumns(dbName, tableName string) ([]connection.ColumnDefin
 }
 
 func (m *MySQLDB) GetIndexes(dbName, tableName string) ([]connection.IndexDefinition, error) {
-	query := fmt.Sprintf("SHOW INDEX FROM `%s`.`%s`", dbName, tableName)
-	if dbName == "" {
-		query = fmt.Sprintf("SHOW INDEX FROM `%s`", tableName)
-	}
-
-	data, _, err := m.Query(query)
+	data, _, err := m.Query(buildMySQLShowIndexQuery(dbName, tableName))
 	if err != nil {
 		return nil, err
 	}
@@ -1198,11 +1228,8 @@ func (m *MySQLDB) GetIndexes(dbName, tableName string) ([]connection.IndexDefini
 }
 
 func (m *MySQLDB) GetForeignKeys(dbName, tableName string) ([]connection.ForeignKeyDefinition, error) {
-	query := fmt.Sprintf(`SELECT CONSTRAINT_NAME, COLUMN_NAME, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME 
-              FROM information_schema.KEY_COLUMN_USAGE 
-              WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s' AND REFERENCED_TABLE_NAME IS NOT NULL`, dbName, tableName)
-
-	data, _, err := m.Query(query)
+	schema, table := mysqlMetadataTableParts(dbName, tableName)
+	data, _, err := queryMetadataRowsWithArgs(m.conn, metadataContextFor(m), "mysql", buildMySQLForeignKeysQuery(), schema, table)
 	if err != nil {
 		return nil, err
 	}
@@ -1222,8 +1249,8 @@ func (m *MySQLDB) GetForeignKeys(dbName, tableName string) ([]connection.Foreign
 }
 
 func (m *MySQLDB) GetTriggers(dbName, tableName string) ([]connection.TriggerDefinition, error) {
-	query := fmt.Sprintf("SHOW TRIGGERS FROM `%s` WHERE `Table` = '%s'", dbName, tableName)
-	data, _, err := m.Query(query)
+	schema, table := mysqlMetadataTableParts(dbName, tableName)
+	data, _, err := queryMetadataRowsWithArgs(m.conn, metadataContextFor(m), "mysql", buildMySQLShowTriggersQuery(schema), table)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/mysql_metadata_test.go
+++ b/internal/db/mysql_metadata_test.go
@@ -1,7 +1,11 @@
 package db
 
 import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
 	"errors"
+	"io"
 	"reflect"
 	"testing"
 )
@@ -302,5 +306,96 @@ func TestBuildMySQLShowFullColumnsQueryEscapesIdentifiers(t *testing.T) {
 				t.Fatalf("buildMySQLShowFullColumnsQuery(%q,%q)=%q,want=%q", tt.dbName, tt.tableName, got, tt.want)
 			}
 		})
+	}
+}
+
+type mysqlMetadataQuotingCapture struct {
+	queries []string
+	args    [][]driver.NamedValue
+}
+
+type mysqlMetadataQuotingConnector struct {
+	capture *mysqlMetadataQuotingCapture
+}
+
+func (c mysqlMetadataQuotingConnector) Connect(context.Context) (driver.Conn, error) {
+	return &mysqlMetadataQuotingConn{capture: c.capture}, nil
+}
+
+func (mysqlMetadataQuotingConnector) Driver() driver.Driver { return mysqlMetadataQuotingDriver{} }
+
+type mysqlMetadataQuotingDriver struct{}
+
+func (mysqlMetadataQuotingDriver) Open(string) (driver.Conn, error) {
+	return nil, errors.New("use sql.OpenDB with the test connector")
+}
+
+type mysqlMetadataQuotingConn struct {
+	capture *mysqlMetadataQuotingCapture
+}
+
+func (mysqlMetadataQuotingConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepared statements are not supported by this test driver")
+}
+
+func (mysqlMetadataQuotingConn) Close() error { return nil }
+
+func (mysqlMetadataQuotingConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("transactions are not supported by this test driver")
+}
+
+func (c *mysqlMetadataQuotingConn) QueryContext(_ context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	c.capture.queries = append(c.capture.queries, query)
+	c.capture.args = append(c.capture.args, append([]driver.NamedValue(nil), args...))
+	return mysqlMetadataQuotingRows{}, nil
+}
+
+var _ driver.QueryerContext = (*mysqlMetadataQuotingConn)(nil)
+
+type mysqlMetadataQuotingRows struct{}
+
+func (mysqlMetadataQuotingRows) Columns() []string { return []string{"unused"} }
+func (mysqlMetadataQuotingRows) Close() error      { return nil }
+func (mysqlMetadataQuotingRows) Next([]driver.Value) error {
+	return io.EOF
+}
+
+func TestMySQLCompatibleMetadataQueriesQuoteIdentifiersAndBindNames(t *testing.T) {
+	const schema = "app`prod"
+	const table = "order'items"
+
+	capture := &mysqlMetadataQuotingCapture{}
+	conn := sql.OpenDB(mysqlMetadataQuotingConnector{capture: capture})
+	t.Cleanup(func() { _ = conn.Close() })
+	db := &MySQLDB{conn: conn}
+	if _, err := db.GetIndexes(schema, table); err != nil {
+		t.Fatalf("GetIndexes returned error: %v", err)
+	}
+	if _, err := db.GetForeignKeys(schema, table); err != nil {
+		t.Fatalf("GetForeignKeys returned error: %v", err)
+	}
+	if _, err := db.GetTriggers(schema, table); err != nil {
+		t.Fatalf("GetTriggers returned error: %v", err)
+	}
+	assertMySQLCompatibleMetadataQueryCapture(t, capture, schema, table)
+}
+
+func assertMySQLCompatibleMetadataQueryCapture(t *testing.T, capture *mysqlMetadataQuotingCapture, schema, table string) {
+	t.Helper()
+	wantQueries := []string{
+		"SHOW INDEX FROM `app``prod`.`order'items`",
+		buildMySQLForeignKeysQuery(),
+		"SHOW TRIGGERS FROM `app``prod` WHERE `Table` = ?",
+	}
+	wantArgs := [][]driver.NamedValue{
+		nil,
+		{{Ordinal: 1, Value: schema}, {Ordinal: 2, Value: table}},
+		{{Ordinal: 1, Value: table}},
+	}
+	if !reflect.DeepEqual(capture.queries, wantQueries) {
+		t.Fatalf("queries = %#v, want %#v", capture.queries, wantQueries)
+	}
+	if !reflect.DeepEqual(capture.args, wantArgs) {
+		t.Fatalf("args = %#v, want %#v", capture.args, wantArgs)
 	}
 }

--- a/internal/db/sqlite_impl.go
+++ b/internal/db/sqlite_impl.go
@@ -25,6 +25,10 @@ type SQLiteDB struct {
 
 var _ BatchApplierContext = (*SQLiteDB)(nil)
 
+func escapeSQLiteStringLiteral(value string) string {
+	return strings.ReplaceAll(value, "'", "''")
+}
+
 func (s *SQLiteDB) Connect(config connection.ConnectionConfig) error {
 	dsn, err := resolveSQLiteDSN(config)
 	if err != nil {
@@ -294,7 +298,7 @@ func (s *SQLiteDB) GetTableRowCounts(_ string, tables []string) (map[string]int6
 }
 
 func (s *SQLiteDB) GetCreateStatement(dbName, tableName string) (string, error) {
-	query := fmt.Sprintf("SELECT sql FROM sqlite_master WHERE type='table' AND name='%s'", tableName)
+	query := fmt.Sprintf("SELECT sql FROM sqlite_master WHERE type='table' AND name='%s'", escapeSQLiteStringLiteral(tableName))
 	data, _, err := s.Query(query)
 	if err != nil {
 		return "", err
@@ -313,10 +317,8 @@ func (s *SQLiteDB) GetColumns(dbName, tableName string) ([]connection.ColumnDefi
 		return nil, localizedDatabaseRuntimeError("db.backend.error.table_name_required", nil)
 	}
 
-	esc := func(v string) string { return strings.ReplaceAll(v, "'", "''") }
-
 	// cid, name, type, notnull, dflt_value, pk
-	data, _, err := s.Query(fmt.Sprintf("PRAGMA table_info('%s')", esc(table)))
+	data, _, err := s.Query(fmt.Sprintf("PRAGMA table_info('%s')", escapeSQLiteStringLiteral(table)))
 	if err != nil {
 		return nil, err
 	}
@@ -404,7 +406,6 @@ func (s *SQLiteDB) GetIndexes(dbName, tableName string) ([]connection.IndexDefin
 		return nil, localizedDatabaseRuntimeError("db.backend.error.table_name_required", nil)
 	}
 
-	esc := func(v string) string { return strings.ReplaceAll(v, "'", "''") }
 	parseInt := func(v interface{}) int {
 		switch val := v.(type) {
 		case int:
@@ -424,7 +425,7 @@ func (s *SQLiteDB) GetIndexes(dbName, tableName string) ([]connection.IndexDefin
 		}
 	}
 
-	data, _, err := s.Query(fmt.Sprintf("PRAGMA index_list('%s')", esc(table)))
+	data, _, err := s.Query(fmt.Sprintf("PRAGMA index_list('%s')", escapeSQLiteStringLiteral(table)))
 	if err != nil {
 		return nil, err
 	}
@@ -452,7 +453,7 @@ func (s *SQLiteDB) GetIndexes(dbName, tableName string) ([]connection.IndexDefin
 			nonUnique = 0
 		}
 
-		cols, _, err := s.Query(fmt.Sprintf("PRAGMA index_info('%s')", esc(indexName)))
+		cols, _, err := s.Query(fmt.Sprintf("PRAGMA index_info('%s')", escapeSQLiteStringLiteral(indexName)))
 		if err != nil {
 			// skip broken index
 			continue
@@ -495,9 +496,7 @@ func (s *SQLiteDB) GetForeignKeys(dbName, tableName string) ([]connection.Foreig
 		return nil, localizedDatabaseRuntimeError("db.backend.error.table_name_required", nil)
 	}
 
-	esc := func(v string) string { return strings.ReplaceAll(v, "'", "''") }
-
-	data, _, err := s.Query(fmt.Sprintf("PRAGMA foreign_key_list('%s')", esc(table)))
+	data, _, err := s.Query(fmt.Sprintf("PRAGMA foreign_key_list('%s')", escapeSQLiteStringLiteral(table)))
 	if err != nil {
 		return nil, err
 	}
@@ -569,9 +568,7 @@ func (s *SQLiteDB) GetTriggers(dbName, tableName string) ([]connection.TriggerDe
 		return nil, localizedDatabaseRuntimeError("db.backend.error.table_name_required", nil)
 	}
 
-	esc := func(v string) string { return strings.ReplaceAll(v, "'", "''") }
-
-	data, _, err := s.Query(fmt.Sprintf("SELECT name AS trigger_name, sql AS statement FROM sqlite_master WHERE type='trigger' AND tbl_name='%s' ORDER BY name", esc(table)))
+	data, _, err := s.Query(fmt.Sprintf("SELECT name AS trigger_name, sql AS statement FROM sqlite_master WHERE type='trigger' AND tbl_name='%s' ORDER BY name", escapeSQLiteStringLiteral(table)))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/sqlite_impl_test.go
+++ b/internal/db/sqlite_impl_test.go
@@ -68,6 +68,52 @@ func TestSQLiteConnectConfiguresBoundedPoolAndSerializesWrites(t *testing.T) {
 	}
 }
 
+func TestSQLiteMetadataSupportsApostropheObjectNames(t *testing.T) {
+	client := &SQLiteDB{}
+	if err := client.Connect(connection.ConnectionConfig{Type: "sqlite", Host: ":memory:"}); err != nil {
+		t.Fatalf("连接 SQLite 失败: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	const parentTable = "parent'items"
+	const table = "order'items"
+	const index = "idx'order_parent"
+	const trigger = "trg'order_insert"
+
+	if _, err := client.conn.Exec(`CREATE TABLE "parent'items" (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatalf("创建父表失败: %v", err)
+	}
+	if _, err := client.conn.Exec(`CREATE TABLE "order'items" (id INTEGER PRIMARY KEY, parent_id INTEGER, FOREIGN KEY (parent_id) REFERENCES "parent'items" (id))`); err != nil {
+		t.Fatalf("创建测试表失败: %v", err)
+	}
+	if _, err := client.conn.Exec(`CREATE INDEX "idx'order_parent" ON "order'items" (parent_id)`); err != nil {
+		t.Fatalf("创建索引失败: %v", err)
+	}
+	if _, err := client.conn.Exec(`CREATE TRIGGER "trg'order_insert" AFTER INSERT ON "order'items" BEGIN SELECT 1; END`); err != nil {
+		t.Fatalf("创建触发器失败: %v", err)
+	}
+
+	ddl, err := client.GetCreateStatement("main", table)
+	if err != nil || !strings.Contains(ddl, table) {
+		t.Fatalf("GetCreateStatement = %q, %v", ddl, err)
+	}
+
+	indexes, err := client.GetIndexes("main", table)
+	if err != nil || len(indexes) != 1 || indexes[0].Name != index || indexes[0].ColumnName != "parent_id" {
+		t.Fatalf("GetIndexes = %#v, %v", indexes, err)
+	}
+
+	foreignKeys, err := client.GetForeignKeys("main", table)
+	if err != nil || len(foreignKeys) != 1 || foreignKeys[0].RefTableName != parentTable || foreignKeys[0].ColumnName != "parent_id" {
+		t.Fatalf("GetForeignKeys = %#v, %v", foreignKeys, err)
+	}
+
+	triggers, err := client.GetTriggers("main", table)
+	if err != nil || len(triggers) != 1 || triggers[0].Name != trigger || triggers[0].Timing != "AFTER" || triggers[0].Event != "INSERT" {
+		t.Fatalf("GetTriggers = %#v, %v", triggers, err)
+	}
+}
+
 func TestResolveSQLiteDSNRejectsHostPort(t *testing.T) {
 	_, err := resolveSQLiteDSN(connection.ConnectionConfig{Type: "sqlite", Host: "localhost:3306"})
 	if err == nil {


### PR DESCRIPTION
## 问题背景

MySQL、MariaDB 的索引、外键和触发器元数据查询会直接拼接模式名或表名；SQLite 的建表 DDL 查询未转义表名中的单引号。特殊对象名会导致侧栏、结构查看和 MCP 元数据读取出现错误结果或查询失败。

## 修复内容

- MySQL、MariaDB 的索引查询复用方言标识符引用器，外键和触发器的表名条件改为参数绑定。
- 统一 MySQL/MariaDB 限定表名的解析逻辑，保证模式名和表名引用一致。
- SQLite 将建表 DDL、列、索引、外键和触发器元数据路径统一使用单引号字面量转义。
- 补充 MySQL/MariaDB fake SQL driver 断言和 SQLite 内存库特殊对象名回归测试。

## 验证方式

- `go test ./internal/db -run 'Test(MySQLCompatibleMetadataQueriesQuoteIdentifiersAndBindNames|BuildMySQLShowFullColumnsQueryEscapesIdentifiers|BuildMySQLShowCreateTableQueryNormalizesQuotedIdentifiers)$'`
- `go test -tags gonavi_mariadb_driver ./internal/db -run 'TestMariaDBMetadataQueriesQuoteIdentifiersAndBindNames$'`
- `go test -tags gonavi_sqlite_driver ./internal/db -run 'TestSQLiteMetadataSupportsApostropheObjectNames$'`
- `go test -tags 'gonavi_mariadb_driver gonavi_sqlite_driver' ./internal/db`

## 影响与风险

仅调整 MySQL、MariaDB 和 SQLite 的元数据查询构造方式，不变更公共接口。MySQL/MariaDB 通过 fake driver 验证生成 SQL 和绑定参数，未连接真实服务端；若需回滚，可回退本 PR 的单个提交。

## 关联 Issue

Closes #1009
