### PR TITLE
✨ feat(datagrid): 支持点击列头选中整列后粘贴数据

### DIFF
--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -2016,28 +2016,6 @@ const DataGrid: React.FC<DataGridProps> = ({
     resetCellSelection();
   }, [resetCellSelection]);
 
-  const selectEditableColumnCells = useCallback((columnName: string) => {
-    if (
-      !cellEditModeRef.current
-      || !canModifyData
-      || !isWritableResultColumn(columnName, effectiveEditLocator)
-    ) {
-      return;
-    }
-
-    resetCellSelection(false);
-    const nextSelection = new Set<string>();
-    displayDataRef.current.forEach((row) => {
-      const rowKey = row?.[GONAVI_ROW_KEY];
-      if (rowKey === undefined || rowKey === null) return;
-      nextSelection.add(makeCellKey(rowKeyStr(rowKey), columnName));
-    });
-    currentSelectionRef.current = nextSelection;
-    setSelectedCells(nextSelection);
-    markCellSelectionDeleteEligible(true);
-    updateCellSelection(nextSelection);
-  }, [canModifyData, effectiveEditLocator, makeCellKey, markCellSelectionDeleteEligible, resetCellSelection, rowKeyStr, updateCellSelection]);
-
   const previousSelectionSourceDataRef = useRef(data);
   useEffect(() => {
     if (previousSelectionSourceDataRef.current === data) return;
@@ -2060,6 +2038,7 @@ const DataGrid: React.FC<DataGridProps> = ({
     handleCopySelectedColumnsFromRow,
     handlePasteCopiedColumnsToSelectedRows,
     handleBatchFillToSelected,
+    selectEditableColumnCells,
   } = useDataGridBatchActions({
     CELL_SELECTION_DRAG_THRESHOLD_PX,
     GONAVI_ROW_KEY,

--- a/frontend/src/components/useDataGridBatchActions.test.tsx
+++ b/frontend/src/components/useDataGridBatchActions.test.tsx
@@ -254,6 +254,77 @@ describe('useDataGridBatchActions clipboard paste', () => {
     expect(messageApi.success).toHaveBeenCalledWith('data_grid.message.pasted_columns_to_rows:{"rows":2,"cells":4}');
   });
 
+  it('anchors a header-selected column at its first cell so paste fills the column', () => {
+    const hook = renderHook();
+    hook.ctx.cellEditModeRef.current = true;
+
+    act(() => {
+      hook.getActions().selectEditableColumnCells('name');
+    });
+
+    expect(hook.selectionStartRef.current).toEqual({ rowKey: 'row-1', colName: 'name', rowIndex: 0, colIndex: 2 });
+    expect(hook.setSelectedCells).toHaveBeenCalledWith(new Set([
+      makeCellKey('row-1', 'name'),
+      makeCellKey('row-2', 'name'),
+      makeCellKey('row-3', 'name'),
+    ]));
+    expect(hook.ctx.markCellSelectionDeleteEligible).toHaveBeenCalledWith(true);
+
+    const preventDefault = vi.fn();
+    act(() => {
+      (windowTarget.listeners.get('paste') as any)?.({
+        target: new MockHTMLElement({ 'data-row-key': 'row-1', 'data-col-name': 'name' }),
+        clipboardData: { types: ['text/plain'], getData: vi.fn(() => 'x\ny\n') },
+        preventDefault,
+      });
+    });
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    const nextRows = hook.setModifiedRows.mock.calls[0][0]({});
+    expect(nextRows).toEqual({
+      'row-1': { name: 'x' },
+      'row-2': { name: 'y' },
+    });
+  });
+
+  it('fills the whole selected column when a single value is pasted after a header selection', () => {
+    const hook = renderHook();
+    hook.ctx.cellEditModeRef.current = true;
+
+    act(() => {
+      hook.getActions().selectEditableColumnCells('name');
+    });
+
+    const preventDefault = vi.fn();
+    act(() => {
+      (windowTarget.listeners.get('paste') as any)?.({
+        target: new MockHTMLElement({ 'data-row-key': 'row-1', 'data-col-name': 'name' }),
+        clipboardData: { types: ['text/plain'], getData: vi.fn(() => 'fixed') },
+        preventDefault,
+      });
+    });
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    const nextRows = hook.setModifiedRows.mock.calls[0][0]({});
+    expect(nextRows).toEqual({
+      'row-1': { name: 'fixed' },
+      'row-2': { name: 'fixed' },
+      'row-3': { name: 'fixed' },
+    });
+  });
+
+  it('ignores column header selection when the column is not writable', () => {
+    const hook = renderHook();
+    hook.ctx.cellEditModeRef.current = true;
+
+    act(() => {
+      hook.getActions().selectEditableColumnCells('generated');
+    });
+
+    expect(hook.selectionStartRef.current).toBeNull();
+    expect(hook.setSelectedCells).not.toHaveBeenCalled();
+  });
+
   it('clears the source selection after creating a fill template', () => {
     const hook = renderHook({
       selectedCells: new Set([makeCellKey('row-1', 'name')]),

--- a/frontend/src/components/useDataGridBatchActions.ts
+++ b/frontend/src/components/useDataGridBatchActions.ts
@@ -51,7 +51,7 @@ type DataGridBatchActionsContext = Record<string, any> & {
   setSelectedCells: React.Dispatch<React.SetStateAction<Set<string>>>;
   markCellSelectionDeleteEligible: (eligible: boolean) => void;
   rowKeyStr: (key: React.Key) => string;
-  resetCellSelection: () => void;
+  resetCellSelection: (clearState?: boolean) => void;
   makeCellKey: (rowKey: string, colName: string) => string;
   splitCellKey: (cellKey: string) => { rowKey: string; colName: string } | null;
   updateCellSelection: (cells: Set<string>) => void;
@@ -880,6 +880,42 @@ const handleBatchFillCells = useCallback(() => {
     setCellContextMenu((prev: any) => ({ ...prev, visible: false }));
   }, [copiedCellPatch, addedRows, modifiedRows, rowKeyStr, selectedCells, canUseCellSelectionAsFillTemplateTargets, effectiveEditLocator, translateDataGrid]);
 
+  const selectEditableColumnCells = useCallback((columnName: string) => {
+    if (
+      !cellEditModeRef.current
+      || !canModifyData
+      || !isWritableResultColumn(columnName, effectiveEditLocator)
+    ) {
+      return;
+    }
+
+    resetCellSelection(false);
+    const currentRows = displayDataRef.current;
+    const colIndex = columnIndexMap.get(columnName) ?? -1;
+    const nextSelection = new Set<string>();
+    let anchorRowIndex = -1;
+    for (let rowIndex = 0; rowIndex < currentRows.length; rowIndex += 1) {
+      const rowKey = currentRows[rowIndex]?.[GONAVI_ROW_KEY];
+      if (rowKey === undefined || rowKey === null) continue;
+      if (anchorRowIndex === -1) anchorRowIndex = rowIndex;
+      nextSelection.add(makeCellKey(rowKeyStr(rowKey), columnName));
+    }
+    if (anchorRowIndex === -1) return;
+
+    const anchorRowKey = currentRows[anchorRowIndex]?.[GONAVI_ROW_KEY];
+    if (anchorRowKey === undefined || anchorRowKey === null) return;
+    selectionStartRef.current = {
+      rowKey: rowKeyStr(anchorRowKey),
+      colName: columnName,
+      rowIndex: anchorRowIndex,
+      colIndex,
+    };
+    currentSelectionRef.current = nextSelection;
+    setSelectedCells(nextSelection);
+    markCellSelectionDeleteEligible(true);
+    updateCellSelection(nextSelection);
+  }, [canModifyData, effectiveEditLocator, columnIndexMap, makeCellKey, markCellSelectionDeleteEligible, resetCellSelection, rowKeyStr, updateCellSelection]);
+
   // 批量填充到选中行
   const handleBatchFillToSelected = useCallback((sourceRecord: Item, dataIndex: string) => {
     if (!isWritableResultColumn(dataIndex, effectiveEditLocator)) {
@@ -947,5 +983,6 @@ const handleBatchFillCells = useCallback(() => {
     handleCopySelectedColumnsFromRow,
     handlePasteCopiedColumnsToSelectedRows,
     handleBatchFillToSelected,
+    selectEditableColumnCells,
   };
 };


### PR DESCRIPTION
## Summary

- 将选中列的首单元格作为锚点，使剪贴板粘贴操作针对整列生效。  
- 支持将多行矩阵数据自上而下粘贴到所选列中，并将单个粘贴值扩展至所有选中的单元格。  
- 将 `selectEditableColumnCells` 移至 `useDataGridBatchActions` 中，与依赖该锚点的粘贴处理函数并列。  
- 添加回归测试，覆盖列选择锚定、矩阵粘贴、单值填充以及不可写列拒绝等场景。

## Tests

- `npx vitest run src/components/useDataGridBatchActions.test.tsx`
- `npx vitest run src/components/DataGrid.ddl.test.tsx src/components/DataGrid.layout.test.tsx src/components/dataGridClipboardPaste.test.ts`
- `npx tsc --noEmit`