### PR TITLE
fix(trino): preserve partial catalog metadata

### DIFF
--- a/internal/app/methods_db.go
+++ b/internal/app/methods_db.go
@@ -2558,6 +2558,24 @@ func (a *App) DBGetDatabases(config connection.ConnectionConfig) connection.Quer
 		}
 	}
 	if err != nil {
+		var partialErr *db.PartialMetadataError
+		if errors.As(err, &partialErr) {
+			warning := partialErr.Error()
+			logger.Warnf("DBGetDatabases 获取到部分数据库列表：%s err=%s", formatConnSummary(runConfig), warning)
+			resData := make([]map[string]string, 0, len(dbs))
+			for _, name := range dbs {
+				resData = append(resData, map[string]string{"Database": name})
+			}
+			return connection.QueryResult{
+				Success:           len(resData) > 0,
+				Data:              resData,
+				Message:           warning,
+				Partial:           true,
+				Warnings:          partialErr.Warnings(),
+				FailedObjectTypes: []string{"database"},
+				Retryable:         true,
+			}
+		}
 		logger.Error(err, "DBGetDatabases 获取数据库列表失败：%s", formatConnSummary(runConfig))
 		return connection.QueryResult{Success: false, Message: err.Error()}
 	}

--- a/internal/app/methods_db_partial_metadata_test.go
+++ b/internal/app/methods_db_partial_metadata_test.go
@@ -1,0 +1,49 @@
+package app
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"GoNavi-Wails/internal/connection"
+	"GoNavi-Wails/internal/db"
+)
+
+type partialMetadataDatabasesDB struct {
+	*releaseRecordingDB
+	err error
+}
+
+func (f *partialMetadataDatabasesDB) GetDatabases() ([]string, error) {
+	f.getDatabasesCalls++
+	return f.databases, f.err
+}
+
+var _ db.Database = (*partialMetadataDatabasesDB)(nil)
+
+func TestDBGetDatabasesReturnsPartialResultForMetadataWarning(t *testing.T) {
+	partialErr := db.NewPartialMetadataError([]db.MetadataObjectFailure{{ObjectName: "restricted", Err: errors.New("metadata read failed")}})
+	database := &partialMetadataDatabasesDB{
+		releaseRecordingDB: &releaseRecordingDB{databases: []string{"hive.default", "hive.analytics"}},
+		err:                partialErr,
+	}
+	config := connection.ConnectionConfig{Type: "custom", Driver: "mysql"}
+	application := NewApp()
+	application.dbCache[getCacheKey(config)] = cachedDatabase{
+		inst:     database,
+		lastPing: time.Now(),
+		config:   config,
+	}
+
+	result := application.DBGetDatabases(config)
+	if !result.Success || !result.Partial || !result.Retryable {
+		t.Fatalf("DBGetDatabases result = %#v, want successful partial retryable result", result)
+	}
+	if len(result.Warnings) != 1 || result.FailedObjectTypes[0] != "database" {
+		t.Fatalf("DBGetDatabases metadata fields = %#v, want one database warning", result)
+	}
+	rows, ok := result.Data.([]map[string]string)
+	if !ok || len(rows) != 2 {
+		t.Fatalf("DBGetDatabases data = %#v, want two usable databases", result.Data)
+	}
+}

--- a/internal/db/trino_impl.go
+++ b/internal/db/trino_impl.go
@@ -481,12 +481,15 @@ func (t *TrinoDB) GetDatabases() ([]string, error) {
 
 	namespaces := make([]string, 0, len(catalogs)*2)
 	seen := make(map[string]struct{}, len(catalogs)*4)
-	var lastErr error
+	failedCatalogs := make([]MetadataObjectFailure, 0)
 	for _, catalog := range catalogs {
 		query := fmt.Sprintf("SHOW SCHEMAS FROM %s", quoteTrinoIdentifier(catalog))
 		schemas, schemaErr := t.queryTrinoSingleColumnStrings(query)
 		if schemaErr != nil {
-			lastErr = schemaErr
+			failedCatalogs = append(failedCatalogs, MetadataObjectFailure{
+				ObjectName: catalog,
+				Err:        schemaErr,
+			})
 			continue
 		}
 		for _, schema := range schemas {
@@ -503,15 +506,13 @@ func (t *TrinoDB) GetDatabases() ([]string, error) {
 		}
 	}
 
-	if len(namespaces) == 0 {
-		if strings.TrimSpace(t.namespace) != "" {
-			return []string{t.namespace}, nil
-		}
-		if lastErr != nil {
-			return nil, lastErr
-		}
+	if len(namespaces) == 0 && strings.TrimSpace(t.namespace) != "" {
+		namespaces = append(namespaces, t.namespace)
 	}
 	sort.Strings(namespaces)
+	if partialErr := NewPartialMetadataError(failedCatalogs); partialErr != nil {
+		return namespaces, partialErr
+	}
 	return namespaces, nil
 }
 

--- a/internal/db/trino_partial_metadata_test.go
+++ b/internal/db/trino_partial_metadata_test.go
@@ -1,0 +1,119 @@
+//go:build gonavi_full_drivers || gonavi_trino_driver
+
+package db
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+var trinoPartialMetadataDriverID atomic.Uint64
+
+type trinoPartialMetadataResult struct {
+	values   []string
+	queryErr error
+}
+
+type trinoPartialMetadataDriver struct {
+	results map[string]trinoPartialMetadataResult
+}
+
+func (d trinoPartialMetadataDriver) Open(string) (driver.Conn, error) {
+	return &trinoPartialMetadataConn{results: d.results}, nil
+}
+
+type trinoPartialMetadataConn struct {
+	results map[string]trinoPartialMetadataResult
+}
+
+func (c *trinoPartialMetadataConn) Prepare(string) (driver.Stmt, error) {
+	return nil, driver.ErrSkip
+}
+
+func (*trinoPartialMetadataConn) Close() error { return nil }
+
+func (*trinoPartialMetadataConn) Begin() (driver.Tx, error) { return nil, driver.ErrSkip }
+
+func (c *trinoPartialMetadataConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	result, ok := c.results[query]
+	if !ok {
+		return nil, fmt.Errorf("unexpected Trino metadata query: %s", query)
+	}
+	if result.queryErr != nil {
+		return nil, result.queryErr
+	}
+	return &trinoPartialMetadataRows{values: result.values}, nil
+}
+
+type trinoPartialMetadataRows struct {
+	values []string
+	index  int
+}
+
+func (*trinoPartialMetadataRows) Columns() []string { return []string{"name"} }
+func (*trinoPartialMetadataRows) Close() error      { return nil }
+
+func (r *trinoPartialMetadataRows) Next(dest []driver.Value) error {
+	if r.index >= len(r.values) {
+		return io.EOF
+	}
+	dest[0] = r.values[r.index]
+	r.index++
+	return nil
+}
+
+func newTrinoPartialMetadataDB(t *testing.T, results map[string]trinoPartialMetadataResult) *TrinoDB {
+	t.Helper()
+	driverName := fmt.Sprintf("gonavi_trino_partial_metadata_%d", trinoPartialMetadataDriverID.Add(1))
+	sql.Register(driverName, trinoPartialMetadataDriver{results: results})
+	conn, err := sql.Open(driverName, "")
+	if err != nil {
+		t.Fatalf("open Trino metadata test database: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return &TrinoDB{conn: conn}
+}
+
+func TestTrinoGetDatabasesReturnsUsableNamespacesWithPartialCatalogFailure(t *testing.T) {
+	underlyingErr := errors.New("permission denied: secret-token")
+	trino := newTrinoPartialMetadataDB(t, map[string]trinoPartialMetadataResult{
+		"SHOW CATALOGS":                  {values: []string{"hive", "restricted"}},
+		`SHOW SCHEMAS FROM "hive"`:       {values: []string{"default", "analytics"}},
+		`SHOW SCHEMAS FROM "restricted"`: {queryErr: underlyingErr},
+	})
+
+	databases, err := trino.GetDatabases()
+	if got, want := fmt.Sprint(databases), "[hive.analytics hive.default]"; got != want {
+		t.Fatalf("GetDatabases() = %s, want %s", got, want)
+	}
+	var partialErr *PartialMetadataError
+	if !errors.As(err, &partialErr) {
+		t.Fatalf("GetDatabases() error = %v, want PartialMetadataError", err)
+	}
+	if len(partialErr.Warnings()) != 1 || !strings.Contains(partialErr.Warnings()[0], "restricted") {
+		t.Fatalf("partial metadata warnings = %v, want restricted catalog warning", partialErr.Warnings())
+	}
+}
+
+func TestTrinoGetDatabasesReturnsAllNamespacesWhenCatalogReadsSucceed(t *testing.T) {
+	trino := newTrinoPartialMetadataDB(t, map[string]trinoPartialMetadataResult{
+		"SHOW CATALOGS":               {values: []string{"hive", "iceberg"}},
+		`SHOW SCHEMAS FROM "hive"`:    {values: []string{"default"}},
+		`SHOW SCHEMAS FROM "iceberg"`: {values: []string{"analytics"}},
+	})
+
+	databases, err := trino.GetDatabases()
+	if err != nil {
+		t.Fatalf("GetDatabases() error = %v", err)
+	}
+	if got, want := fmt.Sprint(databases), "[hive.default iceberg.analytics]"; got != want {
+		t.Fatalf("GetDatabases() = %s, want %s", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Retain namespaces from catalogs that can still be read when another catalog fails.
- Surface partial metadata warnings through the application query result.
- Add Trino and application regression coverage.

## Issue

Fixes #1032

## Tests

- `go test -tags gonavi_trino_driver ./internal/db -run 'TestTrinoGetDatabases' -count=1 -timeout=5m`
- `go test ./internal/app -run 'TestDBGetDatabasesReturnsPartialResultForMetadataWarning' -count=1 -timeout=5m`