### PR TITLE
🐛 fix(db): 统一连接池 search_path 初始化

### DIFF
--- a/internal/db/gaussdb_impl.go
+++ b/internal/db/gaussdb_impl.go
@@ -15,7 +15,6 @@ import (
 	"GoNavi-Wails/internal/connection"
 	"GoNavi-Wails/internal/logger"
 	"GoNavi-Wails/internal/ssh"
-	"GoNavi-Wails/internal/utils"
 
 	_ "github.com/HuaweiCloudDeveloper/gaussdb-go/stdlib"
 )
@@ -27,6 +26,11 @@ const defaultGaussDBPort = 5432
 type GaussDB struct {
 	PostgresDB
 }
+
+var (
+	openGaussDB                 = sql.Open
+	gaussDBRuntimeSupportStatus = DriverRuntimeSupportStatus
+)
 
 func (g *GaussDB) bindMetadataContext(ctx context.Context) {
 	BindMetadataContext(&g.PostgresDB, ctx)
@@ -119,7 +123,7 @@ func (g *GaussDB) Connect(config connection.ConnectionConfig) (err error) {
 		}
 	}()
 
-	if supported, reason := DriverRuntimeSupportStatus("gaussdb"); !supported {
+	if supported, reason := gaussDBRuntimeSupportStatus("gaussdb"); !supported {
 		if strings.TrimSpace(reason) == "" {
 			reason = localizedDriverRuntimeText("driver_manager.backend.status.optional_disabled", map[string]any{"name": "GaussDB"})
 		}
@@ -175,7 +179,7 @@ func (g *GaussDB) Connect(config connection.ConnectionConfig) (err error) {
 			attemptConfig.Database = dbName
 			dsn := g.getDSN(attemptConfig)
 
-			dbConn, err := sql.Open("gaussdb", dsn)
+			dbConn, err := openGaussDB("gaussdb", dsn)
 			if err != nil {
 				failures = append(failures, fmt.Sprintf("%s 数据库=%s 打开连接失败: %v", sslLabel, dbName, err))
 				continue
@@ -197,7 +201,14 @@ func (g *GaussDB) Connect(config connection.ConnectionConfig) (err error) {
 				logger.Infof("GaussDB 自动选择连接数据库：%s", dbName)
 			}
 
-			g.ensureSearchPath(dsn)
+			if err := g.ensureSearchPath(dsn); err != nil {
+				failures = append(failures, fmt.Sprintf("%s 数据库=%s 配置 search_path 失败: %v", sslLabel, dbName, err))
+				if g.conn != nil {
+					_ = g.conn.Close()
+					g.conn = nil
+				}
+				continue
+			}
 
 			return nil
 		}
@@ -209,56 +220,44 @@ func (g *GaussDB) Connect(config connection.ConnectionConfig) (err error) {
 	return fmt.Errorf("连接建立后验证失败：%s", strings.Join(failures, "；"))
 }
 
-func (g *GaussDB) ensureSearchPath(baseDSN string) {
+func (g *GaussDB) ensureSearchPath(baseDSN string) error {
 	if g.conn == nil {
-		return
+		return fmt.Errorf("连接未打开")
+	}
+	if postgresDSNHasExplicitSearchPath(baseDSN) {
+		return nil
 	}
 
 	rawSchemas := g.queryUserSchemas()
 	if len(rawSchemas) == 0 {
-		return
+		return nil
 	}
 
-	searchPathSQL, normalizedSchemas := buildKingbaseSearchPathCommon(rawSchemas)
+	searchPathSQL, _ := buildKingbaseSearchPathCommon(rawSchemas)
 	if strings.TrimSpace(searchPathSQL) == "" {
-		return
+		return nil
 	}
 
-	searchPathDSNVal := strings.Join(normalizedSchemas, ",")
-	u, parseErr := url.Parse(baseDSN)
-	if parseErr == nil {
-		q := u.Query()
-		q.Set("search_path", searchPathDSNVal)
-		u.RawQuery = q.Encode()
-		newDSN := u.String()
-
-		newDB, err := sql.Open("gaussdb", newDSN)
-		if err == nil {
-			configureSQLConnectionPool(newDB, "gaussdb")
-			newDB.SetConnMaxLifetime(5 * time.Minute)
-			oldConn := g.conn
-			g.conn = newDB
-			if err := g.Ping(); err == nil {
-				_ = oldConn.Close()
-				logger.Infof("GaussDB 已通过 DSN 配置 search_path：%s", searchPathDSNVal)
-				return
-			}
-			_ = newDB.Close()
-			g.conn = oldConn
-			logger.Warnf("GaussDB DSN search_path 验证失败，回退至 SET 方式")
-		}
+	newDSN, err := postgresDSNWithSearchPath(baseDSN, searchPathSQL)
+	if err != nil {
+		return err
 	}
 
-	timeout := g.pingTimeout
-	if timeout <= 0 {
-		timeout = 5 * time.Second
+	newDB, err := openGaussDB("gaussdb", newDSN)
+	if err != nil {
+		return fmt.Errorf("打开带 search_path 的连接失败: %w", err)
 	}
-	ctx, cancel := utils.ContextWithTimeout(timeout)
-	defer cancel()
+	configureSQLConnectionPool(newDB, "gaussdb")
+	newDB.SetConnMaxLifetime(5 * time.Minute)
+	oldConn := g.conn
+	g.conn = newDB
+	if err := g.Ping(); err != nil {
+		_ = newDB.Close()
+		g.conn = oldConn
+		return fmt.Errorf("验证带 search_path 的连接失败: %w", err)
+	}
 
-	if _, err := g.conn.ExecContext(ctx, fmt.Sprintf("SET search_path TO %s", searchPathSQL)); err != nil {
-		logger.Warnf("GaussDB 设置 search_path 失败：%v", err)
-		return
-	}
-	logger.Infof("GaussDB 已通过 SET 设置 search_path：%s", searchPathSQL)
+	_ = oldConn.Close()
+	logger.Infof("GaussDB 已通过 DSN 配置 search_path：%s", searchPathSQL)
+	return nil
 }

--- a/internal/db/gaussdb_search_path_test.go
+++ b/internal/db/gaussdb_search_path_test.go
@@ -1,0 +1,80 @@
+//go:build gonavi_full_drivers || gonavi_gaussdb_driver
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"GoNavi-Wails/internal/connection"
+)
+
+func TestGaussDBConnectInitializesSearchPathForEveryPhysicalConnection(t *testing.T) {
+	state := newSearchPathPoolState(false)
+	previousOpen := openGaussDB
+	openGaussDB = state.open
+	previousRuntimeSupportStatus := gaussDBRuntimeSupportStatus
+	gaussDBRuntimeSupportStatus = func(string) (bool, string) { return true, "" }
+	t.Cleanup(func() {
+		openGaussDB = previousOpen
+		gaussDBRuntimeSupportStatus = previousRuntimeSupportStatus
+	})
+
+	db := &GaussDB{}
+	if err := db.Connect(connection.ConnectionConfig{
+		Type:     "gaussdb",
+		Host:     "127.0.0.1",
+		Port:     5432,
+		User:     "gonavi",
+		Password: "test",
+		Database: "app",
+		SSLMode:  "disable",
+	}); err != nil {
+		t.Fatalf("Connect returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	first, err := db.conn.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("获取第一个物理连接失败: %v", err)
+	}
+	t.Cleanup(func() { _ = first.Close() })
+	second, err := db.conn.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("获取第二个物理连接失败: %v", err)
+	}
+	t.Cleanup(func() { _ = second.Close() })
+
+	assertUnqualifiedDuplicateObjectUsesTargetSchema(t, first)
+	assertUnqualifiedDuplicateObjectUsesTargetSchema(t, second)
+	state.assertAllPathConnectionsInitialized(t, 2)
+	state.assertNoSessionSearchPath(t)
+}
+
+func TestGaussDBConnectFailsWhenDSNSearchPathCannotInitialize(t *testing.T) {
+	state := newSearchPathPoolState(true)
+	previousOpen := openGaussDB
+	openGaussDB = state.open
+	previousRuntimeSupportStatus := gaussDBRuntimeSupportStatus
+	gaussDBRuntimeSupportStatus = func(string) (bool, string) { return true, "" }
+	t.Cleanup(func() {
+		openGaussDB = previousOpen
+		gaussDBRuntimeSupportStatus = previousRuntimeSupportStatus
+	})
+
+	db := &GaussDB{}
+	err := db.Connect(connection.ConnectionConfig{
+		Type:     "gaussdb",
+		Host:     "127.0.0.1",
+		Port:     5432,
+		User:     "gonavi",
+		Password: "test",
+		Database: "app",
+		SSLMode:  "disable",
+	})
+	if err == nil {
+		t.Fatal("DSN search_path 初始化失败时 Connect 应返回错误")
+	}
+	state.assertPoolUsedTwoPhysicalConnections(t)
+	state.assertNoSessionSearchPath(t)
+}

--- a/internal/db/kingbase_impl.go
+++ b/internal/db/kingbase_impl.go
@@ -36,6 +36,8 @@ var _ QueryMessageExecer = (*KingbaseDB)(nil)
 var _ StatementQueryMessageExecer = (*kingbaseSessionExecer)(nil)
 var _ DatabaseForeignKeyProvider = (*KingbaseDB)(nil)
 
+var openKingbaseDB = sql.Open
+
 // resolveKingbaseConnectDatabases returns databases that can be used to establish
 // a connection. Kingbase follows PostgreSQL's default of using the login user as
 // the database when no database is supplied, which is surprising for the UI's
@@ -77,6 +79,13 @@ func firstConnectionParamValue(params url.Values, keys ...string) string {
 		}
 	}
 	return ""
+}
+
+func kingbaseConfigHasExplicitSearchPath(config connection.ConnectionConfig) bool {
+	params := url.Values{}
+	mergeConnectionParamValuesWithAllowlist(params, connectionParamsFromURI(config.URI, "kingbase", "postgres", "postgresql"), kingbaseConnectionParamNames)
+	mergeConnectionParamValuesWithAllowlist(params, connectionParamsFromText(config.ConnectionParams), kingbaseConnectionParamNames)
+	return strings.TrimSpace(params.Get("search_path")) != ""
 }
 
 func quoteConnValue(v string) string {
@@ -221,7 +230,7 @@ func (k *KingbaseDB) Connect(config connection.ConnectionConfig) (err error) {
 			attempt := sslConfig
 			attempt.Database = dbName
 			dsn := k.getDSN(attempt)
-			db, err := sql.Open("kingbase", dsn)
+			db, err := openKingbaseDB("kingbase", dsn)
 			if err != nil {
 				failures = append(failures, fmt.Sprintf("%s 数据库=%s 打开连接失败: %v", sslLabel, dbName, err))
 				continue
@@ -242,47 +251,51 @@ func (k *KingbaseDB) Connect(config connection.ConnectionConfig) (err error) {
 				logger.Infof("人大金仓自动选择连接数据库：%s", dbName)
 			}
 
-			// 获取 schema 列表以重构带有 search_path 的连接池
-			searchPathStr := k.getSearchPathStr()
-			if searchPathStr != "" {
-				// 将 search_path 参数拼入 DSN
-				finalDSN := dsn + " search_path=" + quoteConnValue(searchPathStr)
-				if finalDB, err := sql.Open("kingbase", finalDSN); err == nil {
-					configureSQLConnectionPool(finalDB, "kingbase")
-					finalDB.SetConnMaxLifetime(5 * time.Minute)
-					k.pingTimeout = getConnectTimeout(attempt)
-
-					// 临时将 k.conn 指向 finalDB 来做 ping 测试
-					oldConn := k.conn
-					k.conn = finalDB
-					if err := k.Ping(); err == nil {
-						// 成功使用带 search_path 的连接池
-						_ = oldConn.Close()
-						logger.Infof("人大金仓已配置连接级 search_path：%s", searchPathStr)
-					} else {
-						_ = finalDB.Close()
-						k.conn = oldConn
-					}
+			if err := k.ensureSearchPath(dsn, kingbaseConfigHasExplicitSearchPath(attempt)); err != nil {
+				failures = append(failures, fmt.Sprintf("%s 数据库=%s 配置 search_path 失败: %v", sslLabel, dbName, err))
+				if k.conn != nil {
+					_ = k.conn.Close()
+					k.conn = nil
 				}
-			}
-			if searchPathStr != "" {
-				timeout := k.pingTimeout
-				if timeout <= 0 {
-					timeout = 5 * time.Second
-				}
-				ctx, cancel := utils.ContextWithTimeout(timeout)
-				defer cancel()
-				if _, err := k.conn.ExecContext(ctx, fmt.Sprintf("SET search_path TO %s", searchPathStr)); err != nil {
-					logger.Warnf("人大金仓显式设置 search_path 失败：%v", err)
-				} else {
-					logger.Infof("人大金仓已设置默认 search_path：%s", searchPathStr)
-				}
+				continue
 			}
 
 			return nil
 		}
 	}
 	return fmt.Errorf("连接建立后验证失败：%s", strings.Join(failures, "；"))
+}
+
+func (k *KingbaseDB) ensureSearchPath(baseDSN string, hasExplicitSearchPath bool) error {
+	if k.conn == nil {
+		return fmt.Errorf("连接未打开")
+	}
+	if hasExplicitSearchPath {
+		return nil
+	}
+
+	searchPath := k.getSearchPathStr()
+	if strings.TrimSpace(searchPath) == "" {
+		return nil
+	}
+
+	newDB, err := openKingbaseDB("kingbase", baseDSN+" search_path="+quoteConnValue(searchPath))
+	if err != nil {
+		return fmt.Errorf("打开带 search_path 的连接失败: %w", err)
+	}
+	configureSQLConnectionPool(newDB, "kingbase")
+	newDB.SetConnMaxLifetime(5 * time.Minute)
+	oldConn := k.conn
+	k.conn = newDB
+	if err := k.Ping(); err != nil {
+		_ = newDB.Close()
+		k.conn = oldConn
+		return fmt.Errorf("验证带 search_path 的连接失败: %w", err)
+	}
+
+	_ = oldConn.Close()
+	logger.Infof("人大金仓已配置连接级 search_path：%s", searchPath)
+	return nil
 }
 
 // getSearchPathStr 查询当前数据库中所有用户 schema，配置 DSN 的 search_path。

--- a/internal/db/kingbase_search_path_test.go
+++ b/internal/db/kingbase_search_path_test.go
@@ -1,0 +1,74 @@
+//go:build gonavi_full_drivers || gonavi_kingbase_driver
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"GoNavi-Wails/internal/connection"
+)
+
+func TestKingbaseConnectInitializesSearchPathForEveryPhysicalConnection(t *testing.T) {
+	state := newSearchPathPoolState(false)
+	previousOpen := openKingbaseDB
+	openKingbaseDB = state.open
+	t.Cleanup(func() {
+		openKingbaseDB = previousOpen
+	})
+
+	db := &KingbaseDB{}
+	if err := db.Connect(connection.ConnectionConfig{
+		Type:     "kingbase",
+		Host:     "127.0.0.1",
+		Port:     54321,
+		User:     "gonavi",
+		Password: "test",
+		Database: "app",
+		SSLMode:  "disable",
+	}); err != nil {
+		t.Fatalf("Connect returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	first, err := db.conn.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("获取第一个物理连接失败: %v", err)
+	}
+	t.Cleanup(func() { _ = first.Close() })
+	second, err := db.conn.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("获取第二个物理连接失败: %v", err)
+	}
+	t.Cleanup(func() { _ = second.Close() })
+
+	assertUnqualifiedDuplicateObjectUsesTargetSchema(t, first)
+	assertUnqualifiedDuplicateObjectUsesTargetSchema(t, second)
+	state.assertAllPathConnectionsInitialized(t, 2)
+	state.assertNoSessionSearchPath(t)
+}
+
+func TestKingbaseConnectFailsWhenDSNSearchPathCannotInitialize(t *testing.T) {
+	state := newSearchPathPoolState(true)
+	previousOpen := openKingbaseDB
+	openKingbaseDB = state.open
+	t.Cleanup(func() {
+		openKingbaseDB = previousOpen
+	})
+
+	db := &KingbaseDB{}
+	err := db.Connect(connection.ConnectionConfig{
+		Type:     "kingbase",
+		Host:     "127.0.0.1",
+		Port:     54321,
+		User:     "gonavi",
+		Password: "test",
+		Database: "app",
+		SSLMode:  "disable",
+	})
+	if err == nil {
+		t.Fatal("DSN search_path 初始化失败时 Connect 应返回错误")
+	}
+	state.assertPoolUsedTwoPhysicalConnections(t)
+	state.assertNoSessionSearchPath(t)
+}

--- a/internal/db/postgres_connect_test.go
+++ b/internal/db/postgres_connect_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -87,4 +88,68 @@ func TestPostgresDSNHasExplicitSearchPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPostgresConnectInitializesSearchPathForEveryPhysicalConnection(t *testing.T) {
+	state := newSearchPathPoolState(false)
+	previousOpen := openPostgresDB
+	openPostgresDB = state.open
+	t.Cleanup(func() {
+		openPostgresDB = previousOpen
+	})
+
+	db := &PostgresDB{}
+	if err := db.Connect(connection.ConnectionConfig{
+		Type:     "postgres",
+		Host:     "127.0.0.1",
+		Port:     5432,
+		User:     "gonavi",
+		Password: "test",
+		Database: "app",
+		SSLMode:  "disable",
+	}); err != nil {
+		t.Fatalf("Connect returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	first, err := db.conn.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("获取第一个物理连接失败: %v", err)
+	}
+	t.Cleanup(func() { _ = first.Close() })
+	second, err := db.conn.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("获取第二个物理连接失败: %v", err)
+	}
+	t.Cleanup(func() { _ = second.Close() })
+
+	assertUnqualifiedDuplicateObjectUsesTargetSchema(t, first)
+	assertUnqualifiedDuplicateObjectUsesTargetSchema(t, second)
+	state.assertAllPathConnectionsInitialized(t, 2)
+	state.assertNoSessionSearchPath(t)
+}
+
+func TestPostgresConnectFailsWhenDSNSearchPathCannotInitialize(t *testing.T) {
+	state := newSearchPathPoolState(true)
+	previousOpen := openPostgresDB
+	openPostgresDB = state.open
+	t.Cleanup(func() {
+		openPostgresDB = previousOpen
+	})
+
+	db := &PostgresDB{}
+	err := db.Connect(connection.ConnectionConfig{
+		Type:     "postgres",
+		Host:     "127.0.0.1",
+		Port:     5432,
+		User:     "gonavi",
+		Password: "test",
+		Database: "app",
+		SSLMode:  "disable",
+	})
+	if err == nil {
+		t.Fatal("DSN search_path 初始化失败时 Connect 应返回错误")
+	}
+	state.assertPoolUsedTwoPhysicalConnections(t)
+	state.assertNoSessionSearchPath(t)
 }

--- a/internal/db/postgres_impl.go
+++ b/internal/db/postgres_impl.go
@@ -27,6 +27,8 @@ type PostgresDB struct {
 
 var _ BatchApplierContext = (*PostgresDB)(nil)
 
+var openPostgresDB = sql.Open
+
 type postgresSessionExecer struct {
 	*sqlConnStatementExecer
 }
@@ -148,7 +150,7 @@ func (p *PostgresDB) Connect(config connection.ConnectionConfig) (err error) {
 			attemptConfig.Database = dbName
 			dsn := p.getDSN(attemptConfig)
 
-			dbConn, err := sql.Open("postgres", dsn)
+			dbConn, err := openPostgresDB("postgres", dsn)
 			if err != nil {
 				failures = append(failures, fmt.Sprintf("%s 数据库=%s 打开连接失败: %v", sslLabel, dbName, err))
 				continue
@@ -171,8 +173,15 @@ func (p *PostgresDB) Connect(config connection.ConnectionConfig) (err error) {
 				logger.Infof("PostgreSQL 自动选择连接数据库：%s", dbName)
 			}
 
-			// 设置 search_path，使所有用户 schema 下的表可以不带 schema 前缀访问
-			p.ensureSearchPath(dsn)
+			// search_path 必须在连接建立时写入 DSN，避免连接池中的连接配置不一致。
+			if err := p.ensureSearchPath(dsn); err != nil {
+				failures = append(failures, fmt.Sprintf("%s 数据库=%s 配置 search_path 失败: %v", sslLabel, dbName, err))
+				if p.conn != nil {
+					_ = p.conn.Close()
+					p.conn = nil
+				}
+				continue
+			}
 
 			return nil
 		}
@@ -556,71 +565,60 @@ func postgresDSNHasExplicitSearchPath(dsn string) bool {
 	return strings.TrimSpace(u.Query().Get("search_path")) != ""
 }
 
+func postgresDSNWithSearchPath(baseDSN string, searchPath string) (string, error) {
+	u, err := url.Parse(baseDSN)
+	if err != nil {
+		return "", fmt.Errorf("解析连接 DSN 失败: %w", err)
+	}
+	q := u.Query()
+	q.Set("search_path", searchPath)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
 // ensureSearchPath 查询当前数据库中所有用户 schema，通过重建连接池将 search_path 写入 DSN。
-// 仅使用 SET search_path 只对连接池中的单个连接生效，后续查询可能拿到未设置的连接。
 // 将 search_path 写入 DSN (lib/pq 支持任意 PostgreSQL runtime parameter)，
 // 使连接池中每个连接建立时自动携带 search_path，与金仓行为一致。
-func (p *PostgresDB) ensureSearchPath(baseDSN string) {
+func (p *PostgresDB) ensureSearchPath(baseDSN string) error {
 	if p.conn == nil {
-		return
+		return fmt.Errorf("连接未打开")
 	}
 	if postgresDSNHasExplicitSearchPath(baseDSN) {
-		return
+		return nil
 	}
 
 	rawSchemas := p.queryUserSchemas()
 	if len(rawSchemas) == 0 {
-		return
+		return nil
 	}
 
-	// 构建 search_path SQL 片段（带双引号转义），用于 SET 兜底
-	searchPathSQL, normalizedSchemas := buildKingbaseSearchPathCommon(rawSchemas)
+	searchPathSQL, _ := buildKingbaseSearchPathCommon(rawSchemas)
 	if strings.TrimSpace(searchPathSQL) == "" {
-		return
+		return nil
 	}
 
-	// 策略 1：将 search_path 写入 DSN，重建连接池
-	// lib/pq 支持在 URL 查参数中设置任意 PostgreSQL runtime parameter，
-	// 如 ?search_path=ce,public，每个新连接建立时会自动 SET search_path。
-	searchPathDSNVal := strings.Join(normalizedSchemas, ",")
-	u, parseErr := url.Parse(baseDSN)
-	if parseErr == nil {
-		q := u.Query()
-		q.Set("search_path", searchPathDSNVal)
-		u.RawQuery = q.Encode()
-		newDSN := u.String()
-
-		newDB, err := sql.Open("postgres", newDSN)
-		if err == nil {
-			configureSQLConnectionPool(newDB, "postgres")
-			newDB.SetConnMaxLifetime(5 * time.Minute)
-			oldConn := p.conn
-			p.conn = newDB
-			if err := p.Ping(); err == nil {
-				_ = oldConn.Close()
-				logger.Infof("PostgreSQL 已通过 DSN 配置 search_path：%s", searchPathDSNVal)
-				return
-			}
-			// DSN 方式失败，回滚
-			_ = newDB.Close()
-			p.conn = oldConn
-			logger.Warnf("PostgreSQL DSN search_path 验证失败，回退至 SET 方式")
-		}
+	newDSN, err := postgresDSNWithSearchPath(baseDSN, searchPathSQL)
+	if err != nil {
+		return err
 	}
 
-	// 策略 2 兜底：通过 SET search_path 设置（仅影响单个连接，但聊胜于无）
-	timeout := p.pingTimeout
-	if timeout <= 0 {
-		timeout = 5 * time.Second
+	newDB, err := openPostgresDB("postgres", newDSN)
+	if err != nil {
+		return fmt.Errorf("打开带 search_path 的连接失败: %w", err)
 	}
-	ctx, cancel := utils.ContextWithTimeout(timeout)
-	defer cancel()
+	configureSQLConnectionPool(newDB, "postgres")
+	newDB.SetConnMaxLifetime(5 * time.Minute)
+	oldConn := p.conn
+	p.conn = newDB
+	if err := p.Ping(); err != nil {
+		_ = newDB.Close()
+		p.conn = oldConn
+		return fmt.Errorf("验证带 search_path 的连接失败: %w", err)
+	}
 
-	if _, err := p.conn.ExecContext(ctx, fmt.Sprintf("SET search_path TO %s", searchPathSQL)); err != nil {
-		logger.Warnf("PostgreSQL 设置 search_path 失败：%v", err)
-		return
-	}
-	logger.Infof("PostgreSQL 已通过 SET 设置 search_path：%s", searchPathSQL)
+	_ = oldConn.Close()
+	logger.Infof("PostgreSQL 已通过 DSN 配置 search_path：%s", searchPathSQL)
+	return nil
 }
 
 // queryUserSchemas 查询当前数据库中所有用户 schema。

--- a/internal/db/search_path_pool_test.go
+++ b/internal/db/search_path_pool_test.go
@@ -1,0 +1,208 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+)
+
+const searchPathPoolExpected = `"Tenant.Schema", "tenant_b", "public"`
+
+type searchPathPoolState struct {
+	mu                  sync.Mutex
+	executedStatements  []string
+	expectedSearchPath  string
+	pathSearchPaths     []string
+	baseConnectionCount int
+	pathConnectionCount int
+	rejectSearchPath    bool
+}
+
+func newSearchPathPoolState(rejectSearchPath bool) *searchPathPoolState {
+	return &searchPathPoolState{
+		expectedSearchPath: searchPathPoolExpected,
+		rejectSearchPath:   rejectSearchPath,
+	}
+}
+
+func (s *searchPathPoolState) open(_ string, dsn string) (*sql.DB, error) {
+	return sql.OpenDB(searchPathPoolConnector{state: s, dsn: dsn}), nil
+}
+
+func (s *searchPathPoolState) recordConnection(searchPath string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if searchPath == "" {
+		s.baseConnectionCount++
+		return
+	}
+	s.pathConnectionCount++
+	s.pathSearchPaths = append(s.pathSearchPaths, searchPath)
+}
+
+func (s *searchPathPoolState) recordExecution(query string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.executedStatements = append(s.executedStatements, query)
+}
+
+func (s *searchPathPoolState) assertNoSessionSearchPath(t *testing.T) {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, statement := range s.executedStatements {
+		if strings.Contains(strings.ToLower(statement), "set search_path") {
+			t.Fatalf("不应对连接池执行会话级 search_path 设置: %q", statement)
+		}
+	}
+}
+
+func (s *searchPathPoolState) assertPoolUsedTwoPhysicalConnections(t *testing.T) {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	connectionCount := s.baseConnectionCount + s.pathConnectionCount
+	if connectionCount < 2 {
+		t.Fatalf("回归场景应至少使用两个物理连接，实际=%d", connectionCount)
+	}
+}
+
+func (s *searchPathPoolState) assertAllPathConnectionsInitialized(t *testing.T, wantAtLeast int) {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.pathConnectionCount < wantAtLeast {
+		t.Fatalf("应至少建立 %d 个带 search_path 的物理连接，实际=%d", wantAtLeast, s.pathConnectionCount)
+	}
+	for _, searchPath := range s.pathSearchPaths {
+		if searchPath != s.expectedSearchPath {
+			t.Fatalf("物理连接未使用目标 search_path，实际=%q，期望=%q", searchPath, s.expectedSearchPath)
+		}
+	}
+}
+
+type searchPathPoolConnector struct {
+	state *searchPathPoolState
+	dsn   string
+}
+
+func (c searchPathPoolConnector) Connect(context.Context) (driver.Conn, error) {
+	searchPath := searchPathFromTestDSN(c.dsn)
+	c.state.recordConnection(searchPath)
+	return &searchPathPoolConn{
+		state:      c.state,
+		searchPath: searchPath,
+		pingErr:    c.state.rejectSearchPath && searchPath != "",
+	}, nil
+}
+
+func (c searchPathPoolConnector) Driver() driver.Driver {
+	return searchPathPoolDriver{}
+}
+
+type searchPathPoolDriver struct{}
+
+func (searchPathPoolDriver) Open(string) (driver.Conn, error) {
+	return nil, errors.New("请使用 searchPathPoolConnector")
+}
+
+type searchPathPoolConn struct {
+	state      *searchPathPoolState
+	searchPath string
+	pingErr    bool
+}
+
+func (c *searchPathPoolConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("未实现")
+}
+
+func (c *searchPathPoolConn) Close() error { return nil }
+
+func (c *searchPathPoolConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("未实现")
+}
+
+func (c *searchPathPoolConn) Ping(context.Context) error {
+	if c.pingErr {
+		return errors.New("DSN search_path 初始化失败")
+	}
+	return nil
+}
+
+func (c *searchPathPoolConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	switch {
+	case strings.Contains(strings.ToLower(query), "from pg_namespace"):
+		return &searchPathPoolRows{columns: []string{"nspname"}, values: [][]driver.Value{{"Tenant.Schema"}, {"tenant_b"}}}, nil
+	case strings.Contains(strings.ToLower(query), "from duplicate_objects"):
+		if c.searchPath != c.state.expectedSearchPath {
+			return nil, fmt.Errorf("未限定对象解析到了错误 schema，search_path=%q", c.searchPath)
+		}
+		return &searchPathPoolRows{columns: []string{"table_schema"}, values: [][]driver.Value{{"Tenant.Schema"}}}, nil
+	default:
+		return &searchPathPoolRows{columns: []string{"value"}}, nil
+	}
+}
+
+func (c *searchPathPoolConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
+	c.state.recordExecution(query)
+	return driver.RowsAffected(0), nil
+}
+
+type searchPathPoolRows struct {
+	columns []string
+	values  [][]driver.Value
+	index   int
+}
+
+func (r searchPathPoolRows) Columns() []string { return r.columns }
+
+func (r searchPathPoolRows) Close() error { return nil }
+
+func (r *searchPathPoolRows) Next(dest []driver.Value) error {
+	if r.index >= len(r.values) {
+		return io.EOF
+	}
+	copy(dest, r.values[r.index])
+	r.index++
+	return nil
+}
+
+func searchPathFromTestDSN(dsn string) string {
+	if parsed, err := url.Parse(dsn); err == nil && parsed.Scheme != "" {
+		return parsed.Query().Get("search_path")
+	}
+
+	const key = "search_path="
+	index := strings.Index(strings.ToLower(dsn), key)
+	if index < 0 {
+		return ""
+	}
+	value := strings.TrimSpace(dsn[index+len(key):])
+	if len(value) >= 2 && value[0] == '\'' {
+		if end := strings.LastIndex(value[1:], "'"); end >= 0 {
+			return value[1 : end+1]
+		}
+	}
+	if end := strings.IndexAny(value, " \t\r\n"); end >= 0 {
+		return value[:end]
+	}
+	return value
+}
+
+func assertUnqualifiedDuplicateObjectUsesTargetSchema(t *testing.T, conn *sql.Conn) {
+	t.Helper()
+	var schema string
+	if err := conn.QueryRowContext(context.Background(), "SELECT table_schema FROM duplicate_objects").Scan(&schema); err != nil {
+		t.Fatalf("查询未限定的同名对象失败: %v", err)
+	}
+	if schema != "Tenant.Schema" {
+		t.Fatalf("未限定的同名对象应解析到 Tenant.Schema，实际=%q", schema)
+	}
+}


### PR DESCRIPTION
## 问题背景

PostgreSQL、GaussDB 与 Kingbase 在动态 `search_path` 的 DSN 重建失败后，会对连接池中单条物理连接执行会话级 `SET search_path`。同一连接池的其他连接不会继承该设置，未限定 Schema 的同名对象可能随机解析失败或串到错误 Schema。

## 修复内容

- 移除三类驱动的会话级 `SET search_path` 回退，仅允许通过 DSN 在建连时初始化路径。
- 带 `search_path` 的连接池打开或验证失败时，将当前数据库/SSL 候选视为失败；全部候选失败则连接失败。
- 保留用户显式配置的连接级 `search_path`，并保留 PostgreSQL、GaussDB 的 SQL 标识符引号。
- 新增 fake pool 回归测试，验证两个物理连接均使用目标路径、同名对象不串库，以及 DSN 初始化失败时不会执行会话级 `SET`。

## 验证方式

- `go test ./internal/db -count=1`
- `go test -tags gonavi_gaussdb_driver ./internal/db -count=1`
- `go test -tags gonavi_kingbase_driver ./internal/db -count=1`

## 影响与风险

- 当动态 `search_path` 无法通过 DSN 在所有物理连接上初始化时，连接会明确失败，不再保留配置不一致的连接池。
- 回滚可直接还原本 PR 的单个提交。
- fake driver 已覆盖 DSN 参数传递与双连接场景；未接入真实 PostgreSQL、GaussDB、Kingbase 服务验证各驱动对多 Schema 引号值的解析。

## 关联 Issue

Closes #1035
