### PR TITLE
✨ feat(data-export): 支持元数据加载失败原地重试

### DIFF
--- a/frontend/src/components/TableExportWorkbench.test.tsx
+++ b/frontend/src/components/TableExportWorkbench.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { readFileSync } from 'node:fs';
-import { Button, Checkbox, Segmented, Select } from 'antd';
+import { Alert, Button, Checkbox, Segmented, Select } from 'antd';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -46,6 +46,18 @@ const switchBatchIntentToDelete = async (renderer: ReactTestRenderer) => {
     await Promise.resolve();
   });
 };
+const flushAsyncWork = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+const findAlertAction = (
+  renderer: ReactTestRenderer,
+  marker: string,
+): React.ReactElement<any> | undefined => renderer.root
+  .findAllByType(Alert)
+  .map((node) => node.props.action)
+  .find((action) => React.isValidElement(action) && Boolean((action.props as any)[marker]));
 const createMockStoreState = () => ({
   theme: 'light',
   connections: [
@@ -435,6 +447,269 @@ describe('TableExportWorkbench', () => {
       { name: 'Foo', objectType: 'table' },
       { name: 'foo', objectType: 'table' },
     ]);
+  });
+
+  it('retries column metadata in place and preserves the current selection for the same table', async () => {
+    mockProgressRunnerState = createIdleProgressRunnerState();
+    vi.mocked(DBGetColumns)
+      .mockResolvedValueOnce({ success: false, message: 'temporary column failure' } as any)
+      .mockResolvedValueOnce({
+        success: true,
+        data: [{ name: 'id' }, { name: 'email' }],
+      } as any)
+      .mockResolvedValueOnce({ success: false, message: 'temporary column failure' } as any)
+      .mockResolvedValueOnce({
+        success: true,
+        data: [{ name: 'id' }, { name: 'created_at' }],
+      } as any);
+
+    const tab = {
+      id: 'table-export-conn-1-SYS-users',
+      title: '导出 users',
+      type: 'table-export' as const,
+      connectionId: 'conn-1',
+      dbName: 'SYS',
+      tableName: 'users',
+      objectType: 'table' as const,
+      tableExportScopeOptions: [{ value: 'all' as const, label: '全表数据' }],
+      tableExportInitialScope: 'all' as const,
+    };
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<TableExportWorkbench tab={tab} />);
+      await flushAsyncWork();
+    });
+
+    let columnSelect = renderer.root.findAllByType(Select).find((node) => node.props.mode === 'multiple');
+    expect(columnSelect?.props.value).toEqual([]);
+    const initialRetryAction = findAlertAction(renderer, 'data-export-retry-columns');
+    expect(initialRetryAction).toBeDefined();
+    expect(renderer.root.findAllByType(Button).find((node) => (
+      node.props.type === 'primary' && node.props.size === 'large'
+    ))?.props.disabled).toBe(true);
+
+    await act(async () => {
+      initialRetryAction?.props.onClick();
+      await flushAsyncWork();
+    });
+
+    columnSelect = renderer.root.findAllByType(Select).find((node) => node.props.mode === 'multiple');
+    expect(columnSelect?.props.value).toEqual(['id', 'email']);
+    expect(renderer.root.findAllByType(Button).find((node) => (
+      node.props.type === 'primary' && node.props.size === 'large'
+    ))?.props.disabled).toBe(false);
+    await act(async () => {
+      columnSelect?.props.onChange(['id']);
+      await Promise.resolve();
+    });
+
+    mockStoreState = {
+      ...mockStoreState,
+      connections: [{
+        ...mockStoreState.connections[0],
+        config: {
+          ...mockStoreState.connections[0].config,
+          host: '127.0.0.1',
+        },
+      }],
+    };
+    await act(async () => {
+      renderer.update(<TableExportWorkbench tab={tab} />);
+      await flushAsyncWork();
+    });
+
+    columnSelect = renderer.root.findAllByType(Select).find((node) => node.props.mode === 'multiple');
+    expect(columnSelect?.props.value).toEqual(['id']);
+    const retryAction = findAlertAction(renderer, 'data-export-retry-columns');
+    expect(retryAction).toBeDefined();
+    const blockedStartButton = renderer.root.findAllByType(Button).find((node) => (
+      node.props.type === 'primary' && node.props.size === 'large'
+    ));
+    expect(blockedStartButton?.props.disabled).toBe(true);
+    await act(async () => {
+      blockedStartButton?.props.onClick();
+      await Promise.resolve();
+    });
+    expect(mockRunExportWithProgress).not.toHaveBeenCalled();
+
+    await act(async () => {
+      retryAction?.props.onClick();
+      await flushAsyncWork();
+    });
+
+    expect(DBGetColumns).toHaveBeenCalledTimes(4);
+    columnSelect = renderer.root.findAllByType(Select).find((node) => node.props.mode === 'multiple');
+    expect(columnSelect?.props.value).toEqual(['id']);
+    const recoveredStartButton = renderer.root.findAllByType(Button).find((node) => (
+      node.props.type === 'primary' && node.props.size === 'large'
+    ));
+    expect(recoveredStartButton?.props.disabled).toBe(false);
+
+    renderer.unmount();
+  });
+
+  it('keeps batch table targets while the database list fails and blocks destructive actions until retry succeeds', async () => {
+    mockProgressRunnerState = createIdleProgressRunnerState();
+    vi.mocked(DBGetDatabases)
+      .mockResolvedValueOnce({ success: false, message: 'temporary database failure' } as any)
+      .mockResolvedValueOnce({ success: true, data: [{ Database: 'SYS' }] } as any);
+    vi.mocked(DBGetTables).mockResolvedValue({ success: true, data: [{ Name: 'users' }] } as any);
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <TableExportWorkbench
+          tab={{
+            id: 'table-export-batch-tables-conn-1-SYS',
+            title: '批量处理表',
+            type: 'table-export',
+            connectionId: 'conn-1',
+            dbName: 'SYS',
+            exportWorkbenchMode: 'batch-tables',
+            tableExportInitialObjectNames: ['users'],
+          }}
+        />,
+      );
+      await flushAsyncWork();
+    });
+
+    const databaseSelect = renderer.root.findAllByType(Select).find((node) => node.props.value === 'SYS');
+    const objectSelect = renderer.root.findAllByType(Select).find((node) => node.props.mode === 'multiple');
+    expect(databaseSelect).toBeDefined();
+    expect(objectSelect?.props.value).toEqual(['users']);
+    const blockedStartButton = renderer.root.findAllByType(Button).find((node) => (
+      node.props.type === 'primary' && node.props.size === 'large'
+    ));
+    expect(blockedStartButton?.props.disabled).toBe(true);
+
+    await switchBatchIntentToDelete(renderer);
+    const blockedClearButton = renderer.root.findByProps({ 'data-batch-clear-tables': 'true' });
+    expect(blockedClearButton.props.disabled).toBe(true);
+    await act(async () => {
+      blockedClearButton.props.onClick();
+      await Promise.resolve();
+    });
+    expect(ClearTables).not.toHaveBeenCalled();
+    expect(Modal.confirm).not.toHaveBeenCalled();
+
+    const retryAction = findAlertAction(renderer, 'data-export-retry-databases');
+    expect(retryAction).toBeDefined();
+    await act(async () => {
+      retryAction?.props.onClick();
+      await flushAsyncWork();
+    });
+
+    expect(DBGetDatabases).toHaveBeenCalledTimes(2);
+    expect(renderer.root.findAllByType(Select).some((node) => node.props.value === 'SYS')).toBe(true);
+    expect(renderer.root.findAllByType(Select).find((node) => node.props.mode === 'multiple')?.props.value).toEqual(['users']);
+    expect(renderer.root.findByProps({ 'data-batch-clear-tables': 'true' }).props.disabled).toBe(false);
+
+    renderer.unmount();
+  });
+
+  it('retries batch table object metadata and removes only targets missing from the recovered list', async () => {
+    mockProgressRunnerState = createIdleProgressRunnerState();
+    vi.mocked(DBGetDatabases).mockResolvedValue({ success: true, data: [{ Database: 'SYS' }] } as any);
+    vi.mocked(DBGetTables)
+      .mockResolvedValueOnce({ success: false, message: 'temporary object failure' } as any)
+      .mockResolvedValueOnce({ success: true, data: [{ Name: 'users' }] } as any);
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <TableExportWorkbench
+          tab={{
+            id: 'table-export-batch-tables-conn-1-SYS',
+            title: '批量处理表',
+            type: 'table-export',
+            connectionId: 'conn-1',
+            dbName: 'SYS',
+            exportWorkbenchMode: 'batch-tables',
+            tableExportInitialObjectNames: ['users', 'removed_table'],
+          }}
+        />,
+      );
+      await flushAsyncWork();
+    });
+
+    let objectSelect = renderer.root.findAllByType(Select).find((node) => node.props.mode === 'multiple');
+    expect(objectSelect?.props.value).toEqual(['users', 'removed_table']);
+    const blockedStartButton = renderer.root.findAllByType(Button).find((node) => (
+      node.props.type === 'primary' && node.props.size === 'large'
+    ));
+    expect(blockedStartButton?.props.disabled).toBe(true);
+
+    const retryAction = findAlertAction(renderer, 'data-export-retry-objects');
+    expect(retryAction).toBeDefined();
+    await act(async () => {
+      retryAction?.props.onClick();
+      await flushAsyncWork();
+    });
+
+    expect(DBGetTables).toHaveBeenCalledTimes(2);
+    objectSelect = renderer.root.findAllByType(Select).find((node) => node.props.mode === 'multiple');
+    expect(objectSelect?.props.value).toEqual(['users']);
+    const recoveredStartButton = renderer.root.findAllByType(Button).find((node) => (
+      node.props.type === 'primary' && node.props.size === 'large'
+    ));
+    expect(recoveredStartButton?.props.disabled).toBe(false);
+
+    renderer.unmount();
+  });
+
+  it('keeps batch database selections on failure and revalidates them before export or deletion', async () => {
+    mockProgressRunnerState = createIdleProgressRunnerState();
+    vi.mocked(DBGetDatabases)
+      .mockResolvedValueOnce({ success: false, message: 'temporary database failure' } as any)
+      .mockResolvedValueOnce({ success: true, data: [{ Database: 'alpha' }] } as any);
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <TableExportWorkbench
+          tab={{
+            id: 'table-export-batch-databases-conn-1',
+            title: '批量处理数据库',
+            type: 'table-export',
+            connectionId: 'conn-1',
+            exportWorkbenchMode: 'batch-databases',
+            tableExportInitialDatabaseNames: ['alpha', 'removed_database'],
+          }}
+        />,
+      );
+      await flushAsyncWork();
+    });
+
+    let databaseSelect = renderer.root.findAllByType(Select).find((node) => node.props.mode === 'multiple');
+    expect(databaseSelect?.props.value).toEqual(['alpha', 'removed_database']);
+    const blockedStartButton = renderer.root.findAllByType(Button).find((node) => (
+      node.props.type === 'primary' && node.props.size === 'large'
+    ));
+    expect(blockedStartButton?.props.disabled).toBe(true);
+
+    await switchBatchIntentToDelete(renderer);
+    const blockedDeleteButton = renderer.root.findByProps({ 'data-batch-delete-databases': 'true' });
+    expect(blockedDeleteButton.props.disabled).toBe(true);
+    await act(async () => {
+      blockedDeleteButton.props.onClick();
+      await Promise.resolve();
+    });
+    expect(DropDatabase).not.toHaveBeenCalled();
+    expect(Modal.confirm).not.toHaveBeenCalled();
+
+    const retryAction = findAlertAction(renderer, 'data-export-retry-databases');
+    expect(retryAction).toBeDefined();
+    await act(async () => {
+      retryAction?.props.onClick();
+      await flushAsyncWork();
+    });
+
+    expect(DBGetDatabases).toHaveBeenCalledTimes(2);
+    databaseSelect = renderer.root.findAllByType(Select).find((node) => node.props.mode === 'multiple');
+    expect(databaseSelect?.props.value).toEqual(['alpha']);
+    expect(renderer.root.findByProps({ 'data-batch-delete-databases': 'true' }).props.disabled).toBe(false);
+
+    renderer.unmount();
   });
 
   it('syncs manually selected batch connection and database into the existing tab', async () => {

--- a/frontend/src/components/TableExportWorkbench.tsx
+++ b/frontend/src/components/TableExportWorkbench.tsx
@@ -399,6 +399,10 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
   const [databaseLoadError, setDatabaseLoadError] = useState('');
   const [objectLoadError, setObjectLoadError] = useState('');
   const [columnLoadError, setColumnLoadError] = useState('');
+  const [databaseReloadRevision, setDatabaseReloadRevision] = useState(0);
+  const [objectReloadRevision, setObjectReloadRevision] = useState(0);
+  const [columnReloadRevision, setColumnReloadRevision] = useState(0);
+  const successfulColumnRequestKeyRef = useRef('');
   const [destructiveOperation, setDestructiveOperation] = useState<BatchDestructiveOperation | null>(null);
   const [appliedLaunchKey, setAppliedLaunchKey] = useState(() => (
     String(tab.tableExportRequestKey || tab.tableExportLaunchKey || '').trim()
@@ -543,6 +547,7 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
   useEffect(() => {
     const objectName = String(tab.tableName || '').trim();
     if (!isSingleWorkbench || !connectionConfig || !objectName) {
+      successfulColumnRequestKeyRef.current = '';
       setAvailableColumns([]);
       setSelectedColumns([]);
       setColumnLoadError('');
@@ -551,6 +556,12 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
     }
 
     let alive = true;
+    const requestKey = [effectiveConnectionId, effectiveDbName, objectName].join('\u0000');
+    if (successfulColumnRequestKeyRef.current && successfulColumnRequestKeyRef.current !== requestKey) {
+      successfulColumnRequestKeyRef.current = '';
+      setAvailableColumns([]);
+      setSelectedColumns([]);
+    }
     setLoadingColumns(true);
     setColumnLoadError('');
     DBGetColumns(buildRpcConnectionConfig(connectionConfig) as any, effectiveDbName, objectName)
@@ -558,21 +569,28 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
         if (!alive) return;
         if (!res.success) {
           setAvailableColumns([]);
-          setSelectedColumns([]);
           setColumnLoadError(res.message || t('data_export.message.load_columns_failed'));
           return;
         }
         const nextColumns = resolveTableExportColumnNames(res.data);
-        setAvailableColumns(nextColumns);
-        setSelectedColumns(nextColumns);
         if (nextColumns.length === 0) {
+          setAvailableColumns([]);
           setColumnLoadError(t('data_export.message.load_columns_failed'));
+          return;
         }
+        const availableNameSet = new Set(nextColumns);
+        const preserveExistingSelection = successfulColumnRequestKeyRef.current === requestKey;
+        setAvailableColumns(nextColumns);
+        setSelectedColumns((prev) => (
+          preserveExistingSelection
+            ? prev.filter((name) => availableNameSet.has(name))
+            : nextColumns
+        ));
+        successfulColumnRequestKeyRef.current = requestKey;
       })
       .catch((error: any) => {
         if (!alive) return;
         setAvailableColumns([]);
-        setSelectedColumns([]);
         setColumnLoadError(error?.message || t('data_export.message.load_columns_failed'));
       })
       .finally(() => {
@@ -582,7 +600,7 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
     return () => {
       alive = false;
     };
-  }, [connectionConfig, effectiveDbName, isSingleWorkbench, tab.tableName]);
+  }, [columnReloadRevision, connectionConfig, effectiveConnectionId, effectiveDbName, isSingleWorkbench, tab.tableName]);
 
   useEffect(() => {
     if (!progressState.startedAt || progressState.finishedAt > 0) return undefined;
@@ -623,12 +641,6 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
         if (!alive) return;
         if (!res.success) {
           setAvailableDatabases([]);
-          setSelectedDatabaseNames([]);
-          if (isBatchTablesWorkbench) {
-            setSelectedDbName('');
-            setAvailableObjects([]);
-            setSelectedObjectNames([]);
-          }
           setDatabaseLoadError(res.message || t('data_export.message.load_databases_failed'));
           return;
         }
@@ -654,12 +666,6 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
       .catch((error: any) => {
         if (!alive) return;
         setAvailableDatabases([]);
-        setSelectedDatabaseNames([]);
-        if (isBatchTablesWorkbench) {
-          setSelectedDbName('');
-          setAvailableObjects([]);
-          setSelectedObjectNames([]);
-        }
         setDatabaseLoadError(error?.message || t('data_export.message.load_databases_failed'));
       })
       .finally(() => {
@@ -675,6 +681,7 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
     connection?.includeDatabasePatterns,
     connection?.includeDatabases,
     connectionConfig,
+    databaseReloadRevision,
     isBatchDatabasesWorkbench,
     isBatchTablesWorkbench,
   ]);
@@ -699,7 +706,6 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
         if (!alive) return;
         if (!res.success) {
           setAvailableObjects([]);
-          setSelectedObjectNames([]);
           setObjectLoadError(res.message || t('data_export.message.load_objects_failed'));
           return;
         }
@@ -719,7 +725,6 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
       .catch((error: any) => {
         if (!alive) return;
         setAvailableObjects([]);
-        setSelectedObjectNames([]);
         setObjectLoadError(error?.message || t('data_export.message.load_objects_failed'));
       })
       .finally(() => {
@@ -730,7 +735,7 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
     return () => {
       alive = false;
     };
-  }, [connection, connectionConfig, isBatchTablesWorkbench, selectedDbName]);
+  }, [connection, connectionConfig, isBatchTablesWorkbench, objectReloadRevision, selectedDbName]);
 
   const hostSummary = useMemo(
     () => resolveConnectionHostSummary(connection?.config),
@@ -889,9 +894,14 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
     || destructiveOperation !== null
     || loadingDatabases
     || loadingObjects;
+  const hasBatchTableMetadataError = Boolean(databaseLoadError || objectLoadError);
+  const hasBatchDatabaseMetadataError = Boolean(databaseLoadError);
+  const hasBlockingMetadataError = (isSingleWorkbench && !!columnLoadError)
+    || (isBatchTablesWorkbench && hasBatchTableMetadataError)
+    || (isBatchDatabasesWorkbench && hasBatchDatabaseMetadataError);
 
   const canStart = useMemo(() => {
-    if (!connectionConfig || isConfigurationLocked) {
+    if (!connectionConfig || isConfigurationLocked || hasBlockingMetadataError) {
       return false;
     }
     if (isSingleWorkbench) {
@@ -914,6 +924,7 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
     activeScopeQuery,
     connectionConfig,
     effectiveDbName,
+    hasBlockingMetadataError,
     isBatchTablesWorkbench,
     isDirectDatabaseWorkbench,
     isDirectSQLWorkbench,
@@ -955,6 +966,7 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
       || !selectedDbName
       || !isDatabaseVisible(connection, selectedDbName)
       || selectedTableNames.length === 0
+      || hasBatchTableMetadataError
       || isConfigurationLocked
     ) return;
     if (action === 'truncate' && !supportsTableTruncateAction(connectionConfig.type, connectionConfig.driver)) {
@@ -1079,6 +1091,7 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
       || !selectedDbName
       || !isDatabaseVisible(connection, selectedDbName)
       || selectedTableNames.length === 0
+      || hasBatchTableMetadataError
       || isConfigurationLocked
     ) return;
     const confirmed = await confirmDestructiveAction({
@@ -1158,6 +1171,7 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
       || !connection
       || selectedDatabaseNames.length === 0
       || filterVisibleDatabaseNames(connection, selectedDatabaseNames).length !== selectedDatabaseNames.length
+      || hasBatchDatabaseMetadataError
       || isConfigurationLocked
     ) return;
     const confirmed = await confirmDestructiveAction({
@@ -1225,7 +1239,7 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
   };
 
   const handleStartSingleExport = async () => {
-    if (!connectionConfig) {
+    if (!connectionConfig || !!columnLoadError || loadingColumns || selectedColumns.length === 0) {
       return;
     }
     const objectName = String(tab.tableName || '').trim();
@@ -1288,6 +1302,7 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
       || selectedObjectNames.length === 0
       || loadingDatabases
       || loadingObjects
+      || hasBatchTableMetadataError
     ) {
       return;
     }
@@ -1323,6 +1338,7 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
       || selectedDatabaseNames.length === 0
       || filterVisibleDatabaseNames(connection, selectedDatabaseNames).length !== selectedDatabaseNames.length
       || loadingDatabases
+      || hasBatchDatabaseMetadataError
     ) {
       return;
     }
@@ -1684,6 +1700,18 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
               showIcon
               message={t('data_export.workbench.alert.database_load_failed')}
               description={databaseLoadError}
+              action={(
+                <Button
+                  size="small"
+                  icon={<ReloadOutlined />}
+                  data-export-retry-databases="true"
+                  disabled={isRunning || destructiveOperation !== null || loadingDatabases}
+                  loading={loadingDatabases}
+                  onClick={() => setDatabaseReloadRevision((current) => current + 1)}
+                >
+                  {t('common.retry')}
+                </Button>
+              )}
             />
           ) : null}
 
@@ -1693,6 +1721,18 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
               showIcon
               message={t('data_export.workbench.alert.object_load_failed')}
               description={objectLoadError}
+              action={(
+                <Button
+                  size="small"
+                  icon={<ReloadOutlined />}
+                  data-export-retry-objects="true"
+                  disabled={isRunning || destructiveOperation !== null || loadingObjects}
+                  loading={loadingObjects}
+                  onClick={() => setObjectReloadRevision((current) => current + 1)}
+                >
+                  {t('common.retry')}
+                </Button>
+              )}
             />
           ) : null}
 
@@ -1702,6 +1742,18 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
               showIcon
               message={t('data_export.dialog.field.columns')}
               description={columnLoadError}
+              action={(
+                <Button
+                  size="small"
+                  icon={<ReloadOutlined />}
+                  data-export-retry-columns="true"
+                  disabled={isRunning || loadingColumns}
+                  loading={loadingColumns}
+                  onClick={() => setColumnReloadRevision((current) => current + 1)}
+                >
+                  {t('common.retry')}
+                </Button>
+              )}
             />
           ) : null}
 
@@ -2235,7 +2287,7 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
                     size="large"
                     icon={<DeleteOutlined />}
                     data-batch-truncate-tables="true"
-                    disabled={connectionCapabilities.forceReadOnlyQueryResult || isConfigurationLocked || selectedTableNames.length === 0}
+                    disabled={connectionCapabilities.forceReadOnlyQueryResult || isConfigurationLocked || hasBatchTableMetadataError || selectedTableNames.length === 0}
                     loading={destructiveOperation === 'truncate-tables'}
                     onClick={() => { void handleTruncateSelectedTables(); }}
                     style={{ flex: 1 }}
@@ -2248,7 +2300,7 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
                   size="large"
                   icon={<DeleteOutlined />}
                   data-batch-clear-tables="true"
-                  disabled={connectionCapabilities.forceReadOnlyQueryResult || isConfigurationLocked || selectedTableNames.length === 0}
+                  disabled={connectionCapabilities.forceReadOnlyQueryResult || isConfigurationLocked || hasBatchTableMetadataError || selectedTableNames.length === 0}
                   loading={destructiveOperation === 'clear-tables'}
                   onClick={() => { void handleClearSelectedTables(); }}
                   style={{ flex: 1 }}
@@ -2261,7 +2313,7 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
                   size="large"
                   icon={<DeleteOutlined />}
                   data-batch-delete-tables="true"
-                  disabled={connectionCapabilities.forceReadOnlyStructureDesigner || isConfigurationLocked || selectedTableNames.length === 0}
+                  disabled={connectionCapabilities.forceReadOnlyStructureDesigner || isConfigurationLocked || hasBatchTableMetadataError || selectedTableNames.length === 0}
                   loading={destructiveOperation === 'delete-tables'}
                   onClick={() => { void handleDeleteSelectedTables(); }}
                   style={{ flex: 1 }}
@@ -2279,7 +2331,7 @@ const TableExportWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
                   block
                   icon={<DeleteOutlined />}
                   data-batch-delete-databases="true"
-                  disabled={!connectionCapabilities.supportsDropDatabase || isConfigurationLocked || selectedDatabaseNames.length === 0}
+                  disabled={!connectionCapabilities.supportsDropDatabase || isConfigurationLocked || hasBatchDatabaseMetadataError || selectedDatabaseNames.length === 0}
                   loading={destructiveOperation === 'delete-databases'}
                   onClick={() => { void handleDeleteSelectedDatabases(); }}
                 >


### PR DESCRIPTION
## 背景

导出工作台在数据库、对象或列元数据临时加载失败时只展示错误，并清空已选目标。网络瞬断、临时鉴权失败或短暂数据库异常恢复后，用户无法在当前工作台继续原导出配置。

## 改动内容

- 为数据库、对象和列元数据加载错误增加原地重试入口
- 加载失败时保留同一目标下的连接、导出模式及已选数据库、对象和列
- 重试成功后按最新元数据过滤已失效的选择，并保留仍有效的选择
- 元数据恢复前同时在 UI 和事件处理层阻止导出、清表、截断及删除操作
- 保持主动切换连接、数据库时原有的下级选择清理语义
- 补充单表、批量表和批量数据库恢复场景的回归测试

## 验证结果

- TableExportWorkbench 与 i18n 定向测试：35 个通过
- TypeScript 类型检查通过
- Vite 生产构建通过
- git diff --check 通过

## 风险控制

- 未修改后端元数据 RPC、导出执行、任务历史或文件处理逻辑
- 重试仅重新发起对应的只读元数据请求，不自动重试导出任务
- 保留选择后必须等待元数据恢复成功才能执行导出或破坏性操作
- 迟到请求继续由现有 effect 生命周期保护，避免覆盖新连接或新目标状态
- 直接数据库和 Schema 导出行为保持不变

Closes #1111
