### PR TITLE
✨ feat(navigation): 将编辑器与驱动提升至顶部导航

### DIFF
--- a/frontend/src/components/Sidebar.locate-toolbar.test.tsx
+++ b/frontend/src/components/Sidebar.locate-toolbar.test.tsx
@@ -942,6 +942,31 @@ describe('Sidebar locate toolbar', () => {
     expect(narrowLayoutCss).toMatch(/\.gn-v2-active-connection-actions\s*\{[^}]*(?:width|flex-basis):\s*100%;/s);
   });
 
+  it('places editor and driver tools after connection configuration instead of inside More', () => {
+    const source = readSourceFile('./Sidebar.tsx');
+    const actionsStart = source.indexOf('const v2TitlebarQuickActions: TitleBarQuickAction[] = [');
+    const actionsEnd = source.indexOf('\n  ];', actionsStart);
+
+    expect(actionsStart).toBeGreaterThanOrEqual(0);
+    expect(actionsEnd).toBeGreaterThan(actionsStart);
+
+    const actionsSource = source.slice(actionsStart, actionsEnd);
+    const connectionPackageIndex = actionsSource.indexOf("key: 'connection-package'");
+    const workspaceIndex = actionsSource.indexOf("key: 'settings-workspace'");
+    const aboutIndex = actionsSource.indexOf("key: 'settings-about'", workspaceIndex);
+
+    expect(connectionPackageIndex).toBeGreaterThanOrEqual(0);
+    expect(workspaceIndex).toBeGreaterThan(connectionPackageIndex);
+    expect(aboutIndex).toBeGreaterThan(workspaceIndex);
+
+    const workspaceSource = actionsSource.slice(workspaceIndex, aboutIndex);
+    expect(workspaceSource).not.toContain("priority: 'secondary'");
+    expect(workspaceSource).toContain("key: 'drivers'");
+    expect(workspaceSource).toContain("key: 'snippet-settings'");
+    expect(workspaceSource).toContain("key: 'shortcut-settings'");
+    expect(workspaceSource).toContain("key: 'sql-audit'");
+  });
+
   it('renders the fixed v2 rail, titlebar quick actions, explorer filters and workbench actions', () => {
     const markup = renderSidebarMarkup({ uiVersion: 'v2', onCreateConnection: mocks.noop });
     const source = readSidebarSource();

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -4059,7 +4059,6 @@ const Sidebar: React.FC<{
       key: 'settings-workspace',
       label: t('app.tools.group.workspace.title'),
       icon: <CodeOutlined aria-hidden="true" />,
-      priority: 'secondary',
       menu: [
         {
           key: 'drivers',


### PR DESCRIPTION
## 变更内容

- 将“编辑器与驱动”从“更多”菜单提升为顶部一级入口
- 将入口放置在“连接与配置”右侧、“更多”左侧
- 保留驱动、代码片段、快捷键和 SQL 审计的原有子菜单与点击行为
- 增加导航层级、排列顺序及子菜单完整性的回归测试

## 影响范围

- 仅调整 V2 顶部导航入口层级
- 不修改其他功能入口、业务逻辑或样式

## 验证结果

- TitleBarQuickActions.test.tsx 与 Sidebar.locate-toolbar.test.tsx：100 项测试通过
- TypeScript 类型检查通过
- git diff --check 通过