### PR TITLE
fix(vector): reject deletes without point identifiers

### DIFF
--- a/internal/db/chroma_impl.go
+++ b/internal/db/chroma_impl.go
@@ -321,6 +321,9 @@ func (c *ChromaDB) ApplyChanges(tableName string, changes connection.ChangeSet) 
 				ids = append(ids, id)
 			}
 		}
+		if len(ids) != len(changes.Deletes) {
+			return fmt.Errorf("Chroma delete has %d row(s) without a valid id", len(changes.Deletes)-len(ids))
+		}
 		if len(ids) > 0 {
 			if _, err := c.deleteCommand(ctx, tableName, map[string]interface{}{"ids": ids}); err != nil {
 				return err
@@ -1034,7 +1037,15 @@ func chromaCountValue(raw interface{}) int64 {
 }
 
 func chromaRowID(row map[string]interface{}) string {
-	return strings.TrimSpace(fmt.Sprintf("%v", firstExisting(row, "id", "_id")))
+	raw := firstExisting(row, "id", "_id")
+	if raw == nil {
+		return ""
+	}
+	text := strings.TrimSpace(fmt.Sprintf("%v", raw))
+	if text == "" || text == "<nil>" {
+		return ""
+	}
+	return text
 }
 
 func isChromaReservedRowField(key string) bool {

--- a/internal/db/chroma_impl_test.go
+++ b/internal/db/chroma_impl_test.go
@@ -388,6 +388,35 @@ func TestChromaApplyChangesUpsertAndDelete(t *testing.T) {
 	}
 }
 
+func TestChromaApplyChangesRejectsDeleteWithMissingID(t *testing.T) {
+	deleteRequests := 0
+	server := newMockChromaServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v2/heartbeat":
+			writeChromaJSON(w, map[string]interface{}{"ok": true})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/delete"):
+			deleteRequests++
+			writeChromaJSON(w, map[string]interface{}{"ok": true})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	db := newTestChromaDB(t, server.URL)
+	err := db.ApplyChanges("products", connection.ChangeSet{
+		Deletes: []map[string]interface{}{{"id": "valid"}, {"document": "missing id"}},
+	})
+	if err == nil {
+		t.Fatal("ApplyChanges succeeded, want missing id failure")
+	}
+	if IsWriteOutcomeUnknown(err) {
+		t.Fatalf("ApplyChanges reported unknown outcome before issuing a delete: %v", err)
+	}
+	if deleteRequests != 0 {
+		t.Fatalf("delete requests = %d, want 0", deleteRequests)
+	}
+}
+
 func TestChromaLiveSmoke(t *testing.T) {
 	serverURL := strings.TrimSpace(os.Getenv("GONAVI_CHROMA_TEST_URL"))
 	if serverURL == "" {

--- a/internal/db/milvus_impl.go
+++ b/internal/db/milvus_impl.go
@@ -361,6 +361,9 @@ func (m *MilvusDB) ApplyChanges(tableName string, changes connection.ChangeSet) 
 
 	if len(changes.Deletes) > 0 {
 		ids := milvusRowIDs(changes.Deletes, primaryField)
+		if len(ids) != len(changes.Deletes) {
+			return fmt.Errorf("Milvus delete has %d row(s) without a valid primary key field %q", len(changes.Deletes)-len(ids), primaryField)
+		}
 		if len(ids) > 0 {
 			if err := m.deleteEntities(ctx, collection, milvusIDFilter(primaryField, ids)); err != nil {
 				return err

--- a/internal/db/milvus_impl_test.go
+++ b/internal/db/milvus_impl_test.go
@@ -387,6 +387,40 @@ func TestMilvusApplyChangesDeletesMergesUpdatesAndInserts(t *testing.T) {
 	}
 }
 
+func TestMilvusApplyChangesRejectsDeleteWithMissingPrimaryKey(t *testing.T) {
+	description := map[string]interface{}{
+		"fields": []map[string]interface{}{{"name": "id", "type": "Int64", "primaryKey": true}},
+	}
+	deleteRequests := 0
+	server := newMockMilvusServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case isMilvusCollectionListRequest(r):
+			writeMilvusJSON(w, []string{})
+		case r.Method == http.MethodPost && r.URL.Path == milvusCollectionsDescribePath:
+			writeMilvusJSON(w, description)
+		case r.Method == http.MethodPost && r.URL.Path == milvusEntitiesDeletePath:
+			deleteRequests++
+			writeMilvusJSON(w, map[string]interface{}{})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	db := newTestMilvusDB(t, server.URL)
+	err := db.ApplyChanges("products", connection.ChangeSet{
+		Deletes: []map[string]interface{}{{"id": 1}, {"category": "missing id"}},
+	})
+	if err == nil {
+		t.Fatal("ApplyChanges succeeded, want missing primary key failure")
+	}
+	if IsWriteOutcomeUnknown(err) {
+		t.Fatalf("ApplyChanges reported unknown outcome before issuing a delete: %v", err)
+	}
+	if deleteRequests != 0 {
+		t.Fatalf("delete requests = %d, want 0", deleteRequests)
+	}
+}
+
 func TestMilvusResponseCodeFailureIsReturned(t *testing.T) {
 	server := newMockMilvusServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if isMilvusCollectionListRequest(r) {

--- a/internal/db/qdrant_impl.go
+++ b/internal/db/qdrant_impl.go
@@ -317,6 +317,9 @@ func (q *QdrantDB) ApplyChanges(tableName string, changes connection.ChangeSet) 
 				ids = append(ids, id)
 			}
 		}
+		if len(ids) != len(changes.Deletes) {
+			return fmt.Errorf("Qdrant delete has %d row(s) without a valid id", len(changes.Deletes)-len(ids))
+		}
 		if len(ids) > 0 {
 			if _, err := q.deleteCommand(ctx, tableName, map[string]interface{}{"points": ids}); err != nil {
 				return err

--- a/internal/db/qdrant_impl_test.go
+++ b/internal/db/qdrant_impl_test.go
@@ -321,6 +321,35 @@ func TestQdrantApplyChangesUpsertPayloadAndDelete(t *testing.T) {
 	}
 }
 
+func TestQdrantApplyChangesRejectsDeleteWithMissingID(t *testing.T) {
+	deleteRequests := 0
+	server := newMockQdrantServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/collections":
+			writeQdrantJSON(w, map[string]interface{}{"result": map[string]interface{}{"collections": []interface{}{}}})
+		case r.Method == http.MethodPost && r.URL.Path == "/collections/products/points/delete":
+			deleteRequests++
+			writeQdrantJSON(w, map[string]interface{}{"result": map[string]interface{}{"operation_id": 1}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	db := newTestQdrantDB(t, server.URL)
+	err := db.ApplyChanges("products", connection.ChangeSet{
+		Deletes: []map[string]interface{}{{"id": 9}, {"payload.category": "missing id"}},
+	})
+	if err == nil {
+		t.Fatal("ApplyChanges succeeded, want missing id failure")
+	}
+	if IsWriteOutcomeUnknown(err) {
+		t.Fatalf("ApplyChanges reported unknown outcome before issuing a delete: %v", err)
+	}
+	if deleteRequests != 0 {
+		t.Fatalf("delete requests = %d, want 0", deleteRequests)
+	}
+}
+
 func TestQdrantLiveSmoke(t *testing.T) {
 	serverURL := strings.TrimSpace(os.Getenv("GONAVI_QDRANT_TEST_URL"))
 	if serverURL == "" {


### PR DESCRIPTION
## Summary

- Reject Chroma, Qdrant, and Milvus delete batches containing rows without valid identifiers.
- Avoid sending a partial delete request that silently drops invalid rows.
- Add regression tests proving no delete request is issued for invalid batches.

## Issue

Fixes #1041

## Tests

- `go test ./internal/db -run 'Test(Chroma|Qdrant|Milvus)ApplyChangesRejectsDeleteWithMissing' -count=1 -timeout=5m`