### PR TITLE
🐛 fix(elasticsearch): 限制别名写入索引

### DIFF
--- a/internal/db/elasticsearch_impl.go
+++ b/internal/db/elasticsearch_impl.go
@@ -1029,25 +1029,13 @@ func (e *ElasticsearchDB) ApplyChanges(tableName string, changes connection.Chan
 		return fmt.Errorf("解析写入索引失败：%w", err)
 	}
 
-	// resolveWriteIndex 确定写操作的目标索引。
-	// 如果文档数据中包含 _index（来自查询结果），使用实际索引名而非别名。
-	resolveWriteIndex := func(vals map[string]interface{}) string {
-		if idx, ok := vals["_index"]; ok {
-			if idxStr := strings.TrimSpace(fmt.Sprintf("%v", idx)); idxStr != "" {
-				return idxStr
-			}
-		}
-		return writeIndexName
-	}
-
 	// 删除操作
 	for _, pk := range changes.Deletes {
 		idVal, ok := pk["_id"]
 		if !ok {
 			return fmt.Errorf("删除操作缺少 _id")
 		}
-		writeIdx := resolveWriteIndex(pk)
-		actionJSON, _ := json.Marshal(e.esBulkActionMeta("delete", writeIdx, fmt.Sprintf("%v", idVal)))
+		actionJSON, _ := json.Marshal(e.esBulkActionMeta("delete", writeIndexName, fmt.Sprintf("%v", idVal)))
 		bulkBody.Write(actionJSON)
 		bulkBody.WriteByte('\n')
 	}
@@ -1058,8 +1046,7 @@ func (e *ElasticsearchDB) ApplyChanges(tableName string, changes connection.Chan
 		if !ok {
 			return fmt.Errorf("更新操作缺少 _id")
 		}
-		writeIdx := resolveWriteIndex(update.Values)
-		actionJSON, _ := json.Marshal(e.esBulkActionMeta("update", writeIdx, fmt.Sprintf("%v", idVal)))
+		actionJSON, _ := json.Marshal(e.esBulkActionMeta("update", writeIndexName, fmt.Sprintf("%v", idVal)))
 		bulkBody.Write(actionJSON)
 		bulkBody.WriteByte('\n')
 
@@ -1091,8 +1078,7 @@ func (e *ElasticsearchDB) ApplyChanges(tableName string, changes connection.Chan
 			}
 		}
 
-		writeIdx := resolveWriteIndex(insert)
-		actionJSON, _ := json.Marshal(e.esBulkActionMeta("index", writeIdx, docID))
+		actionJSON, _ := json.Marshal(e.esBulkActionMeta("index", writeIndexName, docID))
 		bulkBody.Write(actionJSON)
 		bulkBody.WriteByte('\n')
 		docJSON, _ := json.Marshal(doc)

--- a/internal/db/elasticsearch_impl_test.go
+++ b/internal/db/elasticsearch_impl_test.go
@@ -204,6 +204,87 @@ func TestElasticsearchApplyChangesResolvesWriteAliasMetadata(t *testing.T) {
 	}
 }
 
+func TestElasticsearchApplyChangesUsesAliasWriteIndexDespiteChangeSetIndex(t *testing.T) {
+	const alias = "events"
+	const writeIndex = "events-live"
+	const archivedIndex = "events-archive"
+
+	server := newMockESServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/_alias/"+alias:
+			writeJSON(w, map[string]interface{}{
+				archivedIndex: map[string]interface{}{"aliases": map[string]interface{}{
+					alias: map[string]interface{}{"is_write_index": false},
+				}},
+				writeIndex: map[string]interface{}{"aliases": map[string]interface{}{
+					alias: map[string]interface{}{"is_write_index": true},
+				}},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/_bulk":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("读取 bulk 请求失败：%v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			lines := strings.Split(strings.TrimSpace(string(body)), "\n")
+			if len(lines) != 5 {
+				t.Errorf("unexpected bulk NDJSON line count: got %d want 5, body=%q", len(lines), body)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			for _, expected := range []struct {
+				line      int
+				operation string
+				id        string
+			}{
+				{line: 0, operation: "delete", id: "deleted"},
+				{line: 1, operation: "update", id: "updated"},
+				{line: 3, operation: "index", id: "inserted"},
+			} {
+				var action map[string]map[string]interface{}
+				if err := json.Unmarshal([]byte(lines[expected.line]), &action); err != nil {
+					t.Errorf("解析 bulk action 失败：%v", err)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				metadata, ok := action[expected.operation]
+				if !ok || len(action) != 1 {
+					t.Errorf("bulk action line %d: got %v, want only %q", expected.line, action, expected.operation)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				if got, _ := metadata["_id"].(string); got != expected.id {
+					t.Errorf("%s action used _id %q, want %q", expected.operation, got, expected.id)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				if got, _ := metadata["_index"].(string); got != writeIndex {
+					t.Errorf("%s action wrote to %q, want alias write index %q", expected.operation, got, writeIndex)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+			}
+			writeJSON(w, map[string]interface{}{"errors": false, "items": []interface{}{}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	db := newTestESDB(t, server.URL, alias)
+	err := db.ApplyChanges(alias, connection.ChangeSet{
+		Deletes: []map[string]interface{}{{"_id": "deleted", "_index": archivedIndex}},
+		Updates: []connection.UpdateRow{{
+			Keys:   map[string]interface{}{"_id": "updated"},
+			Values: map[string]interface{}{"message": "updated", "_index": archivedIndex},
+		}},
+		Inserts: []map[string]interface{}{{"_id": "inserted", "message": "inserted", "_index": archivedIndex}},
+	})
+	if err != nil {
+		t.Fatalf("ApplyChanges returned error: %v", err)
+	}
+}
+
 // buildMockESMappingResponse 构造模拟的 mapping 响应 JSON。
 func buildMockESMappingResponse(indexName string, fields map[string]string) map[string]interface{} {
 	properties := make(map[string]interface{})


### PR DESCRIPTION
## 问题背景

Elasticsearch 对别名执行变更保存时，`ApplyChanges` 虽已解析唯一的 write index，但仍会优先采用变更行内的 `_index`。查询结果若来自历史索引，编辑后可能误写入 archive 等非 write index，造成数据分裂。

## 修复内容

- 删除、更新、插入操作统一使用已解析的 write index，不再允许变更行 `_index` 覆盖写入目标。
- 新增回归测试，覆盖三类操作携带历史索引 `_index` 的情况，并校验批量 NDJSON 的操作类型、文档 ID 和写入索引。

## 验证方式

- `go test -tags gonavi_elasticsearch_driver ./internal/db -run 'TestElasticsearchApplyChanges' -count=1`
- 两项独立代码审查：Elasticsearch 写入语义与回归测试覆盖。

## 影响与风险

- 别名写入始终落到解析出的唯一 write index，避免向历史索引写入。
- 保持既有“解析为物理 write index 后写入”的 rollover 别名策略；不改变直接指定物理索引的行为。

## 关联 Issue

Closes #1039
