### PR TITLE
fix: warn before RabbitMQ message preview

### DIFF
--- a/frontend/src/components/DataViewer.primary-key.test.tsx
+++ b/frontend/src/components/DataViewer.primary-key.test.tsx
@@ -38,6 +38,10 @@ const messageApi = vi.hoisted(() => ({
   info: vi.fn(),
 }));
 
+const modalApi = vi.hoisted(() => ({
+  confirm: vi.fn(),
+}));
+
 const dataGridState = vi.hoisted(() => ({
   latestProps: null as any,
   renderedProps: [] as any[],
@@ -55,6 +59,12 @@ vi.mock('../../wailsjs/go/app/App', () => backendApp);
 
 vi.mock('antd', () => ({
   message: messageApi,
+}));
+
+vi.mock('./common/ResizableDraggableModal', () => ({
+  default: {
+    confirm: modalApi.confirm,
+  },
 }));
 
 vi.mock('./DataGrid', () => ({
@@ -144,6 +154,129 @@ describe('DataViewer safe editing locator', () => {
     await flushPromises();
 
     expect(messageApi.error).toHaveBeenCalledWith('未找到连接');
+    renderer!.unmount();
+  });
+
+  it('asks before reading RabbitMQ queue messages and allows cancelling the preview', async () => {
+    storeState.connections = [{
+      id: 'conn-rabbitmq',
+      name: 'rabbitmq',
+      config: {
+        type: 'rabbitmq',
+        host: '127.0.0.1',
+        port: 15672,
+        user: 'guest',
+        password: '',
+        database: '/',
+      },
+    }];
+
+    let modalOptions: any;
+    modalApi.confirm.mockImplementation((options: any) => {
+      modalOptions = options;
+      return { destroy: vi.fn() };
+    });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<DataViewer tab={createTab({
+        id: 'tab-rabbitmq-cancel',
+        connectionId: 'conn-rabbitmq',
+        dbName: '/',
+        tableName: 'orders.events',
+        title: 'orders.events',
+      })} />);
+      await Promise.resolve();
+    });
+    await flushPromises();
+
+    let reloadPromise!: Promise<unknown>;
+    await act(async () => {
+      reloadPromise = dataGridState.latestProps.onReload();
+      await Promise.resolve();
+    });
+    await flushPromises();
+
+    expect(modalApi.confirm).toHaveBeenCalledTimes(1);
+    expect(modalOptions.title).toBe('RabbitMQ 预览可能重新入队消息');
+    expect(modalOptions.content).toContain('ack_requeue_true');
+    expect(modalOptions.content).toContain('orders.events');
+    expect(modalOptions.okText).toBe('继续');
+    expect(modalOptions.cancelText).toBe('取消');
+    expect(backendApp.DBQuery).not.toHaveBeenCalled();
+
+    await act(async () => {
+      modalOptions.onCancel();
+      await reloadPromise;
+    });
+
+    expect(backendApp.DBQuery).not.toHaveBeenCalled();
+    renderer!.unmount();
+  });
+
+  it('continues RabbitMQ preview after confirmation without prompting on reload', async () => {
+    storeState.connections = [{
+      id: 'conn-rabbitmq',
+      name: 'rabbitmq',
+      config: {
+        type: 'rabbitmq',
+        host: '127.0.0.1',
+        port: 15672,
+        user: 'guest',
+        password: '',
+        database: '/',
+      },
+    }];
+    backendApp.DBQuery.mockResolvedValue({
+      success: true,
+      fields: ['payload'],
+      data: [{ payload: 'hello' }],
+    });
+
+    let modalOptions: any;
+    modalApi.confirm.mockImplementation((options: any) => {
+      modalOptions = options;
+      return { destroy: vi.fn() };
+    });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<DataViewer tab={createTab({
+        id: 'tab-rabbitmq-confirm',
+        connectionId: 'conn-rabbitmq',
+        dbName: '/',
+        tableName: 'orders.events',
+        title: 'orders.events',
+      })} />);
+      await Promise.resolve();
+    });
+    await flushPromises();
+
+    let reloadPromise!: Promise<unknown>;
+    await act(async () => {
+      reloadPromise = dataGridState.latestProps.onReload();
+      await Promise.resolve();
+    });
+    await flushPromises();
+
+    expect(modalApi.confirm).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      modalOptions.onOk();
+      await reloadPromise;
+    });
+    await flushPromises();
+
+    expect(backendApp.DBQuery).toHaveBeenCalled();
+    expect(backendApp.DBQuery.mock.calls.some((call: any[]) => (
+      /select\s+\*\s+from\s+"orders\.events"/i.test(String(call[2] || ''))
+    ))).toBe(true);
+
+    const queryCountAfterConfirmation = backendApp.DBQuery.mock.calls.length;
+    await act(async () => {
+      await dataGridState.latestProps.onReload();
+    });
+    expect(backendApp.DBQuery.mock.calls.length).toBeGreaterThan(queryCountAfterConfirmation);
+    expect(modalApi.confirm).toHaveBeenCalledTimes(1);
     renderer!.unmount();
   });
 

--- a/frontend/src/components/DataViewer.tsx
+++ b/frontend/src/components/DataViewer.tsx
@@ -31,6 +31,7 @@ import {
 } from '../utils/columnDefinition';
 import { splitQualifiedNameLast, splitQualifiedNameSegments } from '../utils/qualifiedName';
 import { requestTableMetadata } from '../utils/tableMetadataRequestCache';
+import { confirmRabbitMQPreview } from '../utils/rabbitmqPreview';
 
 type ViewerPaginationState = {
   current: number;
@@ -409,6 +410,8 @@ const DataViewer: React.FC<{ tab: TabData; isActive?: boolean }> = React.memo(({
   const initialLoadRef = useRef(false);
   const skipNextAutoFetchRef = useRef(false);
   const deferredInitialFetchRef = useRef(shouldDeferInitialDataViewerFetch(tab.initialViewMode));
+  const rabbitMQPreviewConfirmedRef = useRef(false);
+  const rabbitMQPreviewConfirmationRef = useRef<Promise<boolean> | null>(null);
 
   const [pagination, setPagination] = useState<ViewerPaginationState>({
       current: initialViewerSnapshot.currentPage,
@@ -497,6 +500,8 @@ const DataViewer: React.FC<{ tab: TabData; isActive?: boolean }> = React.memo(({
     latestCountKeyRef.current = '';
     scrollSnapshotRef.current = { top: snapshot.scrollTop, left: snapshot.scrollLeft };
     initialLoadRef.current = false;
+    rabbitMQPreviewConfirmedRef.current = false;
+    rabbitMQPreviewConfirmationRef.current = null;
     deferredInitialFetchRef.current = shouldDeferInitialDataViewerFetch(tab.initialViewMode);
     skipNextAutoFetchRef.current = true;
     setPagination(prev => ({
@@ -600,6 +605,22 @@ const DataViewer: React.FC<{ tab: TabData; isActive?: boolean }> = React.memo(({
     setPagination(prev => ({ ...prev, totalCountLoading: false, totalCountCancelled: true }));
   }, []);
 
+  const ensureRabbitMQPreviewConfirmed = useCallback(async (queue: string): Promise<boolean> => {
+    if (rabbitMQPreviewConfirmedRef.current) return true;
+
+    const pendingConfirmation = rabbitMQPreviewConfirmationRef.current || (() => {
+      const nextConfirmation = confirmRabbitMQPreview({ queue, translate: tr });
+      rabbitMQPreviewConfirmationRef.current = nextConfirmation;
+      return nextConfirmation;
+    })();
+    const approved = await pendingConfirmation;
+    if (rabbitMQPreviewConfirmationRef.current === pendingConfirmation) {
+      rabbitMQPreviewConfirmationRef.current = null;
+    }
+    if (approved) rabbitMQPreviewConfirmedRef.current = true;
+    return approved;
+  }, [tr]);
+
   const fetchData = useCallback(async (page = pagination.current, size = pagination.pageSize, options?: DataViewerFetchOptions) => {
     const navigateToLastPage = options?.navigateToLastPage === true;
     const refreshTotal = options?.refreshTotal === true || navigateToLastPage;
@@ -636,6 +657,13 @@ const DataViewer: React.FC<{ tab: TabData; isActive?: boolean }> = React.memo(({
 
     const dbName = tab.dbName || '';
     const tableName = tab.tableName || '';
+    if (dbTypeLower === 'rabbitmq' && tableName && !rabbitMQPreviewConfirmedRef.current) {
+        const approved = await ensureRabbitMQPreviewConfirmed(tableName);
+        if (!approved || fetchSeqRef.current !== seq) {
+            if (fetchSeqRef.current === seq) setLoading(false);
+            return;
+        }
+    }
     const isMongoDB = dbTypeLower === 'mongodb';
     let mongoFilter: Record<string, unknown> | undefined;
     if (isMongoDB) {
@@ -1249,7 +1277,7 @@ const DataViewer: React.FC<{ tab: TabData; isActive?: boolean }> = React.memo(({
         });
     }
     if (fetchSeqRef.current === seq) setLoading(false);
-  }, [connections, tab, sortInfo, filterConditions, quickWhereCondition, pkColumns, editLocator, forceReadOnly, pagination.total, pagination.totalKnown, pagination.totalApprox, pagination.approximateTotal, preferManualTotalCount, supportsApproximateTableCount, supportsApproximateTotalPages, tr]);
+  }, [connections, ensureRabbitMQPreviewConfirmed, tab, sortInfo, filterConditions, quickWhereCondition, pkColumns, editLocator, forceReadOnly, pagination.total, pagination.totalKnown, pagination.totalApprox, pagination.approximateTotal, preferManualTotalCount, supportsApproximateTableCount, supportsApproximateTotalPages, tr]);
   // 依赖定位列：在无手动排序时可回退到安全定位列稳定排序。
   // 定位信息只会在表上下文变化后重新加载，避免循环查询。
 

--- a/frontend/src/utils/rabbitmqPreview.ts
+++ b/frontend/src/utils/rabbitmqPreview.ts
@@ -1,0 +1,36 @@
+import { t as defaultTranslate, type I18nParams } from '../i18n';
+
+type Translate = (key: string, params?: I18nParams) => string;
+
+export type RabbitMQPreviewConfirmOptions = {
+  queue?: string;
+  translate?: Translate;
+};
+
+export const confirmRabbitMQPreview = async ({
+  queue,
+  translate = defaultTranslate,
+}: RabbitMQPreviewConfirmOptions = {}): Promise<boolean> => {
+  const { default: Modal } = await import('../components/common/ResizableDraggableModal');
+  const targetQueue = String(queue || '').trim();
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (approved: boolean) => {
+      if (settled) return;
+      settled = true;
+      resolve(approved);
+    };
+
+    Modal.confirm({
+      title: translate('data_viewer.message.rabbitmq_preview_title'),
+      content: translate('data_viewer.message.rabbitmq_preview_warning', { queue: targetQueue }),
+      okText: translate('common.continue'),
+      cancelText: translate('common.cancel'),
+      autoFocusButton: 'cancel',
+      onOk: () => settle(true),
+      onCancel: () => settle(false),
+      afterClose: () => settle(false),
+    });
+  });
+};

--- a/internal/db/rabbitmq_impl_test.go
+++ b/internal/db/rabbitmq_impl_test.go
@@ -173,6 +173,9 @@ func TestRabbitMQQueryExecAndColumns(t *testing.T) {
 				t.Fatalf("decode get body failed: %v", err)
 			}
 			lastGetCount = intFromAny(body["count"], 0)
+			if body["ackmode"] != "ack_requeue_true" {
+				t.Fatalf("expected RabbitMQ preview to use ack_requeue_true, got %#v", body["ackmode"])
+			}
 			_ = json.NewEncoder(w).Encode([]map[string]interface{}{
 				{
 					"exchange":         "events.topic",

--- a/shared/i18n/de-DE.json
+++ b/shared/i18n/de-DE.json
@@ -5210,6 +5210,8 @@
   "data_viewer.message.mongo_filter_invalid_detail": "MongoDB-Filterbedingung ist ungültig: {{detail}}",
   "data_viewer.message.mongo_filter_parse_failed": "Analyse fehlgeschlagen",
   "data_viewer.message.query_failed": "Abfrage fehlgeschlagen",
+  "data_viewer.message.rabbitmq_preview_title": "Die RabbitMQ-Vorschau kann Nachrichten erneut in die Warteschlange stellen",
+  "data_viewer.message.rabbitmq_preview_warning": "Die RabbitMQ-Vorschau verwendet ack_requeue_true für die Warteschlange {{queue}}. Nachrichten werden abgerufen und erneut eingereiht, wodurch sie als redelivered markiert werden und sich die Reihenfolge der Warteschlange ändern kann. Auch aktive Verbraucher können betroffen sein. Vorschau fortsetzen?",
   "data_viewer.message.query_timeout": "Die Abfrage hat das Verbindungstimeout überschritten und wurde unterbrochen. Erhöhen Sie das Verbindungstimeout oder verkleinern Sie den Abfragebereich und versuchen Sie es erneut.",
   "data_viewer.message.result_not_ready": "Die aktuelle Ergebnismenge ist noch nicht bereit. Laden Sie zuerst einmal Daten.",
   "data_viewer.message.sort_buffer_retry_succeeded": "Der Sortierpuffer wurde automatisch erhöht und die Abfrage erfolgreich erneut ausgeführt.",

--- a/shared/i18n/en-US.json
+++ b/shared/i18n/en-US.json
@@ -5210,6 +5210,8 @@
   "data_viewer.message.mongo_filter_invalid_detail": "MongoDB filter condition is invalid: {{detail}}",
   "data_viewer.message.mongo_filter_parse_failed": "Failed to parse",
   "data_viewer.message.query_failed": "Query failed",
+  "data_viewer.message.rabbitmq_preview_title": "RabbitMQ preview may requeue messages",
+  "data_viewer.message.rabbitmq_preview_warning": "RabbitMQ preview uses ack_requeue_true for queue {{queue}}. Messages are fetched and requeued, which may mark them as redelivered and affect queue order. Active consumers may also be affected. Continue?",
   "data_viewer.message.query_timeout": "Query exceeded the connection timeout and was interrupted. Increase the connection timeout, or reduce the query scope and retry.",
   "data_viewer.message.result_not_ready": "Current result set is not ready. Load data once first.",
   "data_viewer.message.sort_buffer_retry_succeeded": "Increased the sort buffer automatically, and the query succeeded.",

--- a/shared/i18n/ja-JP.json
+++ b/shared/i18n/ja-JP.json
@@ -5210,6 +5210,8 @@
   "data_viewer.message.mongo_filter_invalid_detail": "MongoDB のフィルター条件が無効です: {{detail}}",
   "data_viewer.message.mongo_filter_parse_failed": "解析に失敗しました",
   "data_viewer.message.query_failed": "クエリに失敗しました",
+  "data_viewer.message.rabbitmq_preview_title": "RabbitMQ のプレビューではメッセージが再キューされる可能性があります",
+  "data_viewer.message.rabbitmq_preview_warning": "RabbitMQ のキュー {{queue}} のプレビューでは ack_requeue_true を使用します。メッセージは取得後に再キューされるため、redelivered としてマークされたり、キューの順序に影響したりする可能性があります。実行中のコンシューマーも影響を受ける場合があります。プレビューを続行しますか？",
   "data_viewer.message.query_timeout": "クエリが接続タイムアウトを超えたため中断されました。接続タイムアウトを延長するか、クエリ範囲を絞って再試行してください。",
   "data_viewer.message.result_not_ready": "現在の結果セットはまだ準備できていません。先に一度データを読み込んでください。",
   "data_viewer.message.sort_buffer_retry_succeeded": "ソートバッファを自動的に増やして再試行し、クエリに成功しました。",

--- a/shared/i18n/ru-RU.json
+++ b/shared/i18n/ru-RU.json
@@ -5210,6 +5210,8 @@
   "data_viewer.message.mongo_filter_invalid_detail": "Недопустимое условие фильтра MongoDB: {{detail}}",
   "data_viewer.message.mongo_filter_parse_failed": "Не удалось разобрать",
   "data_viewer.message.query_failed": "Ошибка запроса",
+  "data_viewer.message.rabbitmq_preview_title": "Предпросмотр RabbitMQ может повторно поставить сообщения в очередь",
+  "data_viewer.message.rabbitmq_preview_warning": "Предпросмотр очереди RabbitMQ {{queue}} использует ack_requeue_true. Сообщения извлекаются и возвращаются в очередь, из-за чего могут быть помечены как redelivered и может измениться порядок сообщений. Активные потребители также могут быть затронуты. Продолжить предпросмотр?",
   "data_viewer.message.query_timeout": "Запрос превысил тайм-аут подключения и был прерван. Увеличьте тайм-аут подключения или сократите область запроса и повторите попытку.",
   "data_viewer.message.result_not_ready": "Текущий набор результатов еще не готов. Сначала загрузите данные один раз.",
   "data_viewer.message.sort_buffer_retry_succeeded": "Буфер сортировки был автоматически увеличен, повторный запрос выполнен успешно.",

--- a/shared/i18n/zh-CN.json
+++ b/shared/i18n/zh-CN.json
@@ -5210,6 +5210,8 @@
   "data_viewer.message.mongo_filter_invalid_detail": "Mongo 筛选条件无效：{{detail}}",
   "data_viewer.message.mongo_filter_parse_failed": "解析失败",
   "data_viewer.message.query_failed": "查询失败",
+  "data_viewer.message.rabbitmq_preview_title": "RabbitMQ 预览可能重新入队消息",
+  "data_viewer.message.rabbitmq_preview_warning": "RabbitMQ 预览队列 {{queue}} 使用 ack_requeue_true。消息会被取出后重新入队，可能被标记为 redelivered 并影响队列顺序；正在运行的消费者也可能受到影响。确定继续预览吗？",
   "data_viewer.message.query_timeout": "查询超过连接超时时间，已中断。请调大连接超时时间，或减少查询范围后重试。",
   "data_viewer.message.result_not_ready": "当前结果集尚未就绪，请先执行一次加载",
   "data_viewer.message.sort_buffer_retry_succeeded": "已自动提升排序缓冲并重试成功。",

--- a/shared/i18n/zh-TW.json
+++ b/shared/i18n/zh-TW.json
@@ -5210,6 +5210,8 @@
   "data_viewer.message.mongo_filter_invalid_detail": "Mongo 篩選條件無效：{{detail}}",
   "data_viewer.message.mongo_filter_parse_failed": "解析失敗",
   "data_viewer.message.query_failed": "查詢失敗",
+  "data_viewer.message.rabbitmq_preview_title": "RabbitMQ 預覽可能會重新排入訊息",
+  "data_viewer.message.rabbitmq_preview_warning": "RabbitMQ 預覽佇列 {{queue}} 使用 ack_requeue_true。訊息會被取出後重新排入，可能被標記為 redelivered 並影響佇列順序；正在執行的消費者也可能受到影響。確定要繼續預覽嗎？",
   "data_viewer.message.query_timeout": "查詢超過連線逾時時間，已中斷。請調高連線逾時時間，或縮小查詢範圍後再試。",
   "data_viewer.message.result_not_ready": "目前結果集尚未就緒，請先執行一次載入",
   "data_viewer.message.sort_buffer_retry_succeeded": "已自動提升排序緩衝並重試成功。",


### PR DESCRIPTION
## Summary

- warn before RabbitMQ queue message preview because the backend uses `ack_requeue_true`
- let users cancel before any message request is sent, and remember confirmation for reloads in the same queue view
- add localized warning copy and regression coverage

Fixes #1052

## Validation

- `npm test -- --run src/components/DataViewer.primary-key.test.tsx src/utils/objectQueryTemplates.test` — 48 passed
- `NODE_OPTIONS=--localstorage-file=/tmp/gonavi-issue-1052-localstorage.json npm test -- --run` — 509 files, 4430 tests passed
- `npx tsc --noEmit` — passed
- `npx vite build --logLevel error` — passed
- `GOTOOLCHAIN=auto GOCACHE=/tmp/gonavi-issue-1052-go-cache go test ./... -count=1 -timeout=30m` — all packages passed except 3 JVM fixture tests requiring a local JDK; the relevant `internal/db` and `internal/sync` packages passed
- `npm run i18n:scan` and i18n integrity tests — passed (scanner reports existing raw-string findings with exit code 0)

The repository does not currently contain a browser E2E harness; the RabbitMQ object-entry flow is covered by the DataViewer integration regression tests.