### PR TITLE
✨ feat(query): 连接下拉按侧栏顺序显示

### DIFF
--- a/frontend/src/components/QueryEditor.external-sql-save.test.tsx
+++ b/frontend/src/components/QueryEditor.external-sql-save.test.tsx
@@ -392,7 +392,8 @@ const editorState = vi.hoisted(() => {
   return state;
 });
 
-vi.mock('../store', () => {
+vi.mock('../store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../store')>();
   const useStore = Object.assign(
     (selector: (state: typeof storeState) => any) => React.useSyncExternalStore(
       (subscriber) => {
@@ -406,7 +407,7 @@ vi.mock('../store', () => {
     ),
     { getState: () => storeState },
   );
-  return { useStore };
+  return { ...actual, useStore };
 });
 
 vi.mock('../../wailsjs/runtime', () => runtimeApi);

--- a/frontend/src/components/QueryEditor.results-and-drop.test.tsx
+++ b/frontend/src/components/QueryEditor.results-and-drop.test.tsx
@@ -323,7 +323,8 @@ const editorState = vi.hoisted(() => {
   return state;
 });
 
-vi.mock('../store', () => {
+vi.mock('../store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../store')>();
   const useStore = Object.assign(
     (selector: (state: typeof storeState) => any) => React.useSyncExternalStore(
       (subscriber) => {
@@ -337,7 +338,7 @@ vi.mock('../store', () => {
     ),
     { getState: () => storeState },
   );
-  return { useStore };
+  return { ...actual, useStore };
 });
 
 vi.mock('../../wailsjs/go/app/App', () => backendApp);

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -1674,6 +1674,8 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
   const objectDecorationRefreshSeqRef = useRef(0);
 
   const connections = useStore(state => state.connections);
+  const connectionTags = useStore(state => state.connectionTags);
+  const sidebarRootOrder = useStore(state => state.sidebarRootOrder);
   const currentConnection = connections.find(
       (connection) => connection.id === currentConnectionId,
   );
@@ -11352,6 +11354,8 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
         currentConnectionId={currentConnectionId}
         currentDb={currentDb}
         queryCapableConnections={queryCapableConnections}
+        connectionTags={connectionTags}
+        sidebarRootOrder={sidebarRootOrder}
         dbList={dbList}
         contextSelectionDisabled={queryContextLockRunSeq !== 0 || Boolean(pendingSqlTransaction)}
         schemaSelect={canSelectQuerySchema ? {

--- a/frontend/src/components/QueryEditorToolbar.elasticsearch.test.tsx
+++ b/frontend/src/components/QueryEditorToolbar.elasticsearch.test.tsx
@@ -322,6 +322,51 @@ describe('QueryEditorToolbar Elasticsearch mode', () => {
     expect(onSchemaChange).toHaveBeenCalledWith('public');
   });
 
+  it('orders connection options by the sidebar group tree instead of saved order', () => {
+    act(() => {
+      renderer = create(<QueryEditorToolbar {...buildProps({
+        currentConnectionId: 'prod-api',
+        queryCapableConnections: [
+          { id: 'dev-db', name: 'Dev DB', config: { type: 'mysql' } },
+          { id: 'prod-api', name: 'Prod API', config: { type: 'mysql' } },
+          { id: 'prod-db', name: 'Prod DB', config: { type: 'postgres' } },
+          { id: 'prod-warehouse', name: 'Prod Warehouse', config: { type: 'mysql' } },
+          { id: 'local', name: 'Local', config: { type: 'sqlite' } },
+        ] as any[],
+        connectionTags: [
+          {
+            id: 'prod',
+            name: 'Production',
+            connectionIds: ['prod-api', 'prod-warehouse'],
+            childOrder: ['connection:prod-warehouse', 'tag:prod-databases', 'connection:prod-api'],
+          },
+          {
+            id: 'prod-databases',
+            name: 'Databases',
+            parentTagId: 'prod',
+            connectionIds: ['prod-db'],
+            childOrder: ['connection:prod-db'],
+          },
+          {
+            id: 'dev',
+            name: 'Development',
+            connectionIds: ['dev-db'],
+            childOrder: ['connection:dev-db'],
+          },
+        ],
+        sidebarRootOrder: ['tag:prod', 'connection:local', 'tag:dev'],
+      } as any)} />);
+    });
+
+    expect(antdState.selectProps[0].options.map((option: any) => option.value)).toEqual([
+      'prod-warehouse',
+      'prod-db',
+      'prod-api',
+      'local',
+      'dev-db',
+    ]);
+  });
+
   it('disables SQL connection context selectors while the transaction context is locked', () => {
     act(() => {
       renderer = create(<QueryEditorToolbar {...buildProps({

--- a/frontend/src/components/QueryEditorToolbar.tsx
+++ b/frontend/src/components/QueryEditorToolbar.tsx
@@ -22,7 +22,8 @@ import {
 
 import { t as defaultTranslate } from '../i18n';
 import { useOptionalI18n } from '../i18n/provider';
-import type { SavedConnection } from "../types";
+import type { ConnectionTag, SavedConnection } from "../types";
+import { flattenSidebarConnectionTagTree } from './sidebarV2Utils';
 import {
   getShortcutDisplayLabel,
   type ShortcutPlatform,
@@ -49,6 +50,8 @@ export type QueryEditorToolbarProps = {
   currentConnectionId: string;
   currentDb: string;
   queryCapableConnections: SavedConnection[];
+  connectionTags?: ConnectionTag[];
+  sidebarRootOrder?: string[];
   dbList: string[];
   schemaSelect?: QueryEditorSchemaSelectProps;
   maxRows: number;
@@ -225,6 +228,8 @@ const QueryEditorToolbar: React.FC<QueryEditorToolbarProps> = ({
   currentConnectionId,
   currentDb,
   queryCapableConnections,
+  connectionTags = [],
+  sidebarRootOrder = [],
   dbList,
   schemaSelect,
   maxRows,
@@ -273,8 +278,16 @@ const QueryEditorToolbar: React.FC<QueryEditorToolbarProps> = ({
     setOpenToolbarMenu((current) => open ? key : current === key ? null : current);
   };
   const baseMoreMenuItems = saveMoreMenuItems ?? [];
+  const orderedQueryCapableConnections = React.useMemo(
+    () => flattenSidebarConnectionTagTree(
+      queryCapableConnections,
+      connectionTags,
+      sidebarRootOrder,
+    ),
+    [connectionTags, queryCapableConnections, sidebarRootOrder],
+  );
   const connectionSelectOptions: FullNameSelectOption[] =
-    queryCapableConnections.map((connection) => ({
+    orderedQueryCapableConnections.map((connection) => ({
       label: connection.name,
       value: connection.id,
       title: "",

--- a/frontend/src/components/sidebarV2Utils.ts
+++ b/frontend/src/components/sidebarV2Utils.ts
@@ -741,6 +741,26 @@ export const buildSidebarConnectionTagTree = (
   return rootItems;
 };
 
+export const flattenSidebarConnectionTagTree = (
+  connections: SavedConnection[],
+  connectionTags: ConnectionTag[],
+  sidebarRootOrder: string[] = [],
+): SavedConnection[] => {
+  const ordered: SavedConnection[] = [];
+  const append = (items: SidebarConnectionTagTreeItem[]) => {
+    items.forEach((item) => {
+      if (item.kind === 'connection') {
+        ordered.push(item.connection);
+        return;
+      }
+      append(item.children);
+    });
+  };
+
+  append(buildSidebarConnectionTagTree(connections, connectionTags, sidebarRootOrder));
+  return ordered;
+};
+
 export const buildV2RailConnectionGroups = (
   connections: SavedConnection[],
   connectionTags: ConnectionTag[],


### PR DESCRIPTION
## 背景

SQL 编辑器的连接下拉直接使用连接保存顺序，和左侧连接树的分组及拖拽顺序不一致。

## 变更点

- 复用侧栏连接树生成扁平化连接顺序。
- SQL 编辑器工具栏按该顺序渲染可查询连接。
- 补充根分组、嵌套分组和未分组连接的回归测试。
- 将 QueryEditor 相关测试的 store mock 改为 partial mock，保留排序依赖的真实纯 helper。

## 影响范围

- 仅影响 SQL 编辑器工具栏中连接下拉的展示顺序及其测试 mock。
- 不修改连接配置、查询执行、连接可用性过滤或自动回退逻辑。
- 无兼容性、配置或依赖变更。

## 验证

- `npx --no-install vitest run src/components/QueryEditor.external-sql-save.test.tsx src/components/QueryEditor.results-and-drop.test.tsx --maxWorkers=1 --minWorkers=1`（443 项通过）
- `npx --no-install vitest run src/components/QueryEditorToolbar.elasticsearch.test.tsx src/components/QueryEditorToolbar.layout.test.tsx src/components/Sidebar.locate-toolbar.test.tsx --maxWorkers=1 --minWorkers=1`（117 项通过）
- `npm run build`

Closes #1030