### PR TITLE
🐛 fix(mcp): 显式标记表视图元数据部分失败

### DIFF
--- a/internal/app/methods_db.go
+++ b/internal/app/methods_db.go
@@ -2935,7 +2935,18 @@ func (a *App) DBGetViews(config connection.ConnectionConfig, dbName string) conn
 		return connection.QueryResult{Success: false, Message: err.Error()}
 	}
 
-	views := mapValuesSorted(listViewNameLookup(dbInst, runConfig, dbName))
+	viewLookup, err := listViewNameLookupWithStatus(dbInst, runConfig, dbName)
+	if err != nil {
+		logger.Warnf("DBGetViews 获取视图元数据失败：%s err=%v", formatConnSummary(runConfig), err)
+		return connection.QueryResult{
+			Success:   false,
+			Message:   err.Error(),
+			Data:      []map[string]string{},
+			Retryable: true,
+		}
+	}
+
+	views := mapValuesSorted(viewLookup)
 	resData := make([]map[string]string, 0, len(views))
 	for _, name := range views {
 		resData = append(resData, map[string]string{"View": name})

--- a/internal/app/methods_db_metadata_retry_test.go
+++ b/internal/app/methods_db_metadata_retry_test.go
@@ -427,6 +427,51 @@ func TestDBGetSchemaMetadataReusesOceanBaseOracleBaseConnectionForSelectedSchema
 	}
 }
 
+func TestDBGetViewsFailsWhenAllViewMetadataQueriesFail(t *testing.T) {
+	dbInst := &fakeMetadataRetryDB{
+		queryErr: errors.New("view metadata permission denied"),
+	}
+	fixture := newOceanBaseOracleMetadataFixture(t, dbInst)
+
+	result := fixture.app.DBGetViews(fixture.config, "CRH_AC")
+	if result.Success || !result.Retryable {
+		t.Fatalf("expected retryable view metadata failure, got %#v", result)
+	}
+	if !strings.Contains(result.Message, "view metadata permission denied") {
+		t.Fatalf("expected view metadata error to propagate, got %q", result.Message)
+	}
+	views, ok := result.Data.([]map[string]string)
+	if !ok || len(views) != 0 {
+		t.Fatalf("expected no view data on failure, got %#v", result.Data)
+	}
+}
+
+func TestDBGetViewsSucceedsWhenViewFallbackQuerySucceeds(t *testing.T) {
+	dbInst := &fakeMetadataRetryDB{
+		queryResults: []fakeMetadataQueryResult{
+			{match: "information_schema.tables", err: errors.New("catalog query denied")},
+			{match: "SHOW FULL TABLES", rows: []map[string]interface{}{{
+				"table_name": "active_users",
+				"table_type": "VIEW",
+			}}},
+		},
+	}
+	fixture := newOceanBaseOracleMetadataFixture(t, dbInst)
+	config := fixture.config
+	config.Type = "mysql"
+	config.OceanBaseProtocol = ""
+	config.Database = "app"
+
+	result := fixture.app.DBGetViews(config, "app")
+	if !result.Success || result.Retryable {
+		t.Fatalf("expected successful fallback view metadata result, got %#v", result)
+	}
+	views, ok := result.Data.([]map[string]string)
+	if !ok || len(views) != 1 || views[0]["View"] != "active_users" {
+		t.Fatalf("expected fallback view metadata, got %#v", result.Data)
+	}
+}
+
 func TestDBGetObjectsMarksExtensionMetadataFailuresPartial(t *testing.T) {
 	dbInst := &fakeMetadataRetryDB{
 		tables:   []string{"CRH_AC.ORDERS"},

--- a/internal/mcpserver/service.go
+++ b/internal/mcpserver/service.go
@@ -271,14 +271,26 @@ func (s *Service) GetTables(ctx context.Context, req *mcp.CallToolRequest, args 
 	}
 
 	views := []string{}
+	partial := queryResult.Partial
+	warnings := objectMetadataWarnings(queryResult)
+	retryable := queryResult.Retryable
 	viewResult := s.backend.DBGetViews(ctx, view.Config, dbName)
 	if err := ctx.Err(); err != nil {
 		return toolError("获取表列表失败: %s", err), getTablesResult{}, nil
 	}
-	if viewResult.Success {
-		if decodedViews, decodeErr := decodeNamedStringSlice(viewResult.Data, "View", "view", "name"); decodeErr == nil {
+	viewMetadataFailed := !viewResult.Success
+	if !viewMetadataFailed {
+		decodedViews, decodeErr := decodeNamedStringSlice(viewResult.Data, "View", "view", "name")
+		if decodeErr != nil {
+			viewMetadataFailed = true
+		} else {
 			views = decodedViews
 		}
+	}
+	if viewMetadataFailed {
+		partial = true
+		retryable = retryable || viewResult.Retryable
+		warnings = append(warnings, "获取视图元数据失败，返回的对象集合不完整")
 	}
 
 	return successResult(), getTablesResult{
@@ -287,9 +299,9 @@ func (s *Service) GetTables(ctx context.Context, req *mcp.CallToolRequest, args 
 		Tables:       ensureNonNilStrings(tables),
 		Views:        ensureNonNilStrings(views),
 		Message:      strings.TrimSpace(queryResult.Message),
-		Partial:      queryResult.Partial,
-		Warnings:     objectMetadataWarnings(queryResult),
-		Retryable:    queryResult.Retryable,
+		Partial:      partial,
+		Warnings:     warnings,
+		Retryable:    retryable,
 		Truncated:    queryResult.Truncated,
 		ScannedCount: queryResult.ScannedCount,
 	}, nil

--- a/internal/mcpserver/service_test.go
+++ b/internal/mcpserver/service_test.go
@@ -551,6 +551,72 @@ func TestGetTablesIncludesViewsInDedicatedField(t *testing.T) {
 	if len(out.Views) != 1 || out.Views[0] != "active_users" {
 		t.Fatalf("expected GetTables to expose views separately, got %#v", out)
 	}
+	if out.Partial || len(out.Warnings) != 0 {
+		t.Fatalf("expected complete table metadata result, got %#v", out)
+	}
+}
+
+func TestGetTablesMarksViewReadFailurePartial(t *testing.T) {
+	backend := &fakeBackend{
+		editableConnection: connection.SavedConnectionView{
+			ID:     "mysql-main",
+			Config: connection.ConnectionConfig{Type: "mysql", Database: "app"},
+		},
+		tablesResult: connection.QueryResult{
+			Success: true,
+			Data:    []map[string]string{{"Table": "users"}},
+		},
+		viewsResult: connection.QueryResult{
+			Success:   false,
+			Message:   "authentication failed for user",
+			Retryable: true,
+		},
+	}
+
+	result, out, err := NewService(backend).GetTables(context.Background(), nil, databaseArgs{
+		ConnectionID: "mysql-main",
+		DBName:       "app",
+	})
+	if err != nil || result == nil || result.IsError {
+		t.Fatalf("expected partial table metadata success, result=%#v err=%v", result, err)
+	}
+	if !out.Partial || !out.Retryable || len(out.Views) != 0 || len(out.Warnings) != 1 {
+		t.Fatalf("view lookup failure was not represented as partial metadata: %#v", out)
+	}
+	if out.Warnings[0] != "获取视图元数据失败，返回的对象集合不完整" {
+		t.Fatalf("expected safe view metadata warning, got %#v", out.Warnings)
+	}
+}
+
+func TestGetTablesMarksViewDecodeFailurePartial(t *testing.T) {
+	backend := &fakeBackend{
+		editableConnection: connection.SavedConnectionView{
+			ID:     "mysql-main",
+			Config: connection.ConnectionConfig{Type: "mysql", Database: "app"},
+		},
+		tablesResult: connection.QueryResult{
+			Success: true,
+			Data:    []map[string]string{{"Table": "users"}},
+		},
+		viewsResult: connection.QueryResult{
+			Success: true,
+			Data:    []int{1},
+		},
+	}
+
+	result, out, err := NewService(backend).GetTables(context.Background(), nil, databaseArgs{
+		ConnectionID: "mysql-main",
+		DBName:       "app",
+	})
+	if err != nil || result == nil || result.IsError {
+		t.Fatalf("expected partial table metadata success, result=%#v err=%v", result, err)
+	}
+	if !out.Partial || len(out.Views) != 0 || len(out.Warnings) != 1 {
+		t.Fatalf("view decode failure was not represented as partial metadata: %#v", out)
+	}
+	if out.Warnings[0] != "获取视图元数据失败，返回的对象集合不完整" {
+		t.Fatalf("expected safe view metadata warning, got %#v", out.Warnings)
+	}
 }
 
 func TestGetTablesPreservesPartialMetadataWarnings(t *testing.T) {
@@ -569,6 +635,7 @@ func TestGetTablesPreservesPartialMetadataWarnings(t *testing.T) {
 			Warnings:     []string{"Redis key scan truncated after 2 keys: cursor loop detected"},
 			Data:         []map[string]string{{"Table": "orders"}, {"Table": "users"}},
 		},
+		viewsResult: connection.QueryResult{Success: true},
 	}
 
 	result, out, err := NewService(backend).GetTables(context.Background(), nil, databaseArgs{

--- a/internal/mcpserver/service_test.go
+++ b/internal/mcpserver/service_test.go
@@ -568,7 +568,7 @@ func TestGetTablesMarksViewReadFailurePartial(t *testing.T) {
 		},
 		viewsResult: connection.QueryResult{
 			Success:   false,
-			Message:   "authentication failed for user",
+			Message:   "authentication failed password=secret-token",
 			Retryable: true,
 		},
 	}
@@ -585,6 +585,9 @@ func TestGetTablesMarksViewReadFailurePartial(t *testing.T) {
 	}
 	if out.Warnings[0] != "获取视图元数据失败，返回的对象集合不完整" {
 		t.Fatalf("expected safe view metadata warning, got %#v", out.Warnings)
+	}
+	if strings.Contains(out.Message, "secret-token") || strings.Contains(out.Warnings[0], "secret-token") {
+		t.Fatalf("view metadata failure leaked sensitive detail: %#v", out)
 	}
 }
 


### PR DESCRIPTION
## 问题背景

MCP `get_tables` 在表读取成功但视图读取或解码失败时，曾返回空 `views` 的完整成功结果。进一步定位发现，真实 `App.DBGetViews` 会吞掉所有视图候选查询失败的错误，导致 Service 层无法识别该失败。

## 修复内容

- `App.DBGetViews` 直接使用带状态的视图查询函数：全部候选查询失败时返回可重试失败，任一 fallback 查询成功时仍保持成功。
- `get_tables` 在视图读取或解码失败时保留已获取的表，并显式标记 `partial: true`。
- MCP 响应仅返回固定安全摘要，不暴露底层查询的原始错误。
- 补充 App 层的全部失败与 fallback 成功回归测试，以及 MCP 层的失败、解码和敏感错误保护测试。

## 验证方式

- `go test ./internal/app -run TestDBGetViews -count=1`
- `go test ./internal/mcpserver -count=1`

## 影响与风险

- 正常表与视图读取结果保持不变；任一视图 fallback 成功仍返回完整成功结果。
- 全部视图元数据查询失败时，调用方将收到明确的部分结果标记，避免将不完整集合用于 SQL 或迁移建议。
- 如需回滚，可回退本 PR 的两个提交。

## 关联 Issue

Closes #1038
