### PR TITLE
✨ feat(query): SQL选表自动补全表别名

### DIFF
--- a/frontend/src/components/QueryEditor.external-sql-save.test.tsx
+++ b/frontend/src/components/QueryEditor.external-sql-save.test.tsx
@@ -3948,7 +3948,7 @@ describe('QueryEditor external SQL save', () => {
       { lineNumber: 1, column: editorState.value.length + 1 },
     );
     const uppercaseTable = uppercaseTableResult.suggestions.find((item: any) => item.label === 'a_cninfo_announcement');
-    expect(uppercaseTable?.insertText).toBe('a_cninfo_announcement');
+    expect(uppercaseTable?.insertText).toBe('a_cninfo_announcement aca');
 
     editorState.value = 'SELECT * FROM users WHERE sh';
     editorState.latestOnChange?.(editorState.value);
@@ -3968,6 +3968,64 @@ describe('QueryEditor external SQL save', () => {
     );
     const columnSubstringLabels = columnSubstringResult.suggestions.map((item: any) => item.label);
     expect(columnSubstringLabels).toContain('emp_code');
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  it('adds deterministic aliases to table source completions and resolves conflicts', async () => {
+    let renderer!: ReactTestRenderer;
+    autoFetchState.visible = true;
+    storeState.connections[0].config.database = 'main';
+    backendApp.DBGetDatabases.mockResolvedValueOnce({ success: true, data: [{ Database: 'main' }] });
+    backendApp.DBGetTables.mockResolvedValueOnce({
+      success: true,
+      data: [
+        { Tables_in_main: 'system_user' },
+        { Tables_in_main: 'code_query_record_zykj' },
+      ],
+    });
+    backendApp.DBGetAllColumns.mockResolvedValueOnce({ success: true, data: [] });
+
+    await act(async () => {
+      renderer = create(<QueryEditor tab={createTab({ query: '', dbName: 'main' })} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const sqlProvider = findSqlCompletionProvider();
+    expect(sqlProvider).toBeTruthy();
+
+    editorState.value = 'SELECT * FROM system_user su JOIN sys';
+    editorState.latestOnChange?.(editorState.value);
+    const conflictResult = await sqlProvider.provideCompletionItems(
+      editorState.editor.getModel(),
+      { lineNumber: 1, column: editorState.value.length + 1 },
+    );
+    expect(conflictResult.suggestions.find((item: any) => item.label === 'system_user')?.insertText)
+      .toBe('system_user su2');
+
+    editorState.value = 'SELECT * FROM code';
+    editorState.latestOnChange?.(editorState.value);
+    const initialsResult = await sqlProvider.provideCompletionItems(
+      editorState.editor.getModel(),
+      { lineNumber: 1, column: editorState.value.length + 1 },
+    );
+    expect(initialsResult.suggestions.find((item: any) => item.label === 'code_query_record_zykj')?.insertText)
+      .toBe('code_query_record_zykj cqrz');
+
+    editorState.value = 'INSERT INTO system';
+    editorState.latestOnChange?.(editorState.value);
+    const insertResult = await sqlProvider.provideCompletionItems(
+      editorState.editor.getModel(),
+      { lineNumber: 1, column: editorState.value.length + 1 },
+    );
+    expect(insertResult.suggestions.find((item: any) => item.label === 'system_user')?.insertText)
+      .toBe('system_user');
 
     await act(async () => {
       renderer.unmount();
@@ -4325,7 +4383,7 @@ describe('QueryEditor external SQL save', () => {
     const result = await sqlProvider.provideCompletionItems(editorState.editor.getModel(), { lineNumber: 1, column: editorState.value.length + 1 });
     const match = result.suggestions.find((item: any) => item.label === 'MyTable');
 
-    expect(match?.insertText).toBe('"MyTable"');
+    expect(match?.insertText).toBe('"MyTable" mt');
 
     await act(async () => {
       renderer.unmount();
@@ -4358,7 +4416,7 @@ describe('QueryEditor external SQL save', () => {
     const result = await sqlProvider.provideCompletionItems(editorState.editor.getModel(), { lineNumber: 1, column: editorState.value.length + 1 });
     const match = result.suggestions.find((item: any) => item.label === 'MyTable');
 
-    expect(match?.insertText).toBe('"MyTable"');
+    expect(match?.insertText).toBe('"MyTable" mt');
 
     await act(async () => {
       renderer.unmount();
@@ -8539,7 +8597,7 @@ describe('QueryEditor external SQL save', () => {
       const tableSuggestion = completionItems?.suggestions?.find((item: any) => item?.label === 'AAA3_NJ');
 
       expect(tableSuggestion).toBeTruthy();
-      expect(tableSuggestion.insertText).toBe('AAA3_NJ');
+      expect(tableSuggestion.insertText).toBe('AAA3_NJ an');
       expect(tableSuggestion.detail).toContain('表 (sbdev)');
       expect(completionItems?.suggestions?.some((item: any) => item?.label === 'sbdev.SBDEV.AAA3_NJ')).toBe(false);
     });

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -187,6 +187,7 @@ import {
     buildCompletionTriggersMetadataQuerySpecs,
     buildCompletionViewsMetadataQuerySpecs,
     buildQueryEditorAliasMap,
+    buildQueryEditorTableSourceAlias,
     buildQueryEditorHoverMarkdown,
     buildQueryEditorResultSetMergeKey,
     buildQualifiedCompletionName,
@@ -209,6 +210,7 @@ import {
     getQueryEditorObjectResolveText,
     getTabQueryValue,
     isOracleBaseTableReference,
+    isQueryEditorTableAliasCompletionContext,
     isQueryEditorTableSourceCompletionContext,
     isDocumentLevelShortcutTarget,
     isQueryEditorPrimaryMouseButton,
@@ -6786,6 +6788,13 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
               const completionScopeText = currentStatementPrefix || linePrefix;
               const currentStatementText = currentStatementRange?.text || '';
               const completionReferenceText = currentStatementText || completionScopeText;
+              const isTableSourceCompletion = isQueryEditorTableSourceCompletionContext(completionScopeText);
+              const isTableAliasCompletion = isQueryEditorTableAliasCompletionContext(completionScopeText);
+              const appendTableSourceAlias = (insertText: string, tableName: string) => {
+                  if (!isTableAliasCompletion) return insertText;
+                  const alias = buildQueryEditorTableSourceAlias(tableName, completionReferenceText);
+                  return alias ? `${insertText} ${alias}` : insertText;
+              };
 
               // 0) 三段式 db.table.column 格式：当输入 db.table. 时提示列
               const threePartMatch = linePrefix.match(QUERY_EDITOR_SQL_THREE_PART_COMPLETION_REGEX);
@@ -6861,7 +6870,10 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                                       [meta.displayName, table.tableName],
                                   ),
                                   kind: monaco.languages.CompletionItemKind.Class,
-                                  insertText: quoteCompletionPath(applyCompletionFragmentCase(meta.insertName, rawPrefix)),
+                                  insertText: appendTableSourceAlias(
+                                      quoteCompletionPath(applyCompletionFragmentCase(meta.insertName, rawPrefix)),
+                                      meta.insertName,
+                                  ),
                                   detail: appendCommentToDetail(`${translate('query_editor.object_info.table')} (${table.dbName})`, table.comment),
                                   documentation: buildCompletionDocumentation(table.comment),
                                   range,
@@ -6972,7 +6984,10 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                                   [parsed.table, table.tableName],
                               ),
                               kind: monaco.languages.CompletionItemKind.Class,
-                              insertText: quoteCompletionPart(applyCompletionFragmentCase(parsed.table, rawPrefix)),
+                              insertText: appendTableSourceAlias(
+                                  quoteCompletionPart(applyCompletionFragmentCase(parsed.table, rawPrefix)),
+                                  parsed.table,
+                              ),
                               detail: appendCommentToDetail(`${translate('query_editor.object_info.table')} (${table.dbName}${parsed.schema ? '.' + parsed.schema : ''})`, table.comment),
                               documentation: buildCompletionDocumentation(table.comment),
                               range,
@@ -7107,7 +7122,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                   const matchRank = rankQueryEditorCompletionCandidate(wordPrefix, candidates);
                   return matchRank === null ? '9' : String(matchRank);
               };
-              const expectsTableName = isQueryEditorTableSourceCompletionContext(completionScopeText)
+              const expectsTableName = isTableSourceCompletion
                   || /\b(?:TABLE|DESCRIBE|DESC|EXPLAIN)\s+[`"]?[\w.]*$/i.test(linePrefix);
               const expectsRoutineName = /\bCALL\s+[`"]?[\w.]*$/i.test(linePrefix);
               const matchesKeywordPrefix = wordPrefix.length > 0
@@ -7291,7 +7306,10 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                                   [label, table.tableName || '', pureTable],
                               ),
                               kind: monaco.languages.CompletionItemKind.Class,
-                              insertText: quoteCompletionPath(applyCompletionFragmentCase(label, rawWordPrefix)),
+                              insertText: appendTableSourceAlias(
+                                  quoteCompletionPath(applyCompletionFragmentCase(label, rawWordPrefix)),
+                                  table.tableName || label,
+                              ),
                               detail: appendCommentToDetail(`${translate('query_editor.object_info.table')} (${table.dbName})`, table.comment),
                               documentation: buildCompletionDocumentation(table.comment),
                               range,
@@ -7310,10 +7328,13 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                               [label, table.tableName || '', pureTable],
                           ),
                           kind: monaco.languages.CompletionItemKind.Class,
-                          insertText: quoteCompletionPath(applyCompletionFragmentCase(
-                              hasDuplicate ? table.tableName : pureTable,
-                              rawWordPrefix,
-                          )),
+                          insertText: appendTableSourceAlias(
+                              quoteCompletionPath(applyCompletionFragmentCase(
+                                  hasDuplicate ? table.tableName : pureTable,
+                                  rawWordPrefix,
+                              )),
+                              pureTable,
+                          ),
                           detail: appendCommentToDetail(`${translate('query_editor.object_info.table')}${schemaInfo}`, table.comment),
                           documentation: buildCompletionDocumentation(table.comment),
                           range,

--- a/frontend/src/components/queryEditor/QueryEditorAiAssist.test.ts
+++ b/frontend/src/components/queryEditor/QueryEditorAiAssist.test.ts
@@ -648,13 +648,13 @@ describe('QueryEditorAiAssist', () => {
                 columns: [{ dbName: 'shop', tableName: 'users', name: 'id', type: 'bigint' }],
             },
             editorSnapshot: {
-                prefix: 'select * from users ',
+                prefix: 'select * from users where id ',
                 suffix: '',
-                currentLineBeforeCursor: 'select * from users ',
+                currentLineBeforeCursor: 'select * from users where id ',
                 currentLineAfterCursor: '',
             },
         });
-        expect(insertText).toBe('where id > 1;');
+        expect(insertText).toBe('> 1;');
         expect(service.AIChatSend).toHaveBeenCalledTimes(1);
 
         const missingProvider = await resolveQueryEditorAiRuntimeReadiness({
@@ -682,9 +682,9 @@ describe('QueryEditorAiAssist', () => {
                 columns: [],
             },
             editorSnapshot: {
-                prefix: 'select * from users ',
+                prefix: 'select * from users where id ',
                 suffix: '',
-                currentLineBeforeCursor: 'select * from users ',
+                currentLineBeforeCursor: 'select * from users where id ',
                 currentLineAfterCursor: '',
             },
         };
@@ -720,6 +720,45 @@ describe('QueryEditorAiAssist', () => {
         });
 
         expect(insertText).toBe('eos');
+        expect(service.AIChatSend).not.toHaveBeenCalled();
+        expect(service.AIGetProviders).not.toHaveBeenCalled();
+        expect(service.AIGetActiveProvider).not.toHaveBeenCalled();
+    });
+
+    it('suggests an alias after a manually completed table source and skips AI', async () => {
+        const service = readyService('SELECT * FROM system_user su;');
+        const request = {
+            service,
+            aiContext: {
+                connectionName: 'Local MySQL',
+                sourceType: 'mysql',
+                currentDb: 'shop',
+                tables: [
+                    { dbName: 'shop', tableName: 'system_user' },
+                    { dbName: 'shop', tableName: 'service_user' },
+                ],
+                columns: [],
+            },
+        };
+
+        await expect(requestQueryEditorInlineCompletion({
+            ...request,
+            editorSnapshot: {
+                prefix: 'SELECT * FROM system_user ',
+                suffix: '',
+                currentLineBeforeCursor: 'SELECT * FROM system_user ',
+                currentLineAfterCursor: '',
+            },
+        })).resolves.toBe('su');
+        await expect(requestQueryEditorInlineCompletion({
+            ...request,
+            editorSnapshot: {
+                prefix: 'SELECT * FROM system_user su JOIN service_user ',
+                suffix: '',
+                currentLineBeforeCursor: 'SELECT * FROM system_user su JOIN service_user ',
+                currentLineAfterCursor: '',
+            },
+        })).resolves.toBe('su2');
         expect(service.AIChatSend).not.toHaveBeenCalled();
         expect(service.AIGetProviders).not.toHaveBeenCalled();
         expect(service.AIGetActiveProvider).not.toHaveBeenCalled();
@@ -990,15 +1029,15 @@ describe('QueryEditorAiAssist', () => {
                 columns: [{ dbName: 'shop', tableName: 'users', name: 'id', type: 'bigint' }],
             },
             editorSnapshot: {
-                prefix: 'select * from users ',
+                prefix: 'select * from users where id ',
                 suffix: '',
-                currentLineBeforeCursor: 'select * from users ',
+                currentLineBeforeCursor: 'select * from users where id ',
                 currentLineAfterCursor: '',
             },
         });
 
         expect(resolveQueryEditorInlineCompletionModel((await service.AIGetProviders())[0])).toBe('gpt-5-mini');
-        expect(insertText).toBe('where id = 1;');
+        expect(insertText).toBe('= 1;');
         expect(service.AIChatSend).not.toHaveBeenCalled();
         expect(service.AIChatSendWithOptions).toHaveBeenCalledWith(expect.any(Array), [], {
             model: 'gpt-5-mini',
@@ -1023,9 +1062,9 @@ describe('QueryEditorAiAssist', () => {
                 columns: [{ dbName: 'shop', tableName: 'users', name: 'id', type: 'bigint' }],
             },
             editorSnapshot: {
-                prefix: 'select * from users ',
+                prefix: 'select * from users where id ',
                 suffix: '',
-                currentLineBeforeCursor: 'select * from users ',
+                currentLineBeforeCursor: 'select * from users where id ',
                 currentLineAfterCursor: '',
             },
         });
@@ -1055,14 +1094,14 @@ describe('QueryEditorAiAssist', () => {
                 columns: [{ dbName: 'shop', tableName: 'videos', name: 'code', type: 'varchar' }],
             },
             editorSnapshot: {
-                prefix: 'select * from videos ',
+                prefix: 'select * from videos where code ',
                 suffix: '',
-                currentLineBeforeCursor: 'select * from videos ',
+                currentLineBeforeCursor: 'select * from videos where code ',
                 currentLineAfterCursor: '',
             },
         });
 
-        expect(insertText).toBe('WHERE code IS NOT NULL;');
+        expect(insertText).toBe('IS NOT NULL;');
     });
 
     it('drops inline completions that introduce tables outside the selected database context', async () => {
@@ -1081,9 +1120,9 @@ describe('QueryEditorAiAssist', () => {
                 columns: [{ dbName: 'shop', tableName: 'videos', name: 'code', type: 'varchar' }],
             },
             editorSnapshot: {
-                prefix: 'select * from videos ',
+                prefix: 'select * from videos where code ',
                 suffix: '',
-                currentLineBeforeCursor: 'select * from videos ',
+                currentLineBeforeCursor: 'select * from videos where code ',
                 currentLineAfterCursor: '',
             },
         });

--- a/frontend/src/components/queryEditor/QueryEditorAiAssist.ts
+++ b/frontend/src/components/queryEditor/QueryEditorAiAssist.ts
@@ -8,6 +8,9 @@ import type {
 } from './QueryEditorHelpers';
 import {
     buildQueryEditorAliasMap,
+    buildQueryEditorTableSourceAlias,
+    collectQueryEditorTableReferences,
+    isQueryEditorTableAliasCompletionContext,
 } from './QueryEditorHelpers';
 import { isPostgresSchemaDialect } from '../../utils/connectionDriverType';
 
@@ -366,6 +369,14 @@ export const resolveQueryEditorInlineLocalCompletion = ({
         return {
             handled: true,
             insertText: '',
+        };
+    }
+
+    const tableAliasInsertText = resolveDeterministicInlineTableAliasInsertText(editorSnapshot);
+    if (tableAliasInsertText) {
+        return {
+            handled: true,
+            insertText: tableAliasInsertText,
         };
     }
 
@@ -1468,6 +1479,21 @@ const resolveDeterministicInlineTableInsertText = (
         normalizeInlineIdentifierPath(fragment),
         isPostgresSchemaDialect(context.sourceType || ''),
     );
+};
+
+const resolveDeterministicInlineTableAliasInsertText = (
+    editorSnapshot: QueryEditorAiEditorSnapshot,
+): string => {
+    const statementPrefix = getCurrentStatementPrefix(editorSnapshot.prefix);
+    if (!/\s$/.test(statementPrefix) || !isQueryEditorTableAliasCompletionContext(statementPrefix)) {
+        return '';
+    }
+    const references = collectQueryEditorTableReferences(statementPrefix);
+    const currentReference = references[references.length - 1];
+    if (!currentReference || currentReference.alias) {
+        return '';
+    }
+    return buildQueryEditorTableSourceAlias(currentReference.tableIdent, statementPrefix);
 };
 
 const resolveDeterministicInlineColumnInsertText = (

--- a/frontend/src/components/queryEditor/QueryEditorHelpers.test.ts
+++ b/frontend/src/components/queryEditor/QueryEditorHelpers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
     buildBoundedQueryEditorCompletionSuggestions,
     buildQueryEditorAliasMap,
+    buildQueryEditorTableSourceAlias,
     buildQueryEditorResultSetMergeKey,
     collectQueryEditorReferencedDatabaseNames,
     collectQueryEditorTableReferences,
@@ -11,6 +12,7 @@ import {
     getCompletionTableSchemaCounts,
     isSystemMetadataQueryResult,
     isOracleBaseTableReference,
+    isQueryEditorTableAliasCompletionContext,
     isQueryEditorTableSourceCompletionContext,
     materializeBoundedQueryEditorCompletionBatches,
     rankQueryEditorCompletionCandidate,
@@ -345,6 +347,18 @@ describe('QueryEditorHelpers Oracle-like execution schema', () => {
 });
 
 describe('QueryEditorHelpers qualified navigation (MySQL db.table + PG schema.table)', () => {
+    it('generates table source aliases from name initials and resolves collisions', () => {
+        expect(buildQueryEditorTableSourceAlias('system_user', '')).toBe('su');
+        expect(buildQueryEditorTableSourceAlias('code_query_record_zykj', '')).toBe('cqrz');
+        expect(buildQueryEditorTableSourceAlias('public.system_user', 'SELECT * FROM system_user su')).toBe('su2');
+        expect(buildQueryEditorTableSourceAlias('system_user', 'SELECT * FROM system_user su JOIN service_user su2')).toBe('su3');
+    });
+
+    it('only permits table aliases for non-insert table sources', () => {
+        expect(isQueryEditorTableAliasCompletionContext('SELECT * FROM system_user ')).toBe(true);
+        expect(isQueryEditorTableAliasCompletionContext('INSERT INTO system_user ')).toBe(false);
+    });
+
     it('keeps a dotted Dameng owner intact when metadata already identifies it', () => {
         expect(splitCompletionSchemaAndTable(
             'PEM2.4_V1_1.COM_APPROVE_INFO',

--- a/frontend/src/components/queryEditor/QueryEditorHelpers.ts
+++ b/frontend/src/components/queryEditor/QueryEditorHelpers.ts
@@ -2235,6 +2235,14 @@ export const isQueryEditorTableSourceCompletionContext = (source: string): boole
     analyzeQueryEditorTableReferences(source).expectsTableSource
 );
 
+export const isQueryEditorTableAliasCompletionContext = (source: string): boolean => {
+    if (!isQueryEditorTableSourceCompletionContext(source)) {
+        return false;
+    }
+    return !/\b(?:INSERT|REPLACE)\s+INTO\s+(?:[`"\[]?[A-Za-z_][\w$]*[`"\]]?\s*\.\s*){0,2}[`"\[]?[A-Za-z_][\w$]*[`"\]]?\s*$/i
+        .test(source);
+};
+
 export const buildQueryEditorAliasMap = (
     fullText: string,
     currentDb: string,
@@ -2266,6 +2274,34 @@ export const buildQueryEditorAliasMap = (
         aliasMap[alias.toLowerCase()] = aliasTarget;
     }
     return aliasMap;
+};
+
+/**
+ * 为 SQL 表源生成简短别名。仅使用表名本身的单词首字母，避免将数据库或 schema
+ * 混入别名；同一语句中已使用的别名会依次追加数字。
+ */
+export const buildQueryEditorTableSourceAlias = (tableName: string, statementText: string): string => {
+    const table = getCompletionQualifiedNameLastPart(tableName);
+    const baseAlias = table
+        .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+        .split(/[^A-Za-z0-9$]+/)
+        .filter((word) => /^[A-Za-z]/.test(word))
+        .map((word) => word[0].toLowerCase())
+        .join('');
+    if (!baseAlias) return '';
+
+    const usedAliases = new Set(
+        collectQueryEditorTableReferences(statementText)
+            .map((reference) => String(reference.alias || '').trim().toLowerCase())
+            .filter(Boolean),
+    );
+    if (!usedAliases.has(baseAlias)) return baseAlias;
+
+    let suffix = 2;
+    while (usedAliases.has(`${baseAlias}${suffix}`)) {
+        suffix += 1;
+    }
+    return `${baseAlias}${suffix}`;
 };
 
 /**


### PR DESCRIPTION
## 问题背景

SQL 编辑器通过候选列表选择表名或手工输入完整表名后，不会自动补全表别名，多表关联时需要重复手工编写别名。

## 修复内容

- 在 FROM、JOIN 等表源补全中按表名各单词首字母追加别名，例如 `system_user` 生成 `su`、`code_query_record_zykj` 生成 `cqrz`。
- 同一语句中别名冲突时从 `2` 开始递增，例如 `su`、`su2`、`su3`。
- 手工输入完整表名并键入空格后提供确定性内联别名提示，可通过现有快捷键接受。
- 保持 INSERT/REPLACE INTO 目标表不追加别名，避免生成无效 SQL。

## 验证方式

- `npm test -- src/components/queryEditor/QueryEditorHelpers.test.ts src/components/queryEditor/QueryEditorAiAssist.test.ts src/components/QueryEditor.external-sql-save.test.tsx`：405 项通过。
- `npm run build`：TypeScript 与 Vite 构建通过。
- 已构建 Windows 测试包并完成人工验证。

## 影响与风险

- 仅影响 SQL 编辑器表源补全与内联补全，不改变字段、视图和函数补全。
- 不会为 INSERT/REPLACE INTO 的目标表添加别名；若需回滚，移除表源别名补全逻辑即可恢复原插入文本。

## 关联 Issue

Closes #1064
