### PR TITLE
🐛 fix(ai): 修复 ZCode macOS 检测测试

### DIFF
--- a/internal/ai/service/external_mcp_clients_test.go
+++ b/internal/ai/service/external_mcp_clients_test.go
@@ -561,6 +561,7 @@ func TestResolveDeepSeekHarnessNpxPackageDirEmptyWithoutCache(t *testing.T) {
 
 func TestDetectZCodeClientFallsBackToMacOSAppBundle(t *testing.T) {
 	disableLocalCLICommandShellFallback(t)
+	withTestAIGOOS(t, "darwin")
 	originalCLIPathFunc := localCLICommandPathFunc
 	localCLICommandPathFunc = func(string) (string, error) { return "", errors.New("not found") }
 	t.Cleanup(func() { localCLICommandPathFunc = originalCLIPathFunc })


### PR DESCRIPTION
## 问题背景

`TestDetectZCodeClientFallsBackToMacOSAppBundle` 用于验证 macOS `.app` bundle 回退逻辑，但没有模拟 `darwin`。因此该测试在 Linux 的完整后端 CI 中使用真实运行平台并稳定失败，阻塞无关 PR。

## 修复内容

- 在 macOS bundle 正向测试中通过 `withTestAIGOOS(t, "darwin")` 显式模拟目标平台。
- 保持现有实现与“非 Darwin 平台跳过 app bundle”的反向测试不变。

## 验证方式

- `go test ./internal/ai/service -run 'TestDetectZCodeClient(FallsBackToMacOSAppBundle|SkipsAppBundleOutsideDarwin)' -count=1`
- `go test ./internal/ai/service -count=1`
- `go test ./... -count=1 -timeout=30m`

## 影响与风险

- 仅修复测试环境的操作系统模拟，不改变 ZCode 客户端检测的产品行为。
- 不涉及配置文件、网络访问或用户数据。

## 关联说明

当前未找到可准确关联的 Issue；本 PR 修复 `dev` 基线的 Linux 后端测试失败。
