### PR TITLE
fix(vector): classify partial batch writes as unknown

### DIFF
--- a/internal/db/chroma_impl.go
+++ b/internal/db/chroma_impl.go
@@ -313,6 +313,13 @@ func (c *ChromaDB) GetTriggers(dbName, tableName string) ([]connection.TriggerDe
 func (c *ChromaDB) ApplyChanges(tableName string, changes connection.ChangeSet) error {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultChromaQueryTimeout)
 	defer cancel()
+	writeApplied := false
+	writeError := func(err error) error {
+		if writeApplied {
+			return MarkWriteOutcomeUnknown(err)
+		}
+		return err
+	}
 
 	if len(changes.Deletes) > 0 {
 		ids := make([]string, 0, len(changes.Deletes))
@@ -323,8 +330,9 @@ func (c *ChromaDB) ApplyChanges(tableName string, changes connection.ChangeSet) 
 		}
 		if len(ids) > 0 {
 			if _, err := c.deleteCommand(ctx, tableName, map[string]interface{}{"ids": ids}); err != nil {
-				return err
+				return writeError(err)
 			}
+			writeApplied = true
 		}
 	}
 
@@ -341,12 +349,13 @@ func (c *ChromaDB) ApplyChanges(tableName string, changes connection.ChangeSet) 
 			rows = append(rows, row)
 		}
 		if err := c.upsertRows(ctx, tableName, rows); err != nil {
-			return err
+			return writeError(err)
 		}
+		writeApplied = true
 	}
 	if len(changes.Inserts) > 0 {
 		if err := c.upsertRows(ctx, tableName, changes.Inserts); err != nil {
-			return err
+			return writeError(err)
 		}
 	}
 	return nil

--- a/internal/db/milvus_impl.go
+++ b/internal/db/milvus_impl.go
@@ -358,13 +358,21 @@ func (m *MilvusDB) ApplyChanges(tableName string, changes connection.ChangeSet) 
 	if err != nil {
 		return err
 	}
+	writeApplied := false
+	writeError := func(err error) error {
+		if writeApplied {
+			return MarkWriteOutcomeUnknown(err)
+		}
+		return err
+	}
 
 	if len(changes.Deletes) > 0 {
 		ids := milvusRowIDs(changes.Deletes, primaryField)
 		if len(ids) > 0 {
 			if err := m.deleteEntities(ctx, collection, milvusIDFilter(primaryField, ids)); err != nil {
-				return err
+				return writeError(err)
 			}
+			writeApplied = true
 		}
 	}
 
@@ -380,14 +388,14 @@ func (m *MilvusDB) ApplyChanges(tableName string, changes connection.ChangeSet) 
 			}
 			id, ok := milvusRowID(row, primaryField)
 			if !ok {
-				return fmt.Errorf("Milvus update is missing primary key field %q", primaryField)
+				return writeError(fmt.Errorf("Milvus update is missing primary key field %q", primaryField))
 			}
 			existingRows, _, queryErr := m.queryEntities(ctx, collection, milvusIDFilter(primaryField, []interface{}{id}), []string{"*"}, 1, 0)
 			if queryErr != nil {
-				return queryErr
+				return writeError(queryErr)
 			}
 			if len(existingRows) == 0 {
-				return fmt.Errorf("Milvus entity with %s=%v was not found", primaryField, id)
+				return writeError(fmt.Errorf("Milvus entity with %s=%v was not found", primaryField, id))
 			}
 			merged := existingRows[0]
 			for key, value := range row {
@@ -397,14 +405,15 @@ func (m *MilvusDB) ApplyChanges(tableName string, changes connection.ChangeSet) 
 		}
 		if len(rows) > 0 {
 			if err := m.upsertEntities(ctx, collection, rows, false); err != nil {
-				return err
+				return writeError(err)
 			}
+			writeApplied = true
 		}
 	}
 
 	if len(changes.Inserts) > 0 {
 		if err := m.insertEntities(ctx, collection, changes.Inserts); err != nil {
-			return err
+			return writeError(err)
 		}
 	}
 	return nil

--- a/internal/db/qdrant_impl.go
+++ b/internal/db/qdrant_impl.go
@@ -309,6 +309,13 @@ func (q *QdrantDB) GetTriggers(dbName, tableName string) ([]connection.TriggerDe
 func (q *QdrantDB) ApplyChanges(tableName string, changes connection.ChangeSet) error {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultQdrantQueryTimeout)
 	defer cancel()
+	writeApplied := false
+	writeError := func(err error) error {
+		if writeApplied {
+			return MarkWriteOutcomeUnknown(err)
+		}
+		return err
+	}
 
 	if len(changes.Deletes) > 0 {
 		ids := make([]interface{}, 0, len(changes.Deletes))
@@ -319,8 +326,9 @@ func (q *QdrantDB) ApplyChanges(tableName string, changes connection.ChangeSet) 
 		}
 		if len(ids) > 0 {
 			if _, err := q.deleteCommand(ctx, tableName, map[string]interface{}{"points": ids}); err != nil {
-				return err
+				return writeError(err)
 			}
+			writeApplied = true
 		}
 	}
 
@@ -339,19 +347,23 @@ func (q *QdrantDB) ApplyChanges(tableName string, changes connection.ChangeSet) 
 				continue
 			}
 			if err := q.setPayloadFromRow(ctx, tableName, row); err != nil {
-				return err
+				return writeError(err)
+			}
+			if len(qdrantPayloadFromRow(row)) > 0 {
+				writeApplied = true
 			}
 		}
 		if len(upserts) > 0 {
 			if err := q.upsertRows(ctx, tableName, upserts); err != nil {
-				return err
+				return writeError(err)
 			}
+			writeApplied = true
 		}
 	}
 
 	if len(changes.Inserts) > 0 {
 		if err := q.upsertRows(ctx, tableName, changes.Inserts); err != nil {
-			return err
+			return writeError(err)
 		}
 	}
 	return nil

--- a/internal/db/vector_partial_writes_test.go
+++ b/internal/db/vector_partial_writes_test.go
@@ -1,0 +1,162 @@
+package db
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"GoNavi-Wails/internal/connection"
+)
+
+func TestChromaApplyChangesClassifiesPartialWrites(t *testing.T) {
+	tests := []struct {
+		name        string
+		failDelete  bool
+		wantUnknown bool
+	}{
+		{name: "first write fails", failDelete: true},
+		{name: "update fails after delete", wantUnknown: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := newMockChromaServer(t, func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.URL.Path == "/api/v2/heartbeat":
+					writeChromaJSON(w, map[string]interface{}{"ok": true})
+				case r.URL.Path == "/api/v2/tenants/default_tenant/databases/default_database/collections":
+					writeChromaJSON(w, []chromaCollection{{ID: "col-products", Name: "products", Database: "default_database"}})
+				case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/collections/col-products/delete"):
+					if test.failDelete {
+						http.Error(w, "forced delete failure", http.StatusInternalServerError)
+						return
+					}
+					writeChromaJSON(w, map[string]interface{}{"ok": true})
+				case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/collections/col-products/upsert"):
+					http.Error(w, "forced update failure", http.StatusInternalServerError)
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			})
+
+			db := newTestChromaDB(t, server.URL)
+			err := db.ApplyChanges("products", connection.ChangeSet{
+				Deletes: []map[string]interface{}{{"id": "old"}},
+				Updates: []connection.UpdateRow{{
+					Keys:   map[string]interface{}{"id": "existing"},
+					Values: map[string]interface{}{"document": "updated"},
+				}},
+			})
+			if err == nil {
+				t.Fatal("ApplyChanges succeeded, want failure")
+			}
+			if IsWriteOutcomeUnknown(err) != test.wantUnknown {
+				t.Fatalf("ApplyChanges unknown outcome = %t, want %t: %v", IsWriteOutcomeUnknown(err), test.wantUnknown, err)
+			}
+		})
+	}
+}
+
+func TestQdrantApplyChangesClassifiesPartialWrites(t *testing.T) {
+	tests := []struct {
+		name        string
+		failDelete  bool
+		wantUnknown bool
+	}{
+		{name: "first write fails", failDelete: true},
+		{name: "update fails after delete", wantUnknown: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := newMockQdrantServer(t, func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/collections":
+					writeQdrantJSON(w, map[string]interface{}{"result": map[string]interface{}{"collections": []interface{}{}}})
+				case r.Method == http.MethodPost && r.URL.Path == "/collections/products/points/delete":
+					if test.failDelete {
+						http.Error(w, "forced delete failure", http.StatusInternalServerError)
+						return
+					}
+					writeQdrantJSON(w, map[string]interface{}{"result": map[string]interface{}{"operation_id": 1}})
+				case r.Method == http.MethodPost && r.URL.Path == "/collections/products/points/payload":
+					http.Error(w, "forced update failure", http.StatusInternalServerError)
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			})
+
+			db := newTestQdrantDB(t, server.URL)
+			err := db.ApplyChanges("products", connection.ChangeSet{
+				Deletes: []map[string]interface{}{{"id": 9}},
+				Updates: []connection.UpdateRow{{
+					Keys:   map[string]interface{}{"id": 1},
+					Values: map[string]interface{}{"payload.category": "updated"},
+				}},
+			})
+			if err == nil {
+				t.Fatal("ApplyChanges succeeded, want failure")
+			}
+			if IsWriteOutcomeUnknown(err) != test.wantUnknown {
+				t.Fatalf("ApplyChanges unknown outcome = %t, want %t: %v", IsWriteOutcomeUnknown(err), test.wantUnknown, err)
+			}
+		})
+	}
+}
+
+func TestMilvusApplyChangesClassifiesPartialWrites(t *testing.T) {
+	description := map[string]interface{}{
+		"fields": []map[string]interface{}{
+			{"name": "id", "type": "Int64", "primaryKey": true},
+			{"name": "category", "type": "VarChar"},
+		},
+	}
+	tests := []struct {
+		name        string
+		failDelete  bool
+		wantUnknown bool
+	}{
+		{name: "first write fails", failDelete: true},
+		{name: "update fails after delete", wantUnknown: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := newMockMilvusServer(t, func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case isMilvusCollectionListRequest(r):
+					writeMilvusJSON(w, []string{})
+				case r.Method == http.MethodPost && r.URL.Path == milvusCollectionsDescribePath:
+					writeMilvusJSON(w, description)
+				case r.Method == http.MethodPost && r.URL.Path == milvusEntitiesDeletePath:
+					if test.failDelete {
+						http.Error(w, "forced delete failure", http.StatusInternalServerError)
+						return
+					}
+					writeMilvusJSON(w, map[string]interface{}{})
+				case r.Method == http.MethodPost && r.URL.Path == milvusEntitiesQueryPath:
+					writeMilvusJSON(w, []map[string]interface{}{{"id": 2, "category": "old"}})
+				case r.Method == http.MethodPost && r.URL.Path == milvusEntitiesUpsertPath:
+					http.Error(w, "forced update failure", http.StatusInternalServerError)
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			})
+
+			db := newTestMilvusDB(t, server.URL)
+			err := db.ApplyChanges("products", connection.ChangeSet{
+				Deletes: []map[string]interface{}{{"id": 1}},
+				Updates: []connection.UpdateRow{{
+					Keys:   map[string]interface{}{"id": 2},
+					Values: map[string]interface{}{"category": "updated"},
+				}},
+			})
+			if err == nil {
+				t.Fatal("ApplyChanges succeeded, want failure")
+			}
+			if IsWriteOutcomeUnknown(err) != test.wantUnknown {
+				t.Fatalf("ApplyChanges unknown outcome = %t, want %t: %v", IsWriteOutcomeUnknown(err), test.wantUnknown, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Track successful delete, update, and upsert phases in Chroma, Qdrant, and Milvus batch writes.
- Mark later failures as unknown when an earlier phase may already have committed.
- Add regression coverage for first-write failures versus partial-write failures.

## Issue

Fixes #1045

## Tests

- `go test ./internal/db -run 'Test(Chroma|Qdrant|Milvus)ApplyChangesClassifiesPartialWrites' -count=1 -timeout=5m`