### PR TITLE
🐛 fix(query-editor): 修复 SQL Server 查询结果元数据定位

### DIFF
--- a/frontend/src/components/queryEditor/QueryEditorHelpers.test.ts
+++ b/frontend/src/components/queryEditor/QueryEditorHelpers.test.ts
@@ -9,6 +9,7 @@ import {
     createBoundedQueryEditorCompletionCandidateBatch,
     findCompletionTablesByDatabase,
     getCompletionTableSchemaCounts,
+    isSystemMetadataQueryResult,
     isOracleBaseTableReference,
     isQueryEditorTableSourceCompletionContext,
     materializeBoundedQueryEditorCompletionBatches,
@@ -64,6 +65,26 @@ describe('QueryEditor result merge identity', () => {
         expect(first).not.toBe(second);
         expect(first).toContain('::0::0');
         expect(second).toContain('::1::0');
+    });
+});
+
+describe('QueryEditor system metadata guard', () => {
+    it('keeps SQL Server system schemas read-only when metadata uses the current database', () => {
+        expect(isSystemMetadataQueryResult({
+            tableName: 'sys.objects',
+            metadataDbName: 'appdb',
+            metadataTableName: 'sys.objects',
+        }, 'sqlserver')).toBe(true);
+        expect(isSystemMetadataQueryResult({
+            tableName: 'INFORMATION_SCHEMA.TABLES',
+            metadataDbName: 'appdb',
+            metadataTableName: '[INFORMATION_SCHEMA].[TABLES]',
+        }, 'mssql')).toBe(true);
+        expect(isSystemMetadataQueryResult({
+            tableName: 'dbo.orders',
+            metadataDbName: 'appdb',
+            metadataTableName: 'dbo.orders',
+        }, 'sqlserver')).toBe(false);
     });
 });
 

--- a/frontend/src/components/queryEditor/QueryEditorHelpers.ts
+++ b/frontend/src/components/queryEditor/QueryEditorHelpers.ts
@@ -526,8 +526,13 @@ export const isSystemMetadataQueryResult = (tableRef: QueryResultTableRef, dbTyp
     if (normalizedDbType === 'sqlite' || normalizedDbType === 'duckdb') {
         return SQLITE_SYSTEM_METADATA_TABLES.has(metadataTableName) || metadataDbName === 'information_schema';
     }
-    if (normalizedDbType === 'sqlserver') {
-        return metadataDbName === 'information_schema' || metadataDbName === 'sys';
+    if (['sqlserver', 'mssql', 'sql_server', 'sql-server'].includes(normalizedDbType)) {
+        // SQL Server keeps the database in metadataDbName and the schema in
+        // metadataTableName (for example, appdb + sys.objects). Checking the
+        // database here would let system schemas bypass the read-only guard.
+        const parts = splitQualifiedNameSegments(tableRef.metadataTableName);
+        const schema = String(parts.length >= 2 ? parts[0] : '').toLowerCase();
+        return schema === 'information_schema' || schema === 'sys';
     }
     if (normalizedDbType === 'clickhouse') {
         return metadataDbName === 'system' || metadataDbName === 'information_schema';

--- a/frontend/src/utils/queryResultTable.test.ts
+++ b/frontend/src/utils/queryResultTable.test.ts
@@ -127,6 +127,23 @@ describe('extractQueryResultTableRef', () => {
       });
   });
 
+  it('uses the current or explicitly qualified database for SQL Server metadata lookups', () => {
+    expect(extractQueryResultTableRef('SELECT * FROM dbo.orders', 'sqlserver', 'appdb'))
+      .toMatchObject({
+        metadataDbName: 'appdb',
+        metadataTableName: 'dbo.orders',
+        ddlDbName: 'appdb',
+        ddlTableName: 'dbo.orders',
+      });
+    expect(extractQueryResultTableRef('SELECT * FROM sales.dbo.orders', 'sql-server', 'appdb'))
+      .toMatchObject({
+        metadataDbName: 'sales',
+        metadataTableName: 'dbo.orders',
+        ddlDbName: 'sales',
+        ddlTableName: 'dbo.orders',
+      });
+  });
+
   it('resolves Trino catalog and schema namespace for DDL', () => {
     expect(extractQueryResultTableRef('SELECT * FROM hive.audit.orders', 'trino', 'lakehouse.public'))
       .toMatchObject({

--- a/frontend/src/utils/queryResultTable.ts
+++ b/frontend/src/utils/queryResultTable.ts
@@ -17,7 +17,9 @@ const isOracleLikeDialect = (dialect: string): boolean => {
 
 const keepsQualifiedTableNameForMetadata = (dialect: string): boolean => {
   const normalized = String(dialect || '').trim().toLowerCase();
-  return normalized === 'duckdb' || isPostgresLikeDialect(normalized);
+  return normalized === 'duckdb'
+    || isSqlServerLikeDialect(normalized)
+    || isPostgresLikeDialect(normalized);
 };
 
 const isPostgresLikeDialect = (dialect: string): boolean => {
@@ -43,6 +45,11 @@ const normalizeCurrentDbName = (currentDb: string, dialect: string): string => {
   const value = String(currentDb || '').trim();
   if (!value) return '';
   return isOracleLikeDialect(dialect) ? value.toUpperCase() : value;
+};
+
+const isSqlServerLikeDialect = (dialect: string): boolean => {
+  const normalized = String(dialect || '').trim().toLowerCase();
+  return ['sqlserver', 'mssql', 'sql_server', 'sql-server'].includes(normalized);
 };
 
 const normalizeQualifiedNameParts = (raw: string, dialect: string): string[] => (
@@ -159,7 +166,7 @@ const resolveDdlTarget = (
   const table = parts[parts.length - 1] || '';
   if (!table) return {};
 
-  if (normalizedDialect === 'sqlserver' || normalizedDialect === 'mssql') {
+  if (isSqlServerLikeDialect(normalizedDialect)) {
     if (parts.length > 3) return {};
     const schema = parts.length >= 2 ? parts[parts.length - 2] : '';
     const database = parts.length === 3 ? parts[0] : currentNamespace;
@@ -261,13 +268,16 @@ export const extractQueryResultTableRef = (
   const fallbackSchema = isOracleLikeDialect(dialect)
     ? defaultOracleSchema || normalizeCurrentDbName(currentDb, dialect)
     : normalizeCurrentDbName(currentDb, dialect);
-  const metadataDbName = owner || fallbackSchema;
+  const sqlServerLikeDialect = isSqlServerLikeDialect(dialect);
+  const metadataDbName = sqlServerLikeDialect
+    ? (parts.length === 3 ? parts[0] : fallbackSchema)
+    : owner || fallbackSchema;
   const qualifiedTableName = owner ? `${owner}.${metadataTableName}` : metadataTableName;
   const pgLikeQualifiedMetadata = isPostgresLikeDialect(dialect) && owner;
   const resolvedMetadataDbName = pgLikeQualifiedMetadata
     ? normalizeCurrentDbName(currentDb, dialect)
     : metadataDbName;
-  const tableName = (isOracleLikeDialect(dialect) && owner) || pgLikeQualifiedMetadata
+  const tableName = (isOracleLikeDialect(dialect) && owner) || pgLikeQualifiedMetadata || (sqlServerLikeDialect && owner)
     ? `${owner}.${metadataTableName}`
     : (keepsQualifiedTableNameForMetadata(dialect) && owner ? `${owner}.${metadataTableName}` : metadataTableName);
   const resolvedMetadataTableName = keepsQualifiedTableNameForMetadata(dialect) && owner


### PR DESCRIPTION
## 变更说明

- SQL Server 查询结果的元数据改为将数据库与 `schema.table` 分开定位：两段名使用当前数据库，三段名使用显式数据库。
- 保留 schema-qualified 表名供列、索引及 DDL 元数据查询使用。
- 将 `sys` 与 `INFORMATION_SCHEMA` schema 结果标记为只读，避免系统元数据进入编辑流程。
- 统一 `sqlserver`、`mssql`、`sql_server`、`sql-server` 的解析行为。

## 影响范围

仅查询编辑器的 SQL Server 结果元数据解析和只读门禁；不包含生成绑定、依赖升级或其他本地运行产物。

## 验证

- 已在 SQL Server 环境手工验证。
- `npm test -- src/utils/queryResultTable.test.ts src/components/queryEditor/QueryEditorHelpers.test.ts`（59/59）
- `npm run build`