### PR TITLE
fix(db): propagate cancellation through batch writes

### DIFF
--- a/internal/db/chroma_impl.go
+++ b/internal/db/chroma_impl.go
@@ -40,6 +40,8 @@ type ChromaDB struct {
 	forwarder   *ssh.LocalForwarder
 }
 
+var _ BatchApplierContext = (*ChromaDB)(nil)
+
 type chromaCollection struct {
 	ID        string                 `json:"id"`
 	Name      string                 `json:"name"`
@@ -311,7 +313,11 @@ func (c *ChromaDB) GetTriggers(dbName, tableName string) ([]connection.TriggerDe
 }
 
 func (c *ChromaDB) ApplyChanges(tableName string, changes connection.ChangeSet) error {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultChromaQueryTimeout)
+	return c.ApplyChangesContext(context.Background(), tableName, changes)
+}
+
+func (c *ChromaDB) ApplyChangesContext(ctx context.Context, tableName string, changes connection.ChangeSet) error {
+	ctx, cancel := context.WithTimeout(ctx, defaultChromaQueryTimeout)
 	defer cancel()
 
 	if len(changes.Deletes) > 0 {

--- a/internal/db/elasticsearch_apply_context_test.go
+++ b/internal/db/elasticsearch_apply_context_test.go
@@ -1,0 +1,73 @@
+//go:build gonavi_full_drivers || gonavi_elasticsearch_driver
+
+package db
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"GoNavi-Wails/internal/connection"
+)
+
+func TestElasticsearchApplyChangesContextCancelsInFlightBulk(t *testing.T) {
+	requestStarted := make(chan struct{})
+	requestFinished := make(chan struct{})
+	requestRelease := make(chan struct{})
+	releaseRequest := func() {
+		select {
+		case <-requestRelease:
+		default:
+			close(requestRelease)
+		}
+	}
+	t.Cleanup(releaseRequest)
+	server := newMockESServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/_alias/test-index":
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodPost && r.URL.Path == "/_bulk":
+			close(requestStarted)
+			select {
+			case <-r.Context().Done():
+			case <-requestRelease:
+			}
+			close(requestFinished)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	db := newTestESDB(t, server.URL, "test-index")
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- db.ApplyChangesContext(ctx, "test-index", connection.ChangeSet{
+			Inserts: []map[string]interface{}{{"message": "hello"}},
+		})
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ApplyChangesContext did not reach the blocking Elasticsearch bulk request")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("ApplyChangesContext error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ApplyChangesContext did not return after cancellation")
+	}
+	releaseRequest()
+	select {
+	case <-requestFinished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("blocked Elasticsearch handler did not exit after cancellation")
+	}
+}

--- a/internal/db/elasticsearch_impl.go
+++ b/internal/db/elasticsearch_impl.go
@@ -43,6 +43,8 @@ type ElasticsearchDB struct {
 	forwarder        *ssh.LocalForwarder
 }
 
+var _ BatchApplierContext = (*ElasticsearchDB)(nil)
+
 func (e *ElasticsearchDB) ElasticsearchConsoleTransportUsable() bool {
 	return e.consoleClient != nil
 }
@@ -943,11 +945,15 @@ func (e *ElasticsearchDB) esBulkActionMeta(action, indexName string, docID strin
 // resolveWriteIndex 解析别名 metadata 中唯一标记为 is_write_index 的索引。
 // 直接索引名通过 GetAlias 的 404 判定；别名缺失或冲突时拒绝写入。
 func (e *ElasticsearchDB) resolveWriteIndex(indexOrAlias string) (string, error) {
+	return e.resolveWriteIndexContext(context.Background(), indexOrAlias)
+}
+
+func (e *ElasticsearchDB) resolveWriteIndexContext(ctx context.Context, indexOrAlias string) (string, error) {
 	indexOrAlias = strings.TrimSpace(indexOrAlias)
 	if indexOrAlias == "" {
 		return "", fmt.Errorf("未指定索引或别名")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	res, err := e.client.Indices.GetAlias(
@@ -1012,6 +1018,10 @@ func isESMetaField(name string) bool {
 
 // ApplyChanges 实现 BatchApplier 接口，通过 ES _bulk API 批量提交增删改。
 func (e *ElasticsearchDB) ApplyChanges(tableName string, changes connection.ChangeSet) error {
+	return e.ApplyChangesContext(context.Background(), tableName, changes)
+}
+
+func (e *ElasticsearchDB) ApplyChangesContext(ctx context.Context, tableName string, changes connection.ChangeSet) error {
 	if e.client == nil {
 		return localizedDatabaseRuntimeError("db.backend.error.connection_not_open", nil)
 	}
@@ -1024,7 +1034,7 @@ func (e *ElasticsearchDB) ApplyChanges(tableName string, changes connection.Chan
 	var bulkBody bytes.Buffer
 
 	// 如果目标是别名（非直接索引），解析出实际的可写索引名。
-	writeIndexName, err := e.resolveWriteIndex(indexName)
+	writeIndexName, err := e.resolveWriteIndexContext(ctx, indexName)
 	if err != nil {
 		return fmt.Errorf("解析写入索引失败：%w", err)
 	}
@@ -1090,7 +1100,7 @@ func (e *ElasticsearchDB) ApplyChanges(tableName string, changes connection.Chan
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	res, err := e.client.Bulk(

--- a/internal/db/milvus_impl.go
+++ b/internal/db/milvus_impl.go
@@ -50,6 +50,8 @@ type MilvusDB struct {
 	forwarder   *ssh.LocalForwarder
 }
 
+var _ BatchApplierContext = (*MilvusDB)(nil)
+
 func (m *MilvusDB) Connect(config connection.ConnectionConfig) (err error) {
 	_ = m.Close()
 	defer func() {
@@ -348,7 +350,11 @@ func (m *MilvusDB) GetTriggers(dbName, tableName string) ([]connection.TriggerDe
 }
 
 func (m *MilvusDB) ApplyChanges(tableName string, changes connection.ChangeSet) error {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultMilvusQueryTimeout)
+	return m.ApplyChangesContext(context.Background(), tableName, changes)
+}
+
+func (m *MilvusDB) ApplyChangesContext(ctx context.Context, tableName string, changes connection.ChangeSet) error {
+	ctx, cancel := context.WithTimeout(ctx, defaultMilvusQueryTimeout)
 	defer cancel()
 	collection := strings.TrimSpace(tableName)
 	if collection == "" {

--- a/internal/db/qdrant_impl.go
+++ b/internal/db/qdrant_impl.go
@@ -36,6 +36,8 @@ type QdrantDB struct {
 	forwarder   *ssh.LocalForwarder
 }
 
+var _ BatchApplierContext = (*QdrantDB)(nil)
+
 type qdrantCollectionInfo struct {
 	Name string `json:"name"`
 }
@@ -307,7 +309,11 @@ func (q *QdrantDB) GetTriggers(dbName, tableName string) ([]connection.TriggerDe
 }
 
 func (q *QdrantDB) ApplyChanges(tableName string, changes connection.ChangeSet) error {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultQdrantQueryTimeout)
+	return q.ApplyChangesContext(context.Background(), tableName, changes)
+}
+
+func (q *QdrantDB) ApplyChangesContext(ctx context.Context, tableName string, changes connection.ChangeSet) error {
+	ctx, cancel := context.WithTimeout(ctx, defaultQdrantQueryTimeout)
 	defer cancel()
 
 	if len(changes.Deletes) > 0 {

--- a/internal/db/tdengine_apply_context_test.go
+++ b/internal/db/tdengine_apply_context_test.go
@@ -1,0 +1,90 @@
+//go:build gonavi_full_drivers || gonavi_tdengine_driver
+
+package db
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"testing"
+	"time"
+
+	"GoNavi-Wails/internal/connection"
+)
+
+type tdengineContextConnector struct {
+	started  chan struct{}
+	finished chan struct{}
+}
+
+func (c tdengineContextConnector) Connect(context.Context) (driver.Conn, error) {
+	return &tdengineContextConn{started: c.started, finished: c.finished}, nil
+}
+
+func (tdengineContextConnector) Driver() driver.Driver { return tdengineContextDriver{} }
+
+type tdengineContextDriver struct{}
+
+func (tdengineContextDriver) Open(string) (driver.Conn, error) {
+	return nil, errors.New("TDengine context test driver requires connector")
+}
+
+type tdengineContextConn struct {
+	started  chan struct{}
+	finished chan struct{}
+}
+
+func (*tdengineContextConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepare is not supported")
+}
+func (*tdengineContextConn) Close() error { return nil }
+func (*tdengineContextConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("transactions are not supported")
+}
+
+func (c *tdengineContextConn) ExecContext(ctx context.Context, _ string, _ []driver.NamedValue) (driver.Result, error) {
+	close(c.started)
+	<-ctx.Done()
+	close(c.finished)
+	return nil, ctx.Err()
+}
+
+var _ driver.ExecerContext = (*tdengineContextConn)(nil)
+
+func TestTDengineApplyChangesContextCancelsInFlightInsert(t *testing.T) {
+	requestStarted := make(chan struct{})
+	requestFinished := make(chan struct{})
+	dbConn := sql.OpenDB(tdengineContextConnector{started: requestStarted, finished: requestFinished})
+	t.Cleanup(func() { _ = dbConn.Close() })
+
+	database := &TDengineDB{conn: dbConn}
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- database.ApplyChangesContext(ctx, "metrics", connection.ChangeSet{
+			Inserts: []map[string]interface{}{{"ts": "2026-03-09 10:00:00", "value": 12.5}},
+		})
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ApplyChangesContext did not reach the blocking TDengine driver")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("ApplyChangesContext error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ApplyChangesContext did not return after cancellation")
+	}
+	select {
+	case <-requestFinished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("blocked TDengine driver did not exit after cancellation")
+	}
+}

--- a/internal/db/tdengine_impl.go
+++ b/internal/db/tdengine_impl.go
@@ -57,6 +57,8 @@ type TDengineDB struct {
 	probeWebSocketEndpoint tdengineWebSocketEndpointProbeFunc
 }
 
+var _ BatchApplierContext = (*TDengineDB)(nil)
+
 func (t *TDengineDB) getDSN(config connection.ConnectionConfig) string {
 	params := url.Values{}
 	mergeConnectionParamsFromConfigWithAllowlist(params, config, tdengineConnectionParamNames, "taos", "taosws", "tdengine")
@@ -661,6 +663,10 @@ func (t *TDengineDB) GetTriggers(dbName, tableName string) ([]connection.Trigger
 }
 
 func (t *TDengineDB) ApplyChanges(tableName string, changes connection.ChangeSet) error {
+	return t.ApplyChangesContext(context.Background(), tableName, changes)
+}
+
+func (t *TDengineDB) ApplyChangesContext(ctx context.Context, tableName string, changes connection.ChangeSet) error {
 	if t.conn == nil {
 		return localizedDatabaseRuntimeError("db.backend.error.connection_not_open", nil)
 	}
@@ -672,14 +678,18 @@ func (t *TDengineDB) ApplyChanges(tableName string, changes connection.ChangeSet
 	}
 
 	qualifiedTable := quoteTDengineTable("", tableName)
-	return execTDengineInsertBatches(t.conn, qualifiedTable, changes.Inserts)
+	return execTDengineInsertBatchesContext(ctx, t.conn, qualifiedTable, changes.Inserts)
 }
 
 func execTDengineInsertBatches(conn *sql.DB, qualifiedTable string, rows []map[string]interface{}) error {
+	return execTDengineInsertBatchesContext(context.Background(), conn, qualifiedTable, rows)
+}
+
+func execTDengineInsertBatchesContext(ctx context.Context, conn *sql.DB, qualifiedTable string, rows []map[string]interface{}) error {
 	if conn == nil {
 		return fmt.Errorf("连接未打开")
 	}
-	return execLiteralInsertBatches(literalInsertConfig{
+	err := execLiteralInsertBatches(literalInsertConfig{
 		Table: qualifiedTable,
 		Rows:  rows,
 		QuoteColumn: func(column string) string {
@@ -687,9 +697,16 @@ func execTDengineInsertBatches(conn *sql.DB, qualifiedTable string, rows []map[s
 		},
 		Literal: tdengineLiteral,
 		Exec: func(query string) (sql.Result, error) {
-			return conn.Exec(query)
+			return conn.ExecContext(ctx, query)
 		},
 	})
+	if err != nil && ctx.Err() != nil {
+		if IsWriteOutcomeUnknown(err) {
+			return MarkWriteOutcomeUnknown(ctx.Err())
+		}
+		return ctx.Err()
+	}
+	return err
 }
 
 func buildTDengineInsertSQL(qualifiedTable string, row map[string]interface{}) (string, error) {

--- a/internal/db/vector_apply_context_test.go
+++ b/internal/db/vector_apply_context_test.go
@@ -1,0 +1,222 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"GoNavi-Wails/internal/connection"
+)
+
+func TestChromaApplyChangesContextCancelsInFlightRequest(t *testing.T) {
+	requestStarted := make(chan struct{})
+	requestFinished := make(chan struct{})
+	requestRelease := make(chan struct{})
+	releaseRequest := func() {
+		select {
+		case <-requestRelease:
+		default:
+			close(requestRelease)
+		}
+	}
+	t.Cleanup(releaseRequest)
+	server := newMockChromaServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v2/heartbeat":
+			writeChromaJSON(w, map[string]interface{}{"ok": true})
+		case r.URL.Path == "/api/v2/tenants/default_tenant/databases/default_database/collections":
+			writeChromaJSON(w, []chromaCollection{{ID: "col-products", Name: "products", Database: "default_database"}})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/collections/col-products/delete"):
+			writeChromaJSON(w, map[string]interface{}{"ok": true})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/collections/col-products/upsert"):
+			close(requestStarted)
+			select {
+			case <-r.Context().Done():
+			case <-requestRelease:
+			}
+			close(requestFinished)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	db := newTestChromaDB(t, server.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- db.ApplyChangesContext(ctx, "products", connection.ChangeSet{
+			Deletes: []map[string]interface{}{{"id": "old"}},
+			Updates: []connection.UpdateRow{{
+				Keys:   map[string]interface{}{"id": "existing"},
+				Values: map[string]interface{}{"document": "updated"},
+			}},
+		})
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ApplyChangesContext did not reach the blocking Chroma request")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("ApplyChangesContext error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ApplyChangesContext did not return after cancellation")
+	}
+	releaseRequest()
+	select {
+	case <-requestFinished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("blocked Chroma handler did not exit after cancellation")
+	}
+}
+
+func TestQdrantApplyChangesContextCancelsInFlightRequest(t *testing.T) {
+	requestStarted := make(chan struct{})
+	requestFinished := make(chan struct{})
+	requestRelease := make(chan struct{})
+	releaseRequest := func() {
+		select {
+		case <-requestRelease:
+		default:
+			close(requestRelease)
+		}
+	}
+	t.Cleanup(releaseRequest)
+	server := newMockQdrantServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/collections":
+			writeQdrantJSON(w, map[string]interface{}{"result": map[string]interface{}{"collections": []interface{}{}}})
+		case r.Method == http.MethodPost && r.URL.Path == "/collections/products/points/delete":
+			writeQdrantJSON(w, map[string]interface{}{"result": map[string]interface{}{"operation_id": 1}})
+		case r.Method == http.MethodPost && r.URL.Path == "/collections/products/points/payload":
+			close(requestStarted)
+			select {
+			case <-r.Context().Done():
+			case <-requestRelease:
+			}
+			close(requestFinished)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	db := newTestQdrantDB(t, server.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- db.ApplyChangesContext(ctx, "products", connection.ChangeSet{
+			Deletes: []map[string]interface{}{{"id": 9}},
+			Updates: []connection.UpdateRow{{
+				Keys:   map[string]interface{}{"id": 1},
+				Values: map[string]interface{}{"payload.category": "updated"},
+			}},
+		})
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ApplyChangesContext did not reach the blocking Qdrant request")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("ApplyChangesContext error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ApplyChangesContext did not return after cancellation")
+	}
+	releaseRequest()
+	select {
+	case <-requestFinished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("blocked Qdrant handler did not exit after cancellation")
+	}
+}
+
+func TestMilvusApplyChangesContextCancelsInFlightRequest(t *testing.T) {
+	requestStarted := make(chan struct{})
+	requestFinished := make(chan struct{})
+	requestRelease := make(chan struct{})
+	releaseRequest := func() {
+		select {
+		case <-requestRelease:
+		default:
+			close(requestRelease)
+		}
+	}
+	t.Cleanup(releaseRequest)
+	description := map[string]interface{}{
+		"fields": []map[string]interface{}{
+			{"name": "id", "type": "Int64", "primaryKey": true},
+			{"name": "category", "type": "VarChar"},
+		},
+	}
+	server := newMockMilvusServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case isMilvusCollectionListRequest(r):
+			writeMilvusJSON(w, []string{})
+		case r.Method == http.MethodPost && r.URL.Path == milvusCollectionsDescribePath:
+			writeMilvusJSON(w, description)
+		case r.Method == http.MethodPost && r.URL.Path == milvusEntitiesDeletePath:
+			writeMilvusJSON(w, map[string]interface{}{})
+		case r.Method == http.MethodPost && r.URL.Path == milvusEntitiesQueryPath:
+			writeMilvusJSON(w, []map[string]interface{}{{"id": 2, "category": "old"}})
+		case r.Method == http.MethodPost && r.URL.Path == milvusEntitiesUpsertPath:
+			close(requestStarted)
+			select {
+			case <-r.Context().Done():
+			case <-requestRelease:
+			}
+			close(requestFinished)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	db := newTestMilvusDB(t, server.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- db.ApplyChangesContext(ctx, "products", connection.ChangeSet{
+			Deletes: []map[string]interface{}{{"id": 1}},
+			Updates: []connection.UpdateRow{{
+				Keys:   map[string]interface{}{"id": 2},
+				Values: map[string]interface{}{"category": "updated"},
+			}},
+		})
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ApplyChangesContext did not reach the blocking Milvus request")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("ApplyChangesContext error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ApplyChangesContext did not return after cancellation")
+	}
+	releaseRequest()
+	select {
+	case <-requestFinished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("blocked Milvus handler did not exit after cancellation")
+	}
+}


### PR DESCRIPTION
## Summary

- Add cancellation-aware batch-write entry points for Chroma, Qdrant, and Milvus.
- Forward caller context through Elasticsearch alias resolution and bulk requests.
- Forward caller context through TDengine insert batches.
- Keep the existing ApplyChanges API as a backwards-compatible background-context wrapper.

## Issue

Fixes #1046

## Tests

- `go test ./internal/db -run 'Test(Chroma|Qdrant|Milvus)ApplyChangesContextCancelsInFlightRequest' -count=1 -timeout=5m`
- `go test -tags gonavi_elasticsearch_driver ./internal/db -run 'TestElasticsearchApplyChangesContextCancelsInFlightBulk' -count=1 -timeout=5m`
- `go test -tags gonavi_tdengine_driver ./internal/db -run 'TestTDengineApplyChangesContextCancelsInFlightInsert' -count=1 -timeout=5m`