### PR TITLE
fix(mcpserver): wait for active requests before backend close

### DIFF
--- a/internal/mcpserver/run.go
+++ b/internal/mcpserver/run.go
@@ -20,8 +20,9 @@ import (
 )
 
 const (
-	defaultStreamableHTTPAddr = "127.0.0.1:8765"
-	defaultStreamableHTTPPath = "/mcp"
+	defaultStreamableHTTPAddr     = "127.0.0.1:8765"
+	defaultStreamableHTTPPath     = "/mcp"
+	streamableHTTPShutdownTimeout = 5 * time.Second
 )
 
 // HTTPServerOptions 描述远程 Streamable HTTP MCP 入口。
@@ -128,11 +129,15 @@ func StartAppStreamableHTTPServer(ctx context.Context, options HTTPServerOptions
 		return nil, err
 	}
 
+	closeBackendAfterServerStops(handle, backend)
+	return handle, nil
+}
+
+func closeBackendAfterServerStops(handle *StreamableHTTPServerHandle, backend Backend) {
 	go func() {
 		_ = handle.Wait()
 		_ = backend.Close(context.Background())
 	}()
-	return handle, nil
 }
 
 // RunAppStreamableHTTPServer 启动基于真实 GoNavi App 的 Streamable HTTP MCP server。
@@ -175,17 +180,27 @@ func StartStreamableHTTPServer(ctx context.Context, backend Backend, options HTT
 		JSONResponse:   normalized.JSONResponse,
 		SessionTimeout: 30 * time.Minute,
 	})
+	return startStreamableHTTPServer(ctx, normalized, streamableHandler, streamableHTTPShutdownTimeout)
+}
+
+func startStreamableHTTPServer(ctx context.Context, options HTTPServerOptions, streamableHandler http.Handler, shutdownTimeout time.Duration) (*StreamableHTTPServerHandle, error) {
+	var activeRequests sync.WaitGroup
+	requestHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		activeRequests.Add(1)
+		defer activeRequests.Done()
+		streamableHandler.ServeHTTP(w, req)
+	})
 
 	httpServer := &http.Server{
-		Addr:              normalized.Addr,
-		Handler:           streamableHTTPRoutes(normalized, streamableHandler),
+		Addr:              options.Addr,
+		Handler:           streamableHTTPRoutes(options, requestHandler),
 		ReadHeaderTimeout: httpserverlimits.ReadHeaderTimeout,
 		ReadTimeout:       httpserverlimits.ReadTimeout,
 		WriteTimeout:      httpserverlimits.WriteTimeout,
 		IdleTimeout:       httpserverlimits.IdleTimeout,
 	}
 
-	listener, err := net.Listen("tcp", normalized.Addr)
+	listener, err := net.Listen("tcp", options.Addr)
 	if err != nil {
 		return nil, err
 	}
@@ -193,8 +208,8 @@ func StartStreamableHTTPServer(ctx context.Context, backend Backend, options HTT
 	serverCtx, cancel := context.WithCancel(ctx)
 	handle := &StreamableHTTPServerHandle{
 		Addr:       listener.Addr().String(),
-		Path:       normalized.Path,
-		SchemaOnly: normalized.SchemaOnly,
+		Path:       options.Path,
+		SchemaOnly: options.SchemaOnly,
 		cancel:     cancel,
 		done:       make(chan struct{}),
 	}
@@ -208,16 +223,21 @@ func StartStreamableHTTPServer(ctx context.Context, backend Backend, options HTT
 		select {
 		case err := <-errCh:
 			cancel()
+			// Serve can fail for reasons other than an intentional shutdown while
+			// authenticated handlers are still using the backend.
+			activeRequests.Wait()
 			if errors.Is(err, http.ErrServerClosed) {
 				handle.complete(nil)
 				return
 			}
 			handle.complete(err)
 		case <-serverCtx.Done():
-			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), shutdownTimeout)
 			defer shutdownCancel()
 			shutdownErr := httpServer.Shutdown(shutdownCtx)
 			serveErr := <-errCh
+			// A Shutdown timeout does not stop active handlers; keep the backend alive until they return.
+			activeRequests.Wait()
 			if shutdownErr != nil && !errors.Is(shutdownErr, http.ErrServerClosed) {
 				handle.complete(shutdownErr)
 				return

--- a/internal/mcpserver/run_test.go
+++ b/internal/mcpserver/run_test.go
@@ -3,6 +3,7 @@ package mcpserver
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +16,16 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+type closeTrackingBackend struct {
+	*fakeBackend
+	closed chan struct{}
+}
+
+func (b *closeTrackingBackend) Close(context.Context) error {
+	close(b.closed)
+	return nil
+}
 
 type bearerTokenRoundTripper struct {
 	token string
@@ -48,6 +59,87 @@ func TestStartStreamableHTTPServerStopsWhenContextIsCanceled(t *testing.T) {
 
 	if err := handle.Wait(); err != nil {
 		t.Fatalf("HTTP server returned error after context cancellation: %v", err)
+	}
+}
+
+func TestStreamableHTTPServerWaitsForActiveHandlerBeforeClosingBackend(t *testing.T) {
+	const shutdownTimeout = 20 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	backend := &closeTrackingBackend{
+		fakeBackend: &fakeBackend{},
+		closed:      make(chan struct{}),
+	}
+	handlerStarted := make(chan struct{})
+	releaseHandler := make(chan struct{}, 1)
+	t.Cleanup(func() {
+		select {
+		case releaseHandler <- struct{}{}:
+		default:
+		}
+	})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(handlerStarted)
+		<-releaseHandler
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	handle, err := startStreamableHTTPServer(ctx, HTTPServerOptions{
+		Addr:  "127.0.0.1:0",
+		Path:  "/mcp",
+		Token: "test-token",
+	}, handler, shutdownTimeout)
+	if err != nil {
+		t.Fatalf("startStreamableHTTPServer returned error: %v", err)
+	}
+	closeBackendAfterServerStops(handle, backend)
+
+	requestDone := make(chan error, 1)
+	go func() {
+		req, err := http.NewRequest(http.MethodPost, "http://"+handle.Addr+handle.Path, nil)
+		if err != nil {
+			requestDone <- err
+			return
+		}
+		req.Header.Set("Authorization", "Bearer test-token")
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+		requestDone <- err
+	}()
+
+	select {
+	case <-handlerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not start")
+	}
+
+	cancel()
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 3*shutdownTimeout)
+	defer stopCancel()
+	if err := handle.Stop(stopCtx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Stop returned %v while handler was still active, want deadline exceeded", err)
+	}
+	select {
+	case <-backend.closed:
+		t.Fatal("backend closed while handler was still active")
+	default:
+	}
+
+	releaseHandler <- struct{}{}
+	if err := <-requestDone; err != nil {
+		t.Fatalf("request returned error after handler release: %v", err)
+	}
+	if err := handle.Wait(); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Wait returned %v after shutdown timeout, want deadline exceeded", err)
+	}
+	select {
+	case <-backend.closed:
+	case <-time.After(time.Second):
+		t.Fatal("backend did not close after handler completed")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Track authenticated MCP HTTP handlers that are still using the backend.
- Keep the backend open until active handlers finish, even when HTTP shutdown reaches its timeout.
- Preserve the existing HTTP routes, request limits, and streaming timeout behavior.
- Add a regression test covering a handler that outlives the shutdown timeout.

## Issue

Fixes #1043

## Tests

- `GOTOOLCHAIN=auto GOCACHE=/tmp/gonavi-go-build go test ./internal/mcpserver -count=1 -timeout=5m`
- `GOTOOLCHAIN=auto GOCACHE=/tmp/gonavi-go-build go test -race ./internal/mcpserver -run 'Test(StreamableHTTPServerWaitsForActiveHandlerBeforeClosingBackend|StartStreamableHTTPServerStopsWhenContextIsCanceled)' -count=1 -timeout=5m`