### PR TITLE
fix(cloud-backup): stop background sync before shutdown

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -233,6 +233,13 @@ type App struct {
 	cloudBackupSyncMu             sync.Mutex
 	cloudBackupStateMu            sync.Mutex
 	cloudBackupSecretMu           sync.Mutex
+	cloudBackupLifecycleMu        sync.Mutex
+	cloudBackupLifecycleCtx       context.Context
+	cloudBackupLifecycleCancel    context.CancelFunc
+	cloudBackupBackgroundWG       sync.WaitGroup
+	cloudBackupShuttingDown       bool
+	cloudBackupImmediateSignal    chan struct{}
+	cloudBackupImmediateStarted   bool
 	cloudBackupSchedulerMu        sync.Mutex
 	cloudBackupSchedulerCancel    context.CancelFunc
 	cloudBackupDirtyMu            sync.Mutex

--- a/internal/app/cloud_backup.go
+++ b/internal/app/cloud_backup.go
@@ -1558,6 +1558,7 @@ func writeCloudBackupFile(target string, data []byte, mode os.FileMode) error {
 }
 
 func (a *App) initializeCloudBackup(ctx context.Context) {
+	a.initializeCloudBackupLifecycle(ctx)
 	if _, err := a.CloudBackupGetConfig(); err != nil {
 		logger.Warnf("加载云端备份配置失败：%v", err)
 	}
@@ -1577,11 +1578,11 @@ func (a *App) restartCloudBackupScheduler() {
 		return
 	}
 	a.cloudBackupSchedulerMu.Lock()
+	defer a.cloudBackupSchedulerMu.Unlock()
 	if a.cloudBackupSchedulerCancel != nil {
 		a.cloudBackupSchedulerCancel()
 	}
 	a.cloudBackupSchedulerCancel = nil
-	a.cloudBackupSchedulerMu.Unlock()
 	config, err := a.loadCloudBackupConfig()
 	if err != nil || !config.Enabled {
 		return
@@ -1590,11 +1591,18 @@ func (a *App) restartCloudBackupScheduler() {
 	if interval <= 0 {
 		return
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	a.cloudBackupSchedulerMu.Lock()
+	a.cloudBackupLifecycleMu.Lock()
+	parent := a.cloudBackupLifecycleContextLocked(context.Background())
+	if a.cloudBackupShuttingDown || parent.Err() != nil {
+		a.cloudBackupLifecycleMu.Unlock()
+		return
+	}
+	ctx, cancel := context.WithCancel(parent)
 	a.cloudBackupSchedulerCancel = cancel
-	a.cloudBackupSchedulerMu.Unlock()
+	a.cloudBackupBackgroundWG.Add(1)
+	a.cloudBackupLifecycleMu.Unlock()
 	go func() {
+		defer a.cloudBackupBackgroundWG.Done()
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {
@@ -1638,11 +1646,73 @@ func (a *App) markCloudBackupDirty() {
 	if config.Schedule != CloudBackupScheduleImmediate {
 		return
 	}
-	go func() {
-		if _, err := a.cloudBackupSync(context.Background()); err != nil {
-			logger.Warnf("修改后同步云端备份失败：%v", err)
+	a.queueImmediateCloudBackup()
+}
+
+func (a *App) initializeCloudBackupLifecycle(parent context.Context) {
+	a.cloudBackupLifecycleMu.Lock()
+	defer a.cloudBackupLifecycleMu.Unlock()
+	if a.cloudBackupShuttingDown {
+		return
+	}
+	a.cloudBackupLifecycleContextLocked(parent)
+}
+
+func (a *App) cloudBackupLifecycleContextLocked(parent context.Context) context.Context {
+	if a.cloudBackupLifecycleCtx != nil {
+		return a.cloudBackupLifecycleCtx
+	}
+	if parent == nil {
+		parent = context.Background()
+	}
+	a.cloudBackupLifecycleCtx, a.cloudBackupLifecycleCancel = context.WithCancel(parent)
+	a.cloudBackupImmediateSignal = make(chan struct{}, 1)
+	return a.cloudBackupLifecycleCtx
+}
+
+func (a *App) queueImmediateCloudBackup() {
+	a.cloudBackupLifecycleMu.Lock()
+	if a.cloudBackupShuttingDown {
+		a.cloudBackupLifecycleMu.Unlock()
+		return
+	}
+	ctx := a.cloudBackupLifecycleContextLocked(context.Background())
+	if ctx.Err() != nil {
+		a.cloudBackupLifecycleMu.Unlock()
+		return
+	}
+	if !a.cloudBackupImmediateStarted {
+		a.cloudBackupImmediateStarted = true
+		a.cloudBackupBackgroundWG.Add(1)
+		go a.runImmediateCloudBackup(ctx, a.cloudBackupImmediateSignal)
+	}
+	select {
+	case a.cloudBackupImmediateSignal <- struct{}{}:
+	default:
+	}
+	a.cloudBackupLifecycleMu.Unlock()
+}
+
+func (a *App) runImmediateCloudBackup(ctx context.Context, signal <-chan struct{}) {
+	defer a.cloudBackupBackgroundWG.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
 		}
-	}()
+		select {
+		case <-ctx.Done():
+			return
+		case <-signal:
+			if ctx.Err() != nil {
+				return
+			}
+			if _, err := a.cloudBackupSync(ctx); err != nil && ctx.Err() == nil {
+				logger.Warnf("修改后同步云端备份失败：%v", err)
+			}
+		}
+	}
 }
 
 func (a *App) cloudBackupDirtyState() (bool, uint64) {
@@ -1669,6 +1739,13 @@ func (a *App) shutdownCloudBackup() {
 		a.cloudBackupSchedulerCancel = nil
 	}
 	a.cloudBackupSchedulerMu.Unlock()
+	a.cloudBackupLifecycleMu.Lock()
+	a.cloudBackupShuttingDown = true
+	if a.cloudBackupLifecycleCancel != nil {
+		a.cloudBackupLifecycleCancel()
+	}
+	a.cloudBackupLifecycleMu.Unlock()
+	a.cloudBackupBackgroundWG.Wait()
 	config, err := a.loadCloudBackupConfig()
 	if err != nil || !config.Enabled || config.Schedule != CloudBackupScheduleOnExit {
 		return

--- a/internal/app/cloud_backup_test.go
+++ b/internal/app/cloud_backup_test.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1284,6 +1285,116 @@ func TestCloudBackupImmediateScheduleSaveDoesNotWaitForRemote(t *testing.T) {
 	close(releaseRequest)
 	application.cloudBackupSyncMu.Lock()
 	application.cloudBackupSyncMu.Unlock()
+}
+
+func TestCloudBackupImmediateScheduleCoalescesDirtySignals(t *testing.T) {
+	requests := make(chan int32, 128)
+	releaseFirst := make(chan struct{})
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		current := requestCount.Add(1)
+		requests <- current
+		if current == 1 {
+			<-releaseFirst
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	application := NewAppWithSecretStore(newFakeAppSecretStore())
+	application.configDir = t.TempDir()
+	if _, err := application.SaveCloudBackupConfig(CloudBackupConfigInput{
+		Enabled: true, Provider: CloudBackupProviderWebDAV, WebDAVEndpoint: server.URL,
+		WebDAVFilePath: "backup.gonavi", Schedule: CloudBackupScheduleImmediate,
+		WebDAVUsername: "user", WebDAVPassword: "pass", EncryptionPassword: "backup-pass",
+	}); err != nil {
+		close(releaseFirst)
+		t.Fatalf("SaveCloudBackupConfig returned error: %v", err)
+	}
+
+	select {
+	case <-requests:
+	case <-time.After(3 * time.Second):
+		close(releaseFirst)
+		t.Fatal("initial immediate cloud backup did not start")
+	}
+	for range 100 {
+		application.markCloudBackupDirty()
+	}
+	close(releaseFirst)
+
+	select {
+	case request := <-requests:
+		if request != 2 {
+			t.Fatalf("coalesced cloud backup request = %d, want 2", request)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("coalesced dirty cloud backup did not run")
+	}
+	select {
+	case request := <-requests:
+		t.Fatalf("dirty signals queued an extra cloud backup request %d", request)
+	case <-time.After(300 * time.Millisecond):
+	}
+	application.shutdownCloudBackup()
+}
+
+func TestCloudBackupShutdownCancelsImmediateSyncAndDropsPendingDirty(t *testing.T) {
+	requests := make(chan struct{}, 128)
+	releaseServer := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		requests <- struct{}{}
+		select {
+		case <-r.Context().Done():
+		case <-releaseServer:
+		}
+	}))
+	defer server.Close()
+	defer close(releaseServer)
+
+	application := NewAppWithSecretStore(newFakeAppSecretStore())
+	application.configDir = t.TempDir()
+	if _, err := application.SaveCloudBackupConfig(CloudBackupConfigInput{
+		Enabled: true, Provider: CloudBackupProviderWebDAV, WebDAVEndpoint: server.URL,
+		WebDAVFilePath: "backup.gonavi", Schedule: CloudBackupScheduleImmediate,
+		WebDAVUsername: "user", WebDAVPassword: "pass", EncryptionPassword: "backup-pass",
+	}); err != nil {
+		t.Fatalf("SaveCloudBackupConfig returned error: %v", err)
+	}
+	select {
+	case <-requests:
+	case <-time.After(3 * time.Second):
+		t.Fatal("initial immediate cloud backup did not start")
+	}
+	for range 100 {
+		application.markCloudBackupDirty()
+	}
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		application.shutdownCloudBackup()
+		close(shutdownDone)
+	}()
+	select {
+	case <-shutdownDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("cloud backup shutdown did not wait for cancellation")
+	}
+
+	application.markCloudBackupDirty()
+	select {
+	case <-requests:
+		t.Fatal("cloud backup wrote to the remote after shutdown")
+	case <-time.After(300 * time.Millisecond):
+	}
 }
 
 func TestCloudBackupSyncCompletionPreservesConcurrentProviderConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

- Tie scheduled and immediate cloud-backup workers to the application lifecycle.
- Coalesce immediate dirty signals and wait for background work before shutdown.
- Preserve the on-exit backup behavior.

## Issue

Fixes #1042

## Tests

- `go test ./internal/app -run TestCloudBackup -count=1`