### PR TITLE
fix(trino): configure connection pool limits

### DIFF
--- a/internal/db/trino_impl.go
+++ b/internal/db/trino_impl.go
@@ -321,6 +321,15 @@ func (t *TrinoDB) Close() error {
 	return firstErr
 }
 
+func openTrinoSQLConnection(driverName, dsn string) (*sql.DB, error) {
+	conn, err := sql.Open(driverName, dsn)
+	if err != nil {
+		return nil, err
+	}
+	configureSQLConnectionPool(conn, "trino")
+	return conn, nil
+}
+
 func (t *TrinoDB) Connect(config connection.ConnectionConfig) error {
 	_ = t.Close()
 
@@ -362,7 +371,7 @@ func (t *TrinoDB) Connect(config connection.ConnectionConfig) error {
 		_ = t.Close()
 		return err
 	}
-	conn, err := sql.Open("trino", dsn)
+	conn, err := openTrinoSQLConnection("trino", dsn)
 	if err != nil {
 		_ = t.Close()
 		return err

--- a/internal/db/trino_impl_test.go
+++ b/internal/db/trino_impl_test.go
@@ -67,6 +67,23 @@ func TestTrinoCloseCleansStateWhenDatabaseCloseFails(t *testing.T) {
 	}
 }
 
+func TestOpenTrinoSQLConnectionConfiguresPool(t *testing.T) {
+	const driverName = "gonavi_trino_close_test"
+	trinoCloseTestDriverOnce.Do(func() {
+		sql.Register(driverName, trinoCloseTestDriver{})
+	})
+
+	conn, err := openTrinoSQLConnection(driverName, "")
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	if got := conn.Stats().MaxOpenConnections; got != defaultSQLMaxOpenConns {
+		t.Fatalf("max open connections = %d, want %d", got, defaultSQLMaxOpenConns)
+	}
+}
+
 func TestBuildTrinoDSNDoesNotDeriveQueryTimeoutFromConnectionTimeout(t *testing.T) {
 	dsn, err := buildTrinoDSN(connection.ConnectionConfig{
 		Type:     "trino",


### PR DESCRIPTION
## Summary

- Configure Trino SQL connections with the shared bounded connection-pool policy.
- Add regression coverage for the maximum open-connection limit.

## Issue

Fixes #1031

## Tests

- `go test -tags gonavi_trino_driver ./internal/db -run 'Test(OpenTrinoSQLConnection|TrinoClose)' -count=1 -timeout=5m`