### PR TITLE
fix(elasticsearch): classify invalid bulk responses as unknown

### DIFF
--- a/internal/db/elasticsearch_bulk_response_test.go
+++ b/internal/db/elasticsearch_bulk_response_test.go
@@ -1,0 +1,37 @@
+//go:build gonavi_full_drivers || gonavi_elasticsearch_driver
+
+package db
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"GoNavi-Wails/internal/connection"
+)
+
+func TestElasticsearchApplyChangesMarksInvalidBulkJSONAsUnknown(t *testing.T) {
+	server := newMockESServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/_alias/test-index":
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodPost && r.URL.Path == "/_bulk":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("upstream proxy timeout"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	db := newTestESDB(t, server.URL, "test-index")
+	err := db.ApplyChanges("test-index", connection.ChangeSet{
+		Inserts: []map[string]interface{}{{"message": "hello"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "解析 ES 批量操作响应失败") {
+		t.Fatalf("ApplyChanges error = %v, want invalid JSON error", err)
+	}
+	if !IsWriteOutcomeUnknown(err) {
+		t.Fatalf("ApplyChanges error = %v, want unknown write outcome", err)
+	}
+}

--- a/internal/db/elasticsearch_impl.go
+++ b/internal/db/elasticsearch_impl.go
@@ -1113,28 +1113,29 @@ func (e *ElasticsearchDB) ApplyChanges(tableName string, changes connection.Chan
 
 	// 检查是否有单条操作失败
 	var result map[string]interface{}
-	if err := json.Unmarshal(body, &result); err == nil {
-		if hasErrors, ok := result["errors"].(bool); ok && hasErrors {
-			if items, ok := result["items"].([]interface{}); ok {
-				for _, item := range items {
-					itemMap, ok := item.(map[string]interface{})
+	if err := json.Unmarshal(body, &result); err != nil {
+		return MarkWriteOutcomeUnknown(fmt.Errorf("解析 ES 批量操作响应失败，写入状态未知：%w", err))
+	}
+	if hasErrors, ok := result["errors"].(bool); ok && hasErrors {
+		if items, ok := result["items"].([]interface{}); ok {
+			for _, item := range items {
+				itemMap, ok := item.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				for _, op := range itemMap {
+					opMap, ok := op.(map[string]interface{})
 					if !ok {
 						continue
 					}
-					for _, op := range itemMap {
-						opMap, ok := op.(map[string]interface{})
-						if !ok {
-							continue
-						}
-						if errMap, ok := opMap["error"].(map[string]interface{}); ok {
-							reason, _ := errMap["reason"].(string)
-							return fmt.Errorf("ES 批量操作部分失败：%s", reason)
-						}
+					if errMap, ok := opMap["error"].(map[string]interface{}); ok {
+						reason, _ := errMap["reason"].(string)
+						return fmt.Errorf("ES 批量操作部分失败：%s", reason)
 					}
 				}
 			}
-			return fmt.Errorf("ES 批量操作部分失败")
 		}
+		return fmt.Errorf("ES 批量操作部分失败")
 	}
 
 	logger.Infof("ES 批量操作完成：索引=%s 删除=%d 更新=%d 新增=%d",


### PR DESCRIPTION
## Summary

- Treat a successful HTTP status with an invalid bulk JSON response as a failed response.
- Mark the write outcome as unknown because the server may have applied the request.
- Add regression coverage for a non-JSON 2xx response from /_bulk.

## Issue

Fixes #1047

## Tests

- `go test -tags gonavi_elasticsearch_driver ./internal/db -run 'TestElasticsearchApplyChangesMarksInvalidBulkJSONAsUnknown' -count=1 -timeout=5m`