### PR TITLE
fix(trino): preserve unknown rows affected errors

### DIFF
--- a/internal/db/trino_impl.go
+++ b/internal/db/trino_impl.go
@@ -444,9 +444,13 @@ func (t *TrinoDB) ExecContext(ctx context.Context, query string) (int64, error) 
 	if err != nil {
 		return 0, err
 	}
+	return trinoRowsAffected(res)
+}
+
+func trinoRowsAffected(res sql.Result) (int64, error) {
 	affected, err := res.RowsAffected()
 	if err != nil {
-		return 0, nil
+		return 0, MarkWriteOutcomeUnknown(err)
 	}
 	return affected, nil
 }

--- a/internal/db/trino_impl_test.go
+++ b/internal/db/trino_impl_test.go
@@ -18,6 +18,14 @@ var (
 	errTrinoCloseTest        = errors.New("trino close test error")
 )
 
+type fakeTrinoExecResult struct {
+	affected int64
+	err      error
+}
+
+func (r fakeTrinoExecResult) LastInsertId() (int64, error) { return 0, errors.New("not implemented") }
+func (r fakeTrinoExecResult) RowsAffected() (int64, error) { return r.affected, r.err }
+
 type trinoCloseTestDriver struct{}
 
 func (trinoCloseTestDriver) Open(string) (driver.Conn, error) {
@@ -36,6 +44,30 @@ func (trinoCloseTestConn) Close() error {
 
 func (trinoCloseTestConn) Begin() (driver.Tx, error) {
 	return nil, driver.ErrSkip
+}
+
+func TestTrinoRowsAffectedMarksErrorsAsUnknownWriteOutcome(t *testing.T) {
+	rowErr := errors.New("rows affected unavailable")
+	affected, err := trinoRowsAffected(fakeTrinoExecResult{err: rowErr})
+	if affected != 0 {
+		t.Fatalf("trinoRowsAffected() = %d, want 0 with error", affected)
+	}
+	if !errors.Is(err, rowErr) {
+		t.Fatalf("trinoRowsAffected() error = %v, want cause %v", err, rowErr)
+	}
+	if !IsWriteOutcomeUnknown(err) {
+		t.Fatalf("trinoRowsAffected() error = %v, want unknown write outcome", err)
+	}
+}
+
+func TestTrinoRowsAffectedPreservesSuccessfulCount(t *testing.T) {
+	affected, err := trinoRowsAffected(fakeTrinoExecResult{affected: 7})
+	if err != nil {
+		t.Fatalf("trinoRowsAffected() error = %v", err)
+	}
+	if affected != 7 {
+		t.Fatalf("trinoRowsAffected() = %d, want 7", affected)
+	}
 }
 
 func TestTrinoCloseCleansStateWhenDatabaseCloseFails(t *testing.T) {


### PR DESCRIPTION
## Summary

- Preserve Trino RowsAffected failures instead of reporting a successful zero-row write.
- Mark the write outcome as unknown and add regression coverage.

## Issue

Fixes #1033

## Tests

- `go test -tags gonavi_trino_driver ./internal/db -run 'TestTrinoRowsAffected|TestTrinoClose' -count=1 -timeout=5m`