### PR TITLE
fix(db): propagate schema metadata row errors

### DIFF
--- a/internal/db/gaussdb_impl.go
+++ b/internal/db/gaussdb_impl.go
@@ -228,7 +228,10 @@ func (g *GaussDB) ensureSearchPath(baseDSN string) error {
 		return nil
 	}
 
-	rawSchemas := g.queryUserSchemas()
+	rawSchemas, err := g.queryUserSchemas()
+	if err != nil {
+		return fmt.Errorf("查询用户 schema 失败：%w", err)
+	}
 	if len(rawSchemas) == 0 {
 		return nil
 	}

--- a/internal/db/kingbase_impl.go
+++ b/internal/db/kingbase_impl.go
@@ -274,7 +274,10 @@ func (k *KingbaseDB) ensureSearchPath(baseDSN string, hasExplicitSearchPath bool
 		return nil
 	}
 
-	searchPath := k.getSearchPathStr()
+	searchPath, err := k.getSearchPathStr()
+	if err != nil {
+		return err
+	}
 	if strings.TrimSpace(searchPath) == "" {
 		return nil
 	}
@@ -300,9 +303,9 @@ func (k *KingbaseDB) ensureSearchPath(baseDSN string, hasExplicitSearchPath bool
 
 // getSearchPathStr 查询当前数据库中所有用户 schema，配置 DSN 的 search_path。
 // KingBase 默认 search_path 为 "$user", public，对于自定义 schema 下的表不可见。
-func (k *KingbaseDB) getSearchPathStr() string {
+func (k *KingbaseDB) getSearchPathStr() (string, error) {
 	if k.conn == nil {
-		return ""
+		return "", nil
 	}
 
 	query := `SELECT nspname FROM pg_namespace
@@ -312,8 +315,7 @@ func (k *KingbaseDB) getSearchPathStr() string {
 
 	rows, err := k.conn.QueryContext(metadataContextFor(k), query)
 	if err != nil {
-		logger.Warnf("人大金仓查询用户 schema 失败，跳过 search_path 设置：%v", err)
-		return ""
+		return "", fmt.Errorf("查询用户 schema：%w", err)
 	}
 	defer rows.Close()
 
@@ -321,16 +323,19 @@ func (k *KingbaseDB) getSearchPathStr() string {
 	for rows.Next() {
 		var name string
 		if err := rows.Scan(&name); err != nil {
-			continue
+			return "", fmt.Errorf("扫描用户 schema：%w", err)
 		}
 		name = strings.TrimSpace(name)
 		if name != "" {
 			rawSchemas = append(rawSchemas, name)
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return "", fmt.Errorf("遍历用户 schema：%w", err)
+	}
 
 	searchPath, _ := buildKingbaseSearchPathCommon(rawSchemas)
-	return searchPath
+	return searchPath, nil
 }
 
 func (k *KingbaseDB) Close() error {

--- a/internal/db/postgres_impl.go
+++ b/internal/db/postgres_impl.go
@@ -587,7 +587,10 @@ func (p *PostgresDB) ensureSearchPath(baseDSN string) error {
 		return nil
 	}
 
-	rawSchemas := p.queryUserSchemas()
+	rawSchemas, err := p.queryUserSchemas()
+	if err != nil {
+		return fmt.Errorf("查询用户 schema 失败：%w", err)
+	}
 	if len(rawSchemas) == 0 {
 		return nil
 	}
@@ -622,9 +625,9 @@ func (p *PostgresDB) ensureSearchPath(baseDSN string) error {
 }
 
 // queryUserSchemas 查询当前数据库中所有用户 schema。
-func (p *PostgresDB) queryUserSchemas() []string {
+func (p *PostgresDB) queryUserSchemas() ([]string, error) {
 	if p.conn == nil {
-		return nil
+		return nil, nil
 	}
 
 	query := `SELECT nspname FROM pg_namespace
@@ -634,8 +637,7 @@ func (p *PostgresDB) queryUserSchemas() []string {
 
 	rows, err := p.conn.QueryContext(metadataContextFor(p), query)
 	if err != nil {
-		logger.Warnf("PostgreSQL 查询用户 schema 失败：%v", err)
-		return nil
+		return nil, fmt.Errorf("查询用户 schema：%w", err)
 	}
 	defer rows.Close()
 
@@ -643,14 +645,17 @@ func (p *PostgresDB) queryUserSchemas() []string {
 	for rows.Next() {
 		var name string
 		if err := rows.Scan(&name); err != nil {
-			continue
+			return nil, fmt.Errorf("扫描用户 schema：%w", err)
 		}
 		name = strings.TrimSpace(name)
 		if name != "" {
 			schemas = append(schemas, name)
 		}
 	}
-	return schemas
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("遍历用户 schema：%w", err)
+	}
+	return schemas, nil
 }
 
 func (p *PostgresDB) ApplyChanges(tableName string, changes connection.ChangeSet) error {

--- a/internal/db/user_schema_query_kingbase_test.go
+++ b/internal/db/user_schema_query_kingbase_test.go
@@ -1,0 +1,40 @@
+//go:build gonavi_full_drivers || gonavi_kingbase_driver
+
+package db
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestKingbaseGetSearchPathStrPropagatesRowErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		scenario  string
+		wantStage string
+		wantErr   error
+	}{
+		{name: "second row scan error", scenario: "scan", wantStage: "扫描用户 schema"},
+		{name: "second row iteration error", scenario: "iteration", wantStage: "遍历用户 schema", wantErr: errFakeUserSchemaIteration},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &KingbaseDB{conn: openFakeUserSchemaDB(t, tt.scenario)}
+			searchPath, err := client.getSearchPathStr()
+			if err == nil {
+				t.Fatalf("expected %s error, got search_path=%q", tt.wantStage, searchPath)
+			}
+			if searchPath != "" {
+				t.Fatalf("partial schemas must not be used, got search_path=%q", searchPath)
+			}
+			if !strings.Contains(err.Error(), tt.wantStage) {
+				t.Fatalf("error %q does not identify stage %q", err, tt.wantStage)
+			}
+			if tt.wantErr != nil && !errors.Is(err, tt.wantErr) {
+				t.Fatalf("error %q does not wrap %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/db/user_schema_query_test.go
+++ b/internal/db/user_schema_query_test.go
@@ -1,0 +1,108 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+)
+
+const fakeUserSchemaDriverName = "gonavi-fake-user-schema"
+
+var (
+	registerFakeUserSchemaDriverOnce sync.Once
+	errFakeUserSchemaIteration       = errors.New("simulated user schema iteration error")
+)
+
+type fakeUserSchemaDriver struct{}
+
+func (fakeUserSchemaDriver) Open(scenario string) (driver.Conn, error) {
+	return fakeUserSchemaConn{scenario: scenario}, nil
+}
+
+type fakeUserSchemaConn struct {
+	scenario string
+}
+
+func (fakeUserSchemaConn) Prepare(string) (driver.Stmt, error) { return nil, driver.ErrSkip }
+func (fakeUserSchemaConn) Close() error                        { return nil }
+func (fakeUserSchemaConn) Begin() (driver.Tx, error)           { return nil, driver.ErrSkip }
+
+func (c fakeUserSchemaConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+	return &fakeUserSchemaRows{scenario: c.scenario}, nil
+}
+
+type fakeUserSchemaRows struct {
+	scenario string
+	index    int
+}
+
+func (fakeUserSchemaRows) Columns() []string { return []string{"nspname"} }
+func (fakeUserSchemaRows) Close() error      { return nil }
+
+func (r *fakeUserSchemaRows) Next(dest []driver.Value) error {
+	r.index++
+	switch r.index {
+	case 1:
+		dest[0] = "first_schema"
+		return nil
+	case 2:
+		if r.scenario == "scan" {
+			dest[0] = nil
+			return nil
+		}
+		if r.scenario == "iteration" {
+			return errFakeUserSchemaIteration
+		}
+	}
+	return io.EOF
+}
+
+func openFakeUserSchemaDB(t *testing.T, scenario string) *sql.DB {
+	t.Helper()
+	registerFakeUserSchemaDriverOnce.Do(func() {
+		sql.Register(fakeUserSchemaDriverName, fakeUserSchemaDriver{})
+	})
+
+	db, err := sql.Open(fakeUserSchemaDriverName, scenario)
+	if err != nil {
+		t.Fatalf("open fake user schema db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestPostgresQueryUserSchemasPropagatesRowErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		scenario  string
+		wantStage string
+		wantErr   error
+	}{
+		{name: "second row scan error", scenario: "scan", wantStage: "扫描用户 schema"},
+		{name: "second row iteration error", scenario: "iteration", wantStage: "遍历用户 schema", wantErr: errFakeUserSchemaIteration},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &PostgresDB{conn: openFakeUserSchemaDB(t, tt.scenario)}
+			schemas, err := client.queryUserSchemas()
+			if err == nil {
+				t.Fatalf("expected %s error, got schemas=%v", tt.wantStage, schemas)
+			}
+			if schemas != nil {
+				t.Fatalf("partial schemas must not be used, got %v", schemas)
+			}
+			if !strings.Contains(err.Error(), tt.wantStage) {
+				t.Fatalf("error %q does not identify stage %q", err, tt.wantStage)
+			}
+			if tt.wantErr != nil && !errors.Is(err, tt.wantErr) {
+				t.Fatalf("error %q does not wrap %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Propagate PostgreSQL and Kingbase schema query, scan, and iteration failures.
- Keep GaussDB's inherited schema lookup on the same error-aware path.
- Prevent partially scanned schemas from being used to rebuild search_path.

## Issue

Fixes #1040

## Tests

- `go test ./internal/db -run 'TestPostgresQueryUserSchemasPropagatesRowErrors' -count=1 -timeout=5m`
- `go test -tags gonavi_kingbase_driver ./internal/db -run 'Test(KingbaseGetSearchPathStrPropagatesRowErrors|PostgresQueryUserSchemasPropagatesRowErrors)' -count=1 -timeout=5m`
- `go test -tags gonavi_gaussdb_driver ./internal/db -run 'TestPostgresQueryUserSchemasPropagatesRowErrors' -count=1 -timeout=5m`