### PR TITLE
🐛 fix(metadata): 修复数据库枚举错误与 Mongo 索引元数据处理

### DIFF
--- a/internal/db/chroma_impl.go
+++ b/internal/db/chroma_impl.go
@@ -218,7 +218,7 @@ func (c *ChromaDB) GetDatabases() ([]string, error) {
 	var raw []map[string]interface{}
 	err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf("/api/v2/tenants/%s/databases", url.PathEscape(c.tenant)), nil, &raw)
 	if err != nil {
-		return []string{c.database}, nil
+		return nil, err
 	}
 	names := make([]string, 0, len(raw))
 	for _, item := range raw {

--- a/internal/db/chroma_impl_test.go
+++ b/internal/db/chroma_impl_test.go
@@ -126,6 +126,31 @@ func TestChromaGetDatabasesAndTablesV2(t *testing.T) {
 	}
 }
 
+func TestChromaGetDatabasesV2PropagatesHTTPFailure(t *testing.T) {
+	server := newMockChromaServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/heartbeat":
+			writeChromaJSON(w, map[string]interface{}{"ok": true})
+		case "/api/v2/tenants/default_tenant/databases":
+			http.Error(w, "database service unavailable", http.StatusServiceUnavailable)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	db := newTestChromaDB(t, server.URL)
+	dbs, err := db.GetDatabases()
+	if err == nil {
+		t.Fatalf("GetDatabases unexpectedly succeeded with databases %v", dbs)
+	}
+	if dbs != nil {
+		t.Fatalf("databases = %v, want nil on HTTP failure", dbs)
+	}
+	if !strings.Contains(err.Error(), "database service unavailable") {
+		t.Fatalf("GetDatabases error = %q, want server error context", err)
+	}
+}
+
 func TestChromaSelectConvertsToGetRows(t *testing.T) {
 	var capturedPath string
 	var capturedBody map[string]interface{}

--- a/internal/db/duckdb_getdatabases_test.go
+++ b/internal/db/duckdb_getdatabases_test.go
@@ -1,0 +1,17 @@
+//go:build gonavi_full_drivers || gonavi_duckdb_driver
+
+package db
+
+import "testing"
+
+func TestDuckDBGetDatabasesPropagatesQueryFailure(t *testing.T) {
+	db := &DuckDB{}
+
+	databases, err := db.GetDatabases()
+	if err == nil {
+		t.Fatalf("GetDatabases unexpectedly succeeded with databases %v", databases)
+	}
+	if databases != nil {
+		t.Fatalf("databases = %v, want nil on query failure", databases)
+	}
+}

--- a/internal/db/duckdb_impl.go
+++ b/internal/db/duckdb_impl.go
@@ -171,7 +171,7 @@ func (d *DuckDB) Exec(query string) (int64, error) {
 func (d *DuckDB) GetDatabases() ([]string, error) {
 	data, _, err := d.Query("PRAGMA database_list")
 	if err != nil {
-		return []string{"main"}, nil
+		return nil, err
 	}
 
 	seen := map[string]struct{}{}

--- a/internal/db/mongodb_cursor_decode_test.go
+++ b/internal/db/mongodb_cursor_decode_test.go
@@ -1,0 +1,118 @@
+//go:build gonavi_full_drivers || gonavi_mongodb_driver
+
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+type fakeMongoDecodeCursor struct {
+	documents    []any
+	decodeErrors map[int]error
+	cursorErr    error
+	nextIndex    int
+	currentIndex int
+}
+
+func (c *fakeMongoDecodeCursor) Next(context.Context) bool {
+	if c.nextIndex >= len(c.documents) {
+		return false
+	}
+	c.currentIndex = c.nextIndex
+	c.nextIndex++
+	return true
+}
+
+func (c *fakeMongoDecodeCursor) Decode(target any) error {
+	if err := c.decodeErrors[c.currentIndex]; err != nil {
+		return err
+	}
+	raw, err := bson.Marshal(c.documents[c.currentIndex])
+	if err != nil {
+		return err
+	}
+	return bson.Unmarshal(raw, target)
+}
+
+func (c *fakeMongoDecodeCursor) Err() error {
+	return c.cursorErr
+}
+
+func TestDecodeMongoFindCursorReturnsDecodeError(t *testing.T) {
+	decodeErr := errors.New("malformed document")
+	cursor := &fakeMongoDecodeCursor{
+		documents:    []any{bson.D{{Key: "_id", Value: 1}}},
+		decodeErrors: map[int]error{0: decodeErr},
+	}
+
+	rows, columns, err := decodeMongoFindCursor(context.Background(), cursor, false)
+	if !errors.Is(err, decodeErr) {
+		t.Fatalf("decodeMongoFindCursor error = %v, want %v", err, decodeErr)
+	}
+	if rows != nil || columns != nil {
+		t.Fatalf("decode failure returned partial result rows=%v columns=%v", rows, columns)
+	}
+}
+
+func TestDecodeMongoIndexCursorPreservesCompoundKeyOrder(t *testing.T) {
+	cursor := &fakeMongoDecodeCursor{documents: []any{
+		bson.D{
+			{Key: "name", Value: "tenant_slug_created"},
+			{Key: "unique", Value: true},
+			{Key: "key", Value: bson.D{
+				{Key: "tenant_id", Value: int32(1)},
+				{Key: "slug", Value: int32(-1)},
+				{Key: "created_at", Value: int32(1)},
+			}},
+		},
+	}}
+
+	indexes, err := decodeMongoIndexCursor(context.Background(), cursor)
+	if err != nil {
+		t.Fatalf("decodeMongoIndexCursor failed: %v", err)
+	}
+	if len(indexes) != 3 {
+		t.Fatalf("index rows = %d, want 3: %+v", len(indexes), indexes)
+	}
+	wantColumns := []string{"tenant_id", "slug", "created_at"}
+	for i, index := range indexes {
+		if index.Name != "tenant_slug_created" || index.ColumnName != wantColumns[i] || index.SeqInIndex != i+1 || index.NonUnique != 0 {
+			t.Fatalf("index row %d = %+v", i, index)
+		}
+	}
+}
+
+func TestDecodeMongoIndexCursorReturnsDecodeAndCursorErrors(t *testing.T) {
+	t.Run("decode error", func(t *testing.T) {
+		decodeErr := errors.New("malformed index")
+		cursor := &fakeMongoDecodeCursor{
+			documents:    []any{bson.D{{Key: "name", Value: "broken"}}},
+			decodeErrors: map[int]error{0: decodeErr},
+		}
+
+		indexes, err := decodeMongoIndexCursor(context.Background(), cursor)
+		if !errors.Is(err, decodeErr) {
+			t.Fatalf("decodeMongoIndexCursor error = %v, want %v", err, decodeErr)
+		}
+		if indexes != nil {
+			t.Fatalf("decode failure returned partial indexes: %+v", indexes)
+		}
+	})
+
+	t.Run("cursor error", func(t *testing.T) {
+		cursorErr := errors.New("cursor terminated")
+		cursor := &fakeMongoDecodeCursor{cursorErr: cursorErr}
+
+		indexes, err := decodeMongoIndexCursor(context.Background(), cursor)
+		if !errors.Is(err, cursorErr) {
+			t.Fatalf("decodeMongoIndexCursor error = %v, want %v", err, cursorErr)
+		}
+		if indexes != nil {
+			t.Fatalf("cursor failure returned partial indexes: %+v", indexes)
+		}
+	})
+}

--- a/internal/db/mongodb_impl.go
+++ b/internal/db/mongodb_impl.go
@@ -30,6 +30,18 @@ type MongoDB struct {
 	pingTimeout time.Duration
 }
 
+type mongoCursorDecoder interface {
+	Next(context.Context) bool
+	Decode(any) error
+	Err() error
+}
+
+type mongoIndexMetadata struct {
+	Name   any    `bson:"name"`
+	Key    bson.D `bson:"key"`
+	Unique bool   `bson:"unique"`
+}
+
 type mongoProxyDialer struct {
 	proxyConfig connection.ProxyConfig
 }
@@ -968,14 +980,19 @@ func (m *MongoDB) execFind(ctx context.Context, cmd bson.D) ([]map[string]interf
 		return nil, nil, err
 	}
 	defer cursor.Close(ctx)
+	return decodeMongoFindCursor(ctx, cursor, includeObjectIDLocator)
+}
 
+func decodeMongoFindCursor(ctx context.Context, cursor mongoCursorDecoder, includeObjectIDLocator bool) ([]map[string]interface{}, []string, error) {
 	var data []map[string]interface{}
 	columnSet := make(map[string]bool)
 
+	documentNumber := 0
 	for cursor.Next(ctx) {
+		documentNumber++
 		var doc bson.M
 		if err := cursor.Decode(&doc); err != nil {
-			continue
+			return nil, nil, fmt.Errorf("decode MongoDB document %d: %w", documentNumber, err)
 		}
 		row := make(map[string]interface{})
 		for k, v := range doc {
@@ -990,7 +1007,7 @@ func (m *MongoDB) execFind(ctx context.Context, cmd bson.D) ([]map[string]interf
 	}
 
 	if err := cursor.Err(); err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("iterate MongoDB query results: %w", err)
 	}
 
 	columns := make([]string, 0, len(columnSet))
@@ -1236,41 +1253,44 @@ func (m *MongoDB) GetIndexes(dbName, tableName string) ([]connection.IndexDefini
 		return nil, err
 	}
 	defer cursor.Close(ctx)
+	return decodeMongoIndexCursor(ctx, cursor)
+}
 
+func decodeMongoIndexCursor(ctx context.Context, cursor mongoCursorDecoder) ([]connection.IndexDefinition, error) {
 	var indexes []connection.IndexDefinition
+	indexNumber := 0
 	for cursor.Next(ctx) {
-		var idx bson.M
+		indexNumber++
+		var idx mongoIndexMetadata
 		if err := cursor.Decode(&idx); err != nil {
-			continue
+			return nil, fmt.Errorf("decode MongoDB index %d: %w", indexNumber, err)
 		}
-
-		name := fmt.Sprintf("%v", idx["name"])
-		unique := false
-		if u, ok := idx["unique"].(bool); ok {
-			unique = u
-		}
-
-		// Extract key fields
-		if key, ok := idx["key"].(bson.M); ok {
-			seq := 1
-			for field := range key {
-				nonUnique := 1
-				if unique {
-					nonUnique = 0
-				}
-				indexes = append(indexes, connection.IndexDefinition{
-					Name:       name,
-					ColumnName: field,
-					NonUnique:  nonUnique,
-					SeqInIndex: seq,
-					IndexType:  "BTREE",
-				})
-				seq++
-			}
-		}
+		indexes = append(indexes, buildMongoIndexDefinitions(idx)...)
 	}
 
+	if err := cursor.Err(); err != nil {
+		return nil, fmt.Errorf("iterate MongoDB indexes: %w", err)
+	}
 	return indexes, nil
+}
+
+func buildMongoIndexDefinitions(idx mongoIndexMetadata) []connection.IndexDefinition {
+	indexes := make([]connection.IndexDefinition, 0, len(idx.Key))
+	nonUnique := 1
+	if idx.Unique {
+		nonUnique = 0
+	}
+	name := fmt.Sprintf("%v", idx.Name)
+	for position, key := range idx.Key {
+		indexes = append(indexes, connection.IndexDefinition{
+			Name:       name,
+			ColumnName: key.Key,
+			NonUnique:  nonUnique,
+			SeqInIndex: position + 1,
+			IndexType:  "BTREE",
+		})
+	}
+	return indexes
 }
 
 func (m *MongoDB) GetForeignKeys(dbName, tableName string) ([]connection.ForeignKeyDefinition, error) {


### PR DESCRIPTION
## 变更说明

- DuckDB：PRAGMA database_list 查询失败时返回真实错误，不再伪装为 main 数据库可用
- Chroma v2：数据库枚举 HTTP 请求失败时传播服务端错误，不再回退当前数据库并返回成功
- MongoDB 查询：文档 Decode 失败时立即返回带位置上下文的错误，避免静默丢失文档
- MongoDB 索引：传播索引 Decode 错误和 cursor 终止错误，避免返回不完整元数据
- MongoDB 复合索引：使用有序 BSON 文档解析索引键，稳定保持列顺序和 SeqInIndex

## 测试

- go test ./internal/db -count=1
- go test -tags gonavi_mongodb_driver ./internal/db -count=1
- go test -tags gonavi_duckdb_driver ./internal/db -run TestDuckDBGetDatabasesPropagatesQueryFailure -count=1
- go test -tags gonavi_duckdb_driver ./internal/db -run TestBuildDuckDB -count=1
- go test -tags gonavi_duckdb_driver ./internal/db -run TestNormalizeDuckDBObjectPath -count=1

以上测试均通过。DuckDB 完整集成测试依赖本地 CGO 原生驱动，当前 Windows 测试环境未包含该驱动；本次新增的错误传播测试及相关纯单元测试已通过。

## 关联 Issue

Closes #1104
Closes #1105
Closes #1107
Closes #1108
Closes #1109
