### PR TITLE
fix(import): treat blank nullable cells as NULL

### DIFF
--- a/internal/app/import_pipeline.go
+++ b/internal/app/import_pipeline.go
@@ -368,14 +368,18 @@ type importRowColumnValidator interface {
 }
 
 type importColumnTypeLookup struct {
-	byExactName  map[string]string
-	byFoldedName map[string][]string
+	byExactName          map[string]string
+	byFoldedName         map[string][]string
+	nullableByExactName  map[string]string
+	nullableByFoldedName map[string][]string
 }
 
 func newImportColumnTypeLookup(columns []connection.ColumnDefinition) importColumnTypeLookup {
 	lookup := importColumnTypeLookup{
-		byExactName:  make(map[string]string, len(columns)),
-		byFoldedName: make(map[string][]string, len(columns)),
+		byExactName:          make(map[string]string, len(columns)),
+		byFoldedName:         make(map[string][]string, len(columns)),
+		nullableByExactName:  make(map[string]string, len(columns)),
+		nullableByFoldedName: make(map[string][]string, len(columns)),
 	}
 	for _, column := range columns {
 		name := column.Name
@@ -385,8 +389,13 @@ func newImportColumnTypeLookup(columns []connection.ColumnDefinition) importColu
 		if _, exists := lookup.byExactName[name]; !exists {
 			foldedName := normalizeColumnName(name)
 			lookup.byFoldedName[foldedName] = append(lookup.byFoldedName[foldedName], name)
+			lookup.nullableByFoldedName[foldedName] = append(
+				lookup.nullableByFoldedName[foldedName],
+				strings.TrimSpace(column.Nullable),
+			)
 		}
 		lookup.byExactName[name] = strings.TrimSpace(column.Type)
+		lookup.nullableByExactName[name] = strings.TrimSpace(column.Nullable)
 	}
 	return lookup
 }
@@ -400,6 +409,59 @@ func (l importColumnTypeLookup) Resolve(columnName string) string {
 		return ""
 	}
 	return l.byExactName[foldedMatches[0]]
+}
+
+func normalizeImportNullable(raw string) (bool, bool) {
+	switch strings.ToUpper(strings.TrimSpace(raw)) {
+	case "YES", "Y", "TRUE", "1", "NULLABLE":
+		return true, true
+	case "NO", "N", "FALSE", "0", "NOT NULL", "NOT_NULL", "NOTNULL", "REQUIRED":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+func (l importColumnTypeLookup) IsNullable(columnName string) (bool, bool) {
+	raw, ok := l.nullableByExactName[columnName]
+	if !ok {
+		foldedMatches := l.nullableByFoldedName[normalizeColumnName(columnName)]
+		if len(foldedMatches) != 1 {
+			return false, false
+		}
+		raw = foldedMatches[0]
+	}
+	return normalizeImportNullable(raw)
+}
+
+func normalizeImportValueForColumn(value interface{}, nullable bool) interface{} {
+	if nullable {
+		if text, ok := value.(string); ok && text == "" {
+			return nil
+		}
+	}
+	return value
+}
+
+func normalizeImportRowForTargetColumns(row map[string]interface{}, columnTypes importColumnTypeLookup) map[string]interface{} {
+	normalized := cloneImportRow(row)
+	for column, value := range normalized {
+		if nullable, known := columnTypes.IsNullable(column); known {
+			normalized[column] = normalizeImportValueForColumn(value, nullable)
+		}
+	}
+	return normalized
+}
+
+func normalizeImportRowsForTargetColumns(rows []map[string]interface{}, columnTypes importColumnTypeLookup) []map[string]interface{} {
+	if len(rows) == 0 {
+		return nil
+	}
+	normalized := make([]map[string]interface{}, 0, len(rows))
+	for _, row := range rows {
+		normalized = append(normalized, normalizeImportRowForTargetColumns(row, columnTypes))
+	}
+	return normalized
 }
 
 type importDatabaseRowWriter struct {
@@ -454,7 +516,7 @@ func (w *importDatabaseRowWriter) ApplyBatchContext(ctx context.Context, rows []
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	changes := connection.ChangeSet{Inserts: cloneImportRows(rows)}
+	changes := connection.ChangeSet{Inserts: normalizeImportRowsForTargetColumns(rows, w.columnTypes)}
 	if contextApplier, ok := w.applier.(db.BatchApplierContext); ok {
 		return contextApplier.ApplyChangesContext(ctx, w.tableName, changes)
 	}
@@ -483,7 +545,7 @@ func (w *importDatabaseRowWriter) ApplyOneWithOutcomeContext(ctx context.Context
 		return importRowApplySucceeded, err
 	}
 	if w.applier != nil && w.conflictPolicy == importConflictPolicyStop {
-		changes := connection.ChangeSet{Inserts: []map[string]interface{}{cloneImportRow(row)}}
+		changes := connection.ChangeSet{Inserts: []map[string]interface{}{normalizeImportRowForTargetColumns(row, w.columnTypes)}}
 		var err error
 		if contextApplier, ok := w.applier.(db.BatchApplierContext); ok {
 			err = contextApplier.ApplyChangesContext(ctx, w.tableName, changes)
@@ -1359,6 +1421,7 @@ func buildImportInsertQueryWithConflict(
 	quotedCols := make([]string, 0, len(columns))
 	values := make([]string, 0, len(columns))
 	usableColumns := make([]string, 0, len(columns))
+	normalizedRow := normalizeImportRowForTargetColumns(row, columnTypes)
 	for _, column := range columns {
 		if strings.TrimSpace(column) == "" {
 			continue
@@ -1366,7 +1429,8 @@ func buildImportInsertQueryWithConflict(
 		usableColumns = append(usableColumns, column)
 		quotedCols = append(quotedCols, quoteIdentByType(dbType, column))
 		colType := columnTypes.Resolve(column)
-		values = append(values, formatImportSQLValue(dbType, colType, row[column]))
+		value := normalizedRow[column]
+		values = append(values, formatImportSQLValue(dbType, colType, value))
 	}
 	if len(quotedCols) == 0 {
 		return "", fmt.Errorf("导入文件缺少有效列头")

--- a/internal/app/methods_file_import_test.go
+++ b/internal/app/methods_file_import_test.go
@@ -204,6 +204,89 @@ func TestBuildImportPreviewXLSXStreamSupportsInlineStrings(t *testing.T) {
 	}
 }
 
+type issue1025CapturingImportDB struct {
+	fakeMetadataRetryDB
+	batchChanges []connection.ChangeSet
+}
+
+func (database *issue1025CapturingImportDB) ApplyChanges(_ string, changes connection.ChangeSet) error {
+	database.batchChanges = append(database.batchChanges, changes)
+	return nil
+}
+
+func (database *issue1025CapturingImportDB) ApplyChangesContext(ctx context.Context, tableName string, changes connection.ChangeSet) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return database.ApplyChanges(tableName, changes)
+}
+
+func TestIssue1025BlankNullableXLSXCellsBecomeSQLNull(t *testing.T) {
+	database := &issue1025CapturingImportDB{fakeMetadataRetryDB: fakeMetadataRetryDB{
+		columns: []connection.ColumnDefinition{
+			{Name: "id", Type: "bigint", Nullable: "NO"},
+			{Name: "payload", Type: "json", Nullable: "YES"},
+			{Name: "count", Type: "int", Nullable: "YES"},
+			{Name: "required_count", Type: "int", Nullable: "NO"},
+		},
+	}}
+	installImportTestDatabase(t, database)
+
+	path := filepath.Join(t.TempDir(), "users.xlsx")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create xlsx: %v", err)
+	}
+	writer, err := newXLSXExportFileWriter(file, 0)
+	if err != nil {
+		_ = file.Close()
+		t.Fatalf("create xlsx writer: %v", err)
+	}
+	if err := writer.SetColumns([]string{"id", "payload", "count", "required_count"}); err != nil {
+		_ = file.Close()
+		t.Fatalf("set xlsx columns: %v", err)
+	}
+	if err := writer.ConsumeRowValues([]interface{}{"1", "", "", ""}); err != nil {
+		_ = file.Close()
+		t.Fatalf("write xlsx row: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		_ = file.Close()
+		t.Fatalf("close xlsx writer: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close xlsx: %v", err)
+	}
+
+	app := newManagedImportTestApp(t)
+	continueOnError := false
+	result := app.ImportDataWithProgressOptions(
+		connection.ConnectionConfig{Type: "mysql", Host: "127.0.0.1", Port: 3306, Database: "app"},
+		"app",
+		"users",
+		path,
+		ImportFileOptions{
+			ContinueOnError: &continueOnError,
+		},
+	)
+	if !result.Success {
+		t.Fatalf("blank nullable XLSX cells should import successfully: %#v", result)
+	}
+	if len(database.batchChanges) != 1 || len(database.batchChanges[0].Inserts) != 1 {
+		t.Fatalf("batch changes = %#v, want one inserted row", database.batchChanges)
+	}
+	row := database.batchChanges[0].Inserts[0]
+	if row["id"] != "1" {
+		t.Fatalf("id = %#v, want string 1", row["id"])
+	}
+	if row["payload"] != nil || row["count"] != nil {
+		t.Fatalf("nullable blank cells = %#v, want NULL values", row)
+	}
+	if row["required_count"] != "" {
+		t.Fatalf("required blank cell = %#v, want empty string for database validation", row["required_count"])
+	}
+}
+
 func TestBuildImportPreviewXLSXStreamSupportsSharedStrings(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "shared.xlsx")
 	workbook := excelize.NewFile()
@@ -474,6 +557,48 @@ func TestImportColumnTypeLookupKeepsCaseDistinctTypes(t *testing.T) {
 	}
 	if !strings.Contains(query, `("Foo", "foo") VALUES ('false', false)`) {
 		t.Fatalf("case-distinct target types produced wrong SQL: %s", query)
+	}
+}
+
+func TestImportColumnTypeLookupResolvesNullableMetadata(t *testing.T) {
+	lookup := newImportColumnTypeLookup([]connection.ColumnDefinition{
+		{Name: "optional_json", Type: "json", Nullable: "YES"},
+		{Name: "required_count", Type: "int", Nullable: "NO"},
+		{Name: "unknown", Type: "text"},
+	})
+
+	if nullable, known := lookup.IsNullable("OPTIONAL_JSON"); !known || !nullable {
+		t.Fatalf("optional column metadata = (%t, %t), want (true, true)", nullable, known)
+	}
+	if nullable, known := lookup.IsNullable("required_count"); !known || nullable {
+		t.Fatalf("required column metadata = (%t, %t), want (false, true)", nullable, known)
+	}
+	if _, known := lookup.IsNullable("unknown"); known {
+		t.Fatal("missing nullable metadata should remain unknown")
+	}
+}
+
+func TestBuildImportInsertQueryConvertsEmptyNullableValuesToSQLNull(t *testing.T) {
+	query, err := buildImportInsertQuery(
+		"mysql",
+		"users",
+		[]string{"optional_json", "optional_count", "required_count"},
+		map[string]interface{}{
+			"optional_json":  "",
+			"optional_count": "",
+			"required_count": "",
+		},
+		newImportColumnTypeLookup([]connection.ColumnDefinition{
+			{Name: "optional_json", Type: "json", Nullable: "YES"},
+			{Name: "optional_count", Type: "int", Nullable: "YES"},
+			{Name: "required_count", Type: "int", Nullable: "NO"},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("buildImportInsertQuery returned error: %v", err)
+	}
+	if !strings.Contains(query, "VALUES (NULL, NULL, '')") {
+		t.Fatalf("nullable empty values produced wrong SQL: %s", query)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Read target-column nullable metadata during file import.
- Convert blank spreadsheet values to SQL NULL only for nullable columns.
- Preserve blank values for NOT NULL or unknown metadata so the database remains authoritative.
- Cover both batch ApplyChanges and row-based SQL paths.

Fixes #1025

## Tests
- `go test ./internal/app -count=1`
- `npm test -- --run src/components/ImportPreviewModal.test.tsx src/components/DataImportWorkbench.test.tsx src/components/WorkbenchTabContent.data-import.test.tsx`
