### PR TITLE
🐛 fix(query): 表别名补全使用 AS 语法

### DIFF
--- a/frontend/src/components/QueryEditor.external-sql-save.test.tsx
+++ b/frontend/src/components/QueryEditor.external-sql-save.test.tsx
@@ -3948,7 +3948,7 @@ describe('QueryEditor external SQL save', () => {
       { lineNumber: 1, column: editorState.value.length + 1 },
     );
     const uppercaseTable = uppercaseTableResult.suggestions.find((item: any) => item.label === 'a_cninfo_announcement');
-    expect(uppercaseTable?.insertText).toBe('a_cninfo_announcement aca');
+    expect(uppercaseTable?.insertText).toBe('a_cninfo_announcement AS aca');
 
     editorState.value = 'SELECT * FROM users WHERE sh';
     editorState.latestOnChange?.(editorState.value);
@@ -4007,7 +4007,7 @@ describe('QueryEditor external SQL save', () => {
       { lineNumber: 1, column: editorState.value.length + 1 },
     );
     expect(conflictResult.suggestions.find((item: any) => item.label === 'system_user')?.insertText)
-      .toBe('system_user su2');
+      .toBe('system_user AS su2');
 
     editorState.value = 'SELECT * FROM code';
     editorState.latestOnChange?.(editorState.value);
@@ -4016,7 +4016,7 @@ describe('QueryEditor external SQL save', () => {
       { lineNumber: 1, column: editorState.value.length + 1 },
     );
     expect(initialsResult.suggestions.find((item: any) => item.label === 'code_query_record_zykj')?.insertText)
-      .toBe('code_query_record_zykj cqrz');
+      .toBe('code_query_record_zykj AS cqrz');
 
     editorState.value = 'INSERT INTO system';
     editorState.latestOnChange?.(editorState.value);
@@ -4383,7 +4383,7 @@ describe('QueryEditor external SQL save', () => {
     const result = await sqlProvider.provideCompletionItems(editorState.editor.getModel(), { lineNumber: 1, column: editorState.value.length + 1 });
     const match = result.suggestions.find((item: any) => item.label === 'MyTable');
 
-    expect(match?.insertText).toBe('"MyTable" mt');
+    expect(match?.insertText).toBe('"MyTable" AS mt');
 
     await act(async () => {
       renderer.unmount();
@@ -4416,7 +4416,7 @@ describe('QueryEditor external SQL save', () => {
     const result = await sqlProvider.provideCompletionItems(editorState.editor.getModel(), { lineNumber: 1, column: editorState.value.length + 1 });
     const match = result.suggestions.find((item: any) => item.label === 'MyTable');
 
-    expect(match?.insertText).toBe('"MyTable" mt');
+    expect(match?.insertText).toBe('"MyTable" AS mt');
 
     await act(async () => {
       renderer.unmount();
@@ -8597,7 +8597,7 @@ describe('QueryEditor external SQL save', () => {
       const tableSuggestion = completionItems?.suggestions?.find((item: any) => item?.label === 'AAA3_NJ');
 
       expect(tableSuggestion).toBeTruthy();
-      expect(tableSuggestion.insertText).toBe('AAA3_NJ an');
+      expect(tableSuggestion.insertText).toBe('AAA3_NJ AS an');
       expect(tableSuggestion.detail).toContain('表 (sbdev)');
       expect(completionItems?.suggestions?.some((item: any) => item?.label === 'sbdev.SBDEV.AAA3_NJ')).toBe(false);
     });

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -6802,7 +6802,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
               const appendTableSourceAlias = (insertText: string, tableName: string) => {
                   if (!isTableAliasCompletion) return insertText;
                   const alias = buildQueryEditorTableSourceAlias(tableName, completionReferenceText);
-                  return alias ? `${insertText} ${alias}` : insertText;
+                  return alias ? `${insertText} AS ${alias}` : insertText;
               };
 
               // 0) 三段式 db.table.column 格式：当输入 db.table. 时提示列

--- a/frontend/src/components/queryEditor/QueryEditorAiAssist.test.ts
+++ b/frontend/src/components/queryEditor/QueryEditorAiAssist.test.ts
@@ -749,7 +749,7 @@ describe('QueryEditorAiAssist', () => {
                 currentLineBeforeCursor: 'SELECT * FROM system_user ',
                 currentLineAfterCursor: '',
             },
-        })).resolves.toBe('su');
+        })).resolves.toBe('AS su');
         await expect(requestQueryEditorInlineCompletion({
             ...request,
             editorSnapshot: {
@@ -758,7 +758,7 @@ describe('QueryEditorAiAssist', () => {
                 currentLineBeforeCursor: 'SELECT * FROM system_user su JOIN service_user ',
                 currentLineAfterCursor: '',
             },
-        })).resolves.toBe('su2');
+        })).resolves.toBe('AS su2');
         expect(service.AIChatSend).not.toHaveBeenCalled();
         expect(service.AIGetProviders).not.toHaveBeenCalled();
         expect(service.AIGetActiveProvider).not.toHaveBeenCalled();

--- a/frontend/src/components/queryEditor/QueryEditorAiAssist.ts
+++ b/frontend/src/components/queryEditor/QueryEditorAiAssist.ts
@@ -1493,7 +1493,8 @@ const resolveDeterministicInlineTableAliasInsertText = (
     if (!currentReference || currentReference.alias) {
         return '';
     }
-    return buildQueryEditorTableSourceAlias(currentReference.tableIdent, statementPrefix);
+    const alias = buildQueryEditorTableSourceAlias(currentReference.tableIdent, statementPrefix);
+    return alias ? `AS ${alias}` : '';
 };
 
 const resolveDeterministicInlineColumnInsertText = (


### PR DESCRIPTION
## 问题背景

#1064 的首个实现已合并，但表名补全和手动输入表名后的别名提示输出裸别名，未使用显式的 `AS` 语法。

## 修复内容

- 候选区选择表名时插入 `表名 AS 别名`。
- 手动输入完整表名并输入空格时提示 `AS 别名`。
- 保留多表别名冲突时追加数字的既有行为。
- 更新 MySQL、PostgreSQL、Oracle 和行内补全场景的回归断言。

## 验证方式

- `node node_modules/vitest/vitest.mjs run src/components/QueryEditor.external-sql-save.test.tsx src/components/queryEditor/QueryEditorAiAssist.test.ts`
- 362 项测试通过。
- 已构建 Windows 测试包并完成用户侧验证。

## 影响与风险

- 仅调整 SQL 编辑器生成的别名文本格式，写入场景仍不自动添加别名。
- 如需回滚，可撤销本提交，恢复原有裸别名输出。

## 关联 Issue

补充已关闭的 #1064。

Closes #1064
