### PR TITLE
🐛 fix(duckdb): 修复显式限定对象错误降级

### DIFF
--- a/internal/db/duckdb_impl.go
+++ b/internal/db/duckdb_impl.go
@@ -247,27 +247,7 @@ func (d *DuckDB) GetCreateStatement(dbName, tableName string) (string, error) {
 		return "", duckDBTableNameRequiredError()
 	}
 
-	escapedTable := escapeDuckDBLiteral(path.Object)
-	escapedSchema := escapeDuckDBLiteral(path.Schema)
-	escapedCatalog := escapeDuckDBLiteral(path.Catalog)
-
-	queryCandidates := make([]string, 0, 4)
-	if path.Catalog != "" {
-		queryCandidates = append(queryCandidates, fmt.Sprintf("SELECT sql FROM duckdb_tables() WHERE table_name = '%s' AND schema_name = '%s' AND database_name = '%s' LIMIT 1", escapedTable, escapedSchema, escapedCatalog))
-	}
-	queryCandidates = append(queryCandidates,
-		fmt.Sprintf("SELECT sql FROM duckdb_tables() WHERE table_name = '%s' AND schema_name = '%s' LIMIT 1", escapedTable, escapedSchema),
-		fmt.Sprintf("SELECT sql FROM duckdb_tables() WHERE table_name = '%s' LIMIT 1", escapedTable),
-		fmt.Sprintf("SHOW CREATE TABLE %s", quoteDuckDBQualifiedTable(path.Schema, path.Object)),
-	)
-
-	if path.Catalog != "" {
-		queryCandidates = append([]string{
-			fmt.Sprintf("SHOW CREATE TABLE %s.%s", quoteDuckDBIdentifier(path.Catalog), quoteDuckDBQualifiedTable(path.Schema, path.Object)),
-		}, queryCandidates...)
-	}
-
-	for _, query := range queryCandidates {
+	for _, query := range buildDuckDBCreateStatementQueryCandidates(path) {
 		data, _, err := d.Query(query)
 		if err != nil || len(data) == 0 {
 			continue
@@ -311,29 +291,10 @@ ORDER BY ordinal_position`, escapeDuckDBLiteral(path.Object), escapeDuckDBLitera
 	if err != nil {
 		return nil, err
 	}
-	if len(data) == 0 && path.Schema != "main" {
-		fallbackQuery := fmt.Sprintf(`
-SELECT column_name, data_type, is_nullable, column_default
-FROM information_schema.columns
-WHERE table_name = '%s'
-ORDER BY ordinal_position`, escapeDuckDBLiteral(path.Object))
-		data, _, err = d.Query(fallbackQuery)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	constraintQuery := buildDuckDBConstraintMetadataQuery(path, true)
 	constraintRows, _, constraintErr := d.Query(constraintQuery)
 	if constraintErr != nil {
 		return nil, constraintErr
-	}
-	if len(constraintRows) == 0 && path.Schema != "main" {
-		fallbackConstraintQuery := buildDuckDBConstraintMetadataQuery(path, false)
-		constraintRows, _, constraintErr = d.Query(fallbackConstraintQuery)
-		if constraintErr != nil {
-			return nil, constraintErr
-		}
 	}
 
 	return buildDuckDBColumnDefinitions(data, constraintRows), nil
@@ -395,25 +356,10 @@ func (d *DuckDB) GetIndexes(dbName, tableName string) ([]connection.IndexDefinit
 	if err != nil {
 		return nil, err
 	}
-	if len(constraintRows) == 0 && path.Schema != "main" {
-		fallbackQuery := buildDuckDBConstraintMetadataQuery(path, false)
-		constraintRows, _, err = d.Query(fallbackQuery)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	indexQuery := buildDuckDBIndexMetadataQuery(path, true)
 	indexRows, _, indexErr := d.Query(indexQuery)
 	if indexErr != nil {
 		return nil, indexErr
-	}
-	if len(indexRows) == 0 && path.Schema != "main" {
-		fallbackIndexQuery := buildDuckDBIndexMetadataQuery(path, false)
-		indexRows, _, indexErr = d.Query(fallbackIndexQuery)
-		if indexErr != nil {
-			return nil, indexErr
-		}
 	}
 
 	return buildDuckDBIndexDefinitions(constraintRows, indexRows), nil

--- a/internal/db/duckdb_metadata.go
+++ b/internal/db/duckdb_metadata.go
@@ -9,9 +9,10 @@ import (
 )
 
 type duckDBObjectPath struct {
-	Catalog string
-	Schema  string
-	Object  string
+	Catalog             string
+	Schema              string
+	Object              string
+	ExplicitlyQualified bool
 }
 
 func buildDuckDBConstraintMetadataQuery(path duckDBObjectPath, exact bool) string {
@@ -61,6 +62,38 @@ WHERE table_name = '%s'`
 	}
 	base += "\nORDER BY database_name, schema_name, table_name, index_name"
 	return fmt.Sprintf(base, args...)
+}
+
+func buildDuckDBCreateStatementQueryCandidates(path duckDBObjectPath) []string {
+	escapedTable := escapeDuckDBLiteral(path.Object)
+	escapedSchema := escapeDuckDBLiteral(path.Schema)
+	escapedCatalog := escapeDuckDBLiteral(path.Catalog)
+
+	queryCandidates := make([]string, 0, 3)
+	if path.Catalog != "" {
+		queryCandidates = append(queryCandidates,
+			fmt.Sprintf("SHOW CREATE TABLE %s.%s", quoteDuckDBIdentifier(path.Catalog), quoteDuckDBQualifiedTable(path.Schema, path.Object)),
+			fmt.Sprintf("SELECT sql FROM duckdb_tables() WHERE table_name = '%s' AND schema_name = '%s' AND database_name = '%s' LIMIT 1", escapedTable, escapedSchema, escapedCatalog),
+		)
+	} else {
+		queryCandidates = append(queryCandidates,
+			fmt.Sprintf("SELECT sql FROM duckdb_tables() WHERE table_name = '%s' AND schema_name = '%s' LIMIT 1", escapedTable, escapedSchema),
+		)
+	}
+
+	if !path.ExplicitlyQualified {
+		queryCandidates = append(queryCandidates,
+			fmt.Sprintf("SELECT sql FROM duckdb_tables() WHERE table_name = '%s' LIMIT 1", escapedTable),
+		)
+	}
+
+	if path.Catalog == "" {
+		queryCandidates = append(queryCandidates,
+			fmt.Sprintf("SHOW CREATE TABLE %s", quoteDuckDBQualifiedTable(path.Schema, path.Object)),
+		)
+	}
+
+	return queryCandidates
 }
 
 func buildDuckDBColumnDefinitions(rows []map[string]interface{}, constraintRows []map[string]interface{}) []connection.ColumnDefinition {
@@ -156,6 +189,16 @@ func buildDuckDBIndexDefinitions(constraintRows []map[string]interface{}, indexR
 }
 
 func normalizeDuckDBObjectPath(dbName string, tableName string) duckDBObjectPath {
+	path := parseDuckDBObjectPath(dbName, tableName)
+	if strings.TrimSpace(tableName) == "" {
+		return path
+	}
+
+	path.ExplicitlyQualified = len(splitDuckDBQualifiedName(dbName)) > 0 || len(splitDuckDBQualifiedName(tableName)) > 1
+	return path
+}
+
+func parseDuckDBObjectPath(dbName string, tableName string) duckDBObjectPath {
 	rawDB := strings.TrimSpace(dbName)
 	rawTable := strings.TrimSpace(tableName)
 	if rawTable == "" {

--- a/internal/db/duckdb_metadata_integration_test.go
+++ b/internal/db/duckdb_metadata_integration_test.go
@@ -67,6 +67,61 @@ CREATE UNIQUE INDEX idx_events_name ON events(name);
 	}
 }
 
+func TestDuckDBQualifiedMetadataDoesNotFallbackToSameNamedObject(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "qualified-fallback.duckdb")
+	client := &DuckDB{}
+	if err := client.Connect(connection.ConnectionConfig{Type: "duckdb", Host: dbPath}); err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+
+	if _, err := client.Exec(`
+CREATE TABLE main.events (
+	id BIGINT PRIMARY KEY,
+	marker VARCHAR UNIQUE
+);
+CREATE SCHEMA compat;
+CREATE TABLE compat.legacy (id BIGINT);
+`); err != nil {
+		t.Fatalf("create qualified fallback fixtures failed: %v", err)
+	}
+
+	columns, err := client.GetColumns("main", "missing.events")
+	if err != nil {
+		t.Fatalf("GetColumns for missing qualified object failed: %v", err)
+	}
+	if len(columns) != 0 {
+		t.Fatalf("missing schema returned columns from a same-named table: %+v", columns)
+	}
+
+	indexes, err := client.GetIndexes("main", "missing.events")
+	if err != nil {
+		t.Fatalf("GetIndexes for missing qualified object failed: %v", err)
+	}
+	if len(indexes) != 0 {
+		t.Fatalf("missing schema returned indexes from a same-named table: %+v", indexes)
+	}
+
+	if ddl, err := client.GetCreateStatement("main", "missing.events"); err == nil {
+		t.Fatalf("missing schema returned a same-named table definition: %q", ddl)
+	}
+	if ddl, err := client.GetCreateStatement("missing_catalog", "main.events"); err == nil {
+		t.Fatalf("missing catalog returned a same-named table definition: %q", ddl)
+	}
+
+	ddl, err := client.GetCreateStatement("", "legacy")
+	if err != nil {
+		t.Fatalf("unqualified compatibility lookup failed: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(ddl), "legacy") {
+		t.Fatalf("unqualified compatibility lookup returned unexpected DDL: %q", ddl)
+	}
+}
+
 func TestDuckDBDefinitionReloadReflectsLatestDDL(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/duckdb_metadata_test.go
+++ b/internal/db/duckdb_metadata_test.go
@@ -240,6 +240,95 @@ func TestNormalizeDuckDBObjectPath_DoesNotTreatMainDatabaseAsExternalCatalog(t *
 	}
 }
 
+func TestNormalizeDuckDBObjectPath_TracksExplicitQualification(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		dbName    string
+		tableName string
+		explicit  bool
+	}{
+		{name: "plain table", tableName: "events", explicit: false},
+		{name: "schema argument", dbName: "main", tableName: "events", explicit: true},
+		{name: "qualified schema", tableName: "analytics.events", explicit: true},
+		{name: "catalog and schema", dbName: "analytics", tableName: "main.events", explicit: true},
+		{name: "quoted qualified name", tableName: `"analytics.schema"."daily.events"`, explicit: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := normalizeDuckDBObjectPath(tc.dbName, tc.tableName)
+			if path.ExplicitlyQualified != tc.explicit {
+				t.Fatalf("normalizeDuckDBObjectPath(%q, %q) explicit=%v, want %v: %+v", tc.dbName, tc.tableName, path.ExplicitlyQualified, tc.explicit, path)
+			}
+		})
+	}
+}
+
+func TestBuildDuckDBCreateStatementQueryCandidates_DoesNotDropExplicitSchema(t *testing.T) {
+	t.Parallel()
+
+	queries := buildDuckDBCreateStatementQueryCandidates(duckDBObjectPath{
+		Schema:              "missing",
+		Object:              "events",
+		ExplicitlyQualified: true,
+	})
+
+	if len(queries) != 2 {
+		t.Fatalf("explicit schema query count = %d, want 2: %#v", len(queries), queries)
+	}
+	if !duckDBTestContainsQuery(queries, "SELECT sql FROM duckdb_tables() WHERE table_name = 'events' AND schema_name = 'missing' LIMIT 1") {
+		t.Fatalf("explicit schema query missing: %#v", queries)
+	}
+	if !duckDBTestContainsQuery(queries, `SHOW CREATE TABLE "missing"."events"`) {
+		t.Fatalf("qualified SHOW CREATE query missing: %#v", queries)
+	}
+	if duckDBTestContainsQuery(queries, "SELECT sql FROM duckdb_tables() WHERE table_name = 'events' LIMIT 1") {
+		t.Fatalf("explicit schema unexpectedly falls back to an unqualified query: %#v", queries)
+	}
+}
+
+func TestBuildDuckDBCreateStatementQueryCandidates_DoesNotDropExplicitCatalog(t *testing.T) {
+	t.Parallel()
+
+	queries := buildDuckDBCreateStatementQueryCandidates(duckDBObjectPath{
+		Catalog:             "missing_catalog",
+		Schema:              "main",
+		Object:              "events",
+		ExplicitlyQualified: true,
+	})
+
+	if len(queries) != 2 {
+		t.Fatalf("explicit catalog query count = %d, want 2: %#v", len(queries), queries)
+	}
+	if !duckDBTestContainsQuery(queries, `SHOW CREATE TABLE "missing_catalog"."main"."events"`) {
+		t.Fatalf("qualified catalog SHOW CREATE query missing: %#v", queries)
+	}
+	if !duckDBTestContainsQuery(queries, "SELECT sql FROM duckdb_tables() WHERE table_name = 'events' AND schema_name = 'main' AND database_name = 'missing_catalog' LIMIT 1") {
+		t.Fatalf("explicit catalog metadata query missing: %#v", queries)
+	}
+	for _, query := range queries {
+		if query == "SELECT sql FROM duckdb_tables() WHERE table_name = 'events' LIMIT 1" || query == "SELECT sql FROM duckdb_tables() WHERE table_name = 'events' AND schema_name = 'main' LIMIT 1" || query == `SHOW CREATE TABLE "main"."events"` {
+			t.Fatalf("explicit catalog unexpectedly drops its catalog: %#v", queries)
+		}
+	}
+}
+
+func TestBuildDuckDBCreateStatementQueryCandidates_PreservesUnqualifiedCompatibility(t *testing.T) {
+	t.Parallel()
+
+	queries := buildDuckDBCreateStatementQueryCandidates(duckDBObjectPath{
+		Schema: "main",
+		Object: "events",
+	})
+
+	if !duckDBTestContainsQuery(queries, "SELECT sql FROM duckdb_tables() WHERE table_name = 'events' LIMIT 1") {
+		t.Fatalf("unqualified compatibility query missing: %#v", queries)
+	}
+}
+
 func TestParseDuckDBExpressionList_KeepsQuotedExpressionsIntact(t *testing.T) {
 	t.Parallel()
 
@@ -270,4 +359,13 @@ func containsAll(source string, needles ...string) bool {
 		}
 	}
 	return true
+}
+
+func duckDBTestContainsQuery(queries []string, target string) bool {
+	for _, query := range queries {
+		if query == target {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## 问题说明

DuckDB 元数据查询在显式指定 catalog 或 schema 后，如果精确目标不存在，会继续按同名未限定对象查询，可能返回其他对象的 DDL、列或索引信息。

## 修复内容

- 为 DuckDB 对象路径记录显式限定状态
- 显式 catalog/schema 的 DDL 查询只保留目标对象范围内的兼容查询方式
- 列、约束和索引元数据查询不再删除 catalog/schema 条件
- 保留普通未限定表名的既有 DDL 兼容查询
- 补充缺失 schema、缺失 catalog、同名对象及带引号名称测试

## 测试

- go test ./internal/db -count=1
- go test ./internal/app -run Test.*CreateStatement -count=1
- go test ./internal/app -run DuckDB 元数据相关用例
- go test ./internal/sync -count=1
- go vet ./internal/db

以上纯单元测试和应用层回归测试均通过。真实 DuckDB 同名对象集成用例已添加；本地 Windows 环境因 CGO_ENABLED=0、未包含 DuckDB 原生驱动而无法执行，将由具备原生驱动的环境运行。

## 关联 Issue

Closes #1103
