### PR TITLE
🐛 fix(chroma): 修复筛选计数分页截断

### DIFF
--- a/internal/db/chroma_impl.go
+++ b/internal/db/chroma_impl.go
@@ -23,10 +23,11 @@ import (
 )
 
 const (
-	defaultChromaPort         = 8000
-	defaultChromaTenant       = "default_tenant"
-	defaultChromaDatabase     = "default_database"
-	defaultChromaQueryTimeout = 30 * time.Second
+	defaultChromaPort           = 8000
+	defaultChromaTenant         = "default_tenant"
+	defaultChromaDatabase       = "default_database"
+	defaultChromaQueryTimeout   = 30 * time.Second
+	chromaFilteredCountPageSize = 10_000
 )
 
 type ChromaDB struct {
@@ -641,22 +642,57 @@ func (c *ChromaDB) getCollectionRows(ctx context.Context, collection string, lim
 	return rows, columns, nil
 }
 
-func (c *ChromaDB) countCollection(ctx context.Context, collection string, where interface{}) (int64, error) {
-	path, err := c.collectionActionPath(ctx, collection, "count")
-	if err != nil {
+func (c *ChromaDB) getCollectionIDCount(ctx context.Context, path string, offset int, where interface{}) (int, error) {
+	body := map[string]interface{}{
+		"limit":   chromaFilteredCountPageSize,
+		"offset":  offset,
+		"include": []string{},
+	}
+	if where != nil {
+		body["where"] = where
+	}
+	var resp chromaGetResponse
+	if err := c.doJSON(ctx, http.MethodPost, path, body, &resp); err != nil {
 		return 0, err
 	}
+	return len(resp.IDs), nil
+}
+
+func (c *ChromaDB) countCollection(ctx context.Context, collection string, where interface{}) (int64, error) {
 	if where == nil {
+		path, err := c.collectionActionPath(ctx, collection, "count")
+		if err != nil {
+			return 0, err
+		}
 		var raw interface{}
 		if err := c.doJSON(ctx, http.MethodGet, path, nil, &raw); err == nil {
 			return chromaCountValue(raw), nil
 		}
 	}
-	rows, _, err := c.getCollectionRows(ctx, collection, 1_000_000, 0, where, []string{"documents"})
+	path, err := c.collectionActionPath(ctx, collection, "get")
 	if err != nil {
 		return 0, err
 	}
-	return int64(len(rows)), nil
+
+	countCtx := ctx
+	var cancel context.CancelFunc = func() {}
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		countCtx, cancel = context.WithTimeout(ctx, defaultChromaQueryTimeout)
+	}
+	defer cancel()
+
+	var total int64
+	for offset := 0; ; {
+		pageCount, err := c.getCollectionIDCount(countCtx, path, offset, where)
+		if err != nil {
+			return 0, err
+		}
+		total += int64(pageCount)
+		if pageCount < chromaFilteredCountPageSize {
+			return total, nil
+		}
+		offset += pageCount
+	}
 }
 
 func (c *ChromaDB) queryJSON(ctx context.Context, text string) ([]map[string]interface{}, []string, error) {

--- a/internal/db/chroma_impl_test.go
+++ b/internal/db/chroma_impl_test.go
@@ -208,6 +208,69 @@ func TestChromaSelectPassesWhereToGetAndCount(t *testing.T) {
 	}
 }
 
+func TestChromaCountWithWherePaginatesBeyondOneMillion(t *testing.T) {
+	const matchingDocuments = 1_000_001
+	var offsets []int
+	server := newMockChromaServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v2/heartbeat":
+			writeChromaJSON(w, map[string]interface{}{"ok": true})
+		case strings.HasSuffix(r.URL.Path, "/collections"):
+			writeChromaJSON(w, []chromaCollection{{ID: "col-products", Name: "products"}})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/collections/col-products/get"):
+			var body map[string]interface{}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode count request: %v", err)
+			}
+			if body["where"] == nil {
+				t.Fatal("count request must keep WHERE filter")
+			}
+			if include, ok := body["include"].([]interface{}); !ok || len(include) != 0 {
+				t.Fatalf("count request must not fetch documents, include = %#v", body["include"])
+			}
+			offset := intFromAny(body["offset"], -1)
+			limit := intFromAny(body["limit"], 0)
+			if offset < 0 || limit != chromaFilteredCountPageSize {
+				t.Fatalf("count request offset=%d limit=%d", offset, limit)
+			}
+			offsets = append(offsets, offset)
+			remaining := matchingDocuments - offset
+			if remaining < 0 {
+				remaining = 0
+			}
+			count := min(limit, remaining)
+			ids := make([]string, count)
+			for i := range ids {
+				ids[i] = fmt.Sprintf("doc-%d", offset+i)
+			}
+			writeChromaJSON(w, chromaGetResponse{IDs: ids})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	db := newTestChromaDB(t, server.URL)
+	rows, columns, err := db.Query("SELECT count(*) FROM products WHERE active = true")
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+	if len(rows) != 1 || len(columns) != 1 || columns[0] != "total" {
+		t.Fatalf("count result = %#v, columns = %v", rows, columns)
+	}
+	if total, ok := rows[0]["total"].(int64); !ok || total != matchingDocuments {
+		t.Fatalf("count total = %#v, want %d", rows[0]["total"], matchingDocuments)
+	}
+	wantPages := (matchingDocuments + chromaFilteredCountPageSize - 1) / chromaFilteredCountPageSize
+	if len(offsets) != wantPages {
+		t.Fatalf("count pages = %d, want %d", len(offsets), wantPages)
+	}
+	for page, offset := range offsets {
+		if want := page * chromaFilteredCountPageSize; offset != want {
+			t.Fatalf("page %d offset = %d, want %d", page, offset, want)
+		}
+	}
+}
+
 func TestChromaSelectRejectsUnsupportedWhereWithoutDataRequest(t *testing.T) {
 	db := &ChromaDB{client: &http.Client{Transport: vectorWhereRoundTripFunc(func(*http.Request) (*http.Response, error) {
 		t.Fatal("unsupported WHERE must not make an HTTP request")


### PR DESCRIPTION
## 问题背景

Chroma 的带 WHERE `COUNT` 会单次拉取最多 1,000,000 条文档后直接以返回行数作为总数。当筛选命中超过该上限时，界面会将截断值显示为准确计数。

## 修复内容

- 将带 WHERE 的计数改为每页 10,000 条的 `get` 请求，按实际返回的 ID 数量累加直到最后一页。
- 计数请求仅获取 `ids`，避免为计数读取 document、metadata 或 embedding 内容。
- 对没有 deadline 的 `QueryContext` 补充 30 秒计数预算；超时会返回错误，不再返回截断计数。
- 新增 1,000,001 条筛选命中的回归测试，覆盖连续 offset、分页次数和准确总数。

## 验证方式

- `go test ./internal/db -run TestChroma -count=1`
- `go test ./internal/db -count=1`
- 独立子 agent 代码审查：未发现 P0-P2 级可复现问题。

## 影响与风险

- 带 WHERE 的超大集合计数会产生多次分页请求，但单页响应固定为 10,000 条 ID，避免单次百万级载荷。
- 未连接真实 Chroma 服务；v1/v2 对空 `include` 与 `offset` 组合的兼容性仍需在集成环境验证。
- 集合在分页期间发生并发增删时，返回值不是严格的单时刻快照。

## 关联 Issue

Closes #1037
