### PR TITLE
🐛 修复 Nacos 服务查询

### DIFF
--- a/frontend/src/components/NacosServiceViewer.interaction.test.tsx
+++ b/frontend/src/components/NacosServiceViewer.interaction.test.tsx
@@ -273,11 +273,16 @@ describe('NacosServiceViewer interactions', () => {
     await flushEffects();
 
     const serviceInput = renderer!.root.findAllByType('input')
-      .find((input) => input.props.placeholder === 'nacos_service.field.service');
+      .find((input) => input.props.style?.width === 180);
     expect(serviceInput).toBeDefined();
     await act(async () => {
       serviceInput!.props.onChange({ target: { value: 'order' } });
-      serviceInput!.props.onPressEnter();
+    });
+    await flushEffects();
+    const updatedServiceInput = renderer!.root.findAllByType('input')
+      .find((input) => input.props.style?.width === 180);
+    await act(async () => {
+      updatedServiceInput!.props.onPressEnter();
     });
     await flushEffects();
 

--- a/frontend/src/components/NacosServiceViewer.interaction.test.tsx
+++ b/frontend/src/components/NacosServiceViewer.interaction.test.tsx
@@ -264,6 +264,38 @@ describe('NacosServiceViewer interactions', () => {
     });
   });
 
+  it('sends the service name filter and preserves it when changing page size', async () => {
+    await act(async () => {
+      renderer = create(
+        <NacosServiceViewer connectionId="nacos-1" namespaceId="dev" namespaceName="dev" />,
+      );
+    });
+    await flushEffects();
+
+    const serviceInput = renderer!.root.findAllByType('input')
+      .find((input) => input.props.placeholder === 'nacos_service.field.service');
+    expect(serviceInput).toBeDefined();
+    await act(async () => {
+      serviceInput!.props.onChange({ target: { value: 'order' } });
+      serviceInput!.props.onPressEnter();
+    });
+    await flushEffects();
+
+    expect(nacosBackend.NacosListServices).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ serviceName: 'order', groupName: '' }),
+    );
+    const pagination = latestServicePaginationProps();
+    await act(async () => {
+      pagination.onChange(1, 100);
+    });
+    await flushEffects();
+    expect(nacosBackend.NacosListServices).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ serviceName: 'order', pageSize: 100 }),
+    );
+  });
+
   it('renders endpoint-first instance records instead of a horizontal instance table', async () => {
     nacosBackend.NacosListInstances.mockResolvedValue({
       success: true,

--- a/frontend/src/components/NacosServiceViewer.tsx
+++ b/frontend/src/components/NacosServiceViewer.tsx
@@ -97,6 +97,7 @@ type ServiceViewContext = {
   page: number;
   pageSize: number;
   group: string;
+  serviceName: string;
 };
 
 type NacosLoadOptions = {
@@ -107,6 +108,7 @@ type LoadServices = (
   page?: number,
   requestedGroup?: string,
   requestedPageSize?: number,
+  requestedServiceName?: string,
   options?: NacosLoadOptions,
 ) => Promise<void>;
 
@@ -199,6 +201,7 @@ const NacosServiceViewer: React.FC<NacosServiceViewerProps> = ({
   const [pageNo, setPageNo] = useState(1);
   const [pageSize, setPageSize] = useState(50);
   const [groupFilter, setGroupFilter] = useState(() => String(initialGroup || '').trim());
+  const [serviceFilter, setServiceFilter] = useState('');
   const [selectedServiceRaw, setSelectedServiceRaw] = useState<string | null>(null);
   const [selectedServiceDetail, setSelectedServiceDetail] = useState<NacosServiceDetail | null>(null);
   const [instances, setInstances] = useState<NacosInstance[]>([]);
@@ -238,6 +241,7 @@ const NacosServiceViewer: React.FC<NacosServiceViewerProps> = ({
     page: 1,
     pageSize: 50,
     group: String(initialGroup || '').trim(),
+    serviceName: '',
   });
   activeContextRef.current = { connectionId, namespaceId, rpcConfig };
 
@@ -308,6 +312,7 @@ const NacosServiceViewer: React.FC<NacosServiceViewerProps> = ({
       page = 1,
       requestedGroup = groupFilter.trim(),
       requestedPageSize = pageSize,
+      requestedServiceName = serviceFilter.trim(),
       options?: NacosLoadOptions,
     ) => {
       if (!rpcConfig) return;
@@ -317,11 +322,13 @@ const NacosServiceViewer: React.FC<NacosServiceViewerProps> = ({
         page,
         pageSize: requestedPageSize,
         group: requestedGroup,
+        serviceName: requestedServiceName,
       };
       setLoadingServices(true);
       try {
         const res = await (window as any).go.app.App.NacosListServices(rpcConfig, {
           namespaceId: namespaceId || '',
+          serviceName: requestedServiceName,
           groupName: requestedGroup,
           pageNo: page,
           pageSize: requestedPageSize,
@@ -336,7 +343,7 @@ const NacosServiceViewer: React.FC<NacosServiceViewerProps> = ({
         const total = Number(pageData.count) || names.length;
         const lastPage = Math.max(1, Math.ceil(total / requestedPageSize));
         if (names.length === 0 && page > lastPage) {
-          await loadServices(lastPage, requestedGroup, requestedPageSize, options);
+          await loadServices(lastPage, requestedGroup, requestedPageSize, requestedServiceName, options);
           return;
         }
         setServiceNames(names);
@@ -362,7 +369,7 @@ const NacosServiceViewer: React.FC<NacosServiceViewerProps> = ({
         }
       }
     },
-    [rpcConfig, namespaceId, groupFilter, pageSize, closeInstanceModal],
+    [rpcConfig, namespaceId, groupFilter, pageSize, serviceFilter, closeInstanceModal],
   );
 
   const loadInstances = useCallback(
@@ -454,6 +461,7 @@ const NacosServiceViewer: React.FC<NacosServiceViewerProps> = ({
     instanceRequestIdRef.current += 1;
     selectedServiceRawRef.current = null;
     setGroupFilter(requestedGroup);
+    setServiceFilter('');
     setServiceNames([]);
     setServiceTotal(0);
     setPageNo(1);
@@ -464,7 +472,7 @@ const NacosServiceViewer: React.FC<NacosServiceViewerProps> = ({
     closeInstanceModal();
     setLoadingServices(false);
     setLoadingInstances(false);
-    void loadServices(1, requestedGroup);
+    void loadServices(1, requestedGroup, undefined, '');
     return () => {
       serviceRequestIdRef.current += 1;
       instanceRequestIdRef.current += 1;
@@ -496,7 +504,7 @@ const NacosServiceViewer: React.FC<NacosServiceViewerProps> = ({
     const refresh = async () => {
       if (cancelled || autoRefreshGenerationRef.current !== generation) return;
       const view = serviceViewRef.current;
-      await loadServicesRef.current(view.page, view.group, view.pageSize, { silent: true });
+      await loadServicesRef.current(view.page, view.group, view.pageSize, view.serviceName, { silent: true });
       if (cancelled || autoRefreshGenerationRef.current !== generation) return;
       const selected = selectedServiceRawRef.current;
       if (selected) {
@@ -558,6 +566,7 @@ const NacosServiceViewer: React.FC<NacosServiceViewerProps> = ({
           currentView.requestId === sourceView.requestId ? 1 : currentView.page,
           currentView.group,
           currentView.pageSize,
+          currentView.serviceName,
         );
       }
       message.success(tr('nacos_service.message.service_create_success'));
@@ -611,7 +620,7 @@ const NacosServiceViewer: React.FC<NacosServiceViewerProps> = ({
           const lastRemainingPage = Math.max(1, Math.ceil(remainingTotal / currentView.pageSize));
           refreshPage = Math.min(sourceView.page, lastRemainingPage);
         }
-        await loadServices(refreshPage, currentView.group, currentView.pageSize);
+        await loadServices(refreshPage, currentView.group, currentView.pageSize, currentView.serviceName);
       }
       message.success(tr('nacos_service.message.service_delete_success'));
     } catch (error: any) {
@@ -957,6 +966,15 @@ const NacosServiceViewer: React.FC<NacosServiceViewerProps> = ({
                 onChange={(event) => setGroupFilter(event.target.value)}
                 onPressEnter={() => void loadServices(1)}
               />
+              <Input
+                allowClear
+                {...noAutoCapInputProps}
+                style={{ width: 180 }}
+                placeholder={tr('nacos_service.field.service')}
+                value={serviceFilter}
+                onChange={(event) => setServiceFilter(event.target.value)}
+                onPressEnter={() => void loadServices(1, groupFilter.trim(), pageSize, serviceFilter.trim())}
+              />
               <Button icon={<ReloadOutlined />} loading={loadingServices} onClick={() => void loadServices(1)}>
                 {tr('nacos_viewer.action.refresh')}
               </Button>
@@ -1101,10 +1119,10 @@ const NacosServiceViewer: React.FC<NacosServiceViewerProps> = ({
                 onChange={(page, nextPageSize) => {
                   const size = nextPageSize || pageSize;
                   if (size !== pageSize) {
-                    void loadServices(1, groupFilter.trim(), size);
+                    void loadServices(1, groupFilter.trim(), size, serviceFilter.trim());
                     return;
                   }
-                  void loadServices(page, groupFilter.trim(), size);
+                  void loadServices(page, groupFilter.trim(), size, serviceFilter.trim());
                 }}
               />
             </div>

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1455,6 +1455,7 @@ export namespace app {
 	}
 	export class NacosServiceQuery {
 	    namespaceId: string;
+	    serviceName?: string;
 	    groupName?: string;
 	    pageNo?: number;
 	    pageSize?: number;
@@ -1466,6 +1467,7 @@ export namespace app {
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.namespaceId = source["namespaceId"];
+	        this.serviceName = source["serviceName"];
 	        this.groupName = source["groupName"];
 	        this.pageNo = source["pageNo"];
 	        this.pageSize = source["pageSize"];

--- a/internal/app/methods_nacos.go
+++ b/internal/app/methods_nacos.go
@@ -121,6 +121,7 @@ type NacosHistoryQuery struct {
 // NacosServiceQuery lists services.
 type NacosServiceQuery struct {
 	NamespaceID string `json:"namespaceId"`
+	ServiceName string `json:"serviceName,omitempty"`
 	GroupName   string `json:"groupName,omitempty"`
 	PageNo      int    `json:"pageNo,omitempty"`
 	PageSize    int    `json:"pageSize,omitempty"`
@@ -914,6 +915,7 @@ func (a *App) NacosListServices(config connection.ConnectionConfig, query NacosS
 	}
 	page, err := client.ListServices(ctx, nacos.ServiceQuery{
 		NamespaceID: query.NamespaceID,
+		ServiceName: query.ServiceName,
 		GroupName:   query.GroupName,
 		PageNo:      query.PageNo,
 		PageSize:    query.PageSize,

--- a/internal/nacos/api_version_test.go
+++ b/internal/nacos/api_version_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -579,7 +578,7 @@ func TestNacosV3ListServicesFiltersExactGroupAcrossPages(t *testing.T) {
 	}
 }
 
-func TestNacosV3ListServicesEscapesExactGroupPattern(t *testing.T) {
+func TestNacosV3ListServicesFiltersExactGroupWithoutRegex(t *testing.T) {
 	const targetGroup = "PAY[1]"
 
 	recorder := &nacosAPIRequestRecorder{}
@@ -589,11 +588,6 @@ func TestNacosV3ListServicesEscapesExactGroupPattern(t *testing.T) {
 		case nacosV3ReadinessPath:
 			writeNacosResult(w, nacosAPIV3, "ok")
 		case routesForNacosAPI(nacosAPIV3).serviceList:
-			groupPattern, err := regexp.Compile(request.Form.Get("groupNameParam"))
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
 			candidates := []nacosServiceItem{
 				{Name: "literal", GroupName: targetGroup},
 				{Name: "regex-lookalike", GroupName: "PAY1"},
@@ -601,9 +595,7 @@ func TestNacosV3ListServicesEscapesExactGroupPattern(t *testing.T) {
 			}
 			pageItems := make([]nacosServiceItem, 0, len(candidates))
 			for _, candidate := range candidates {
-				if groupPattern.MatchString(candidate.GroupName) {
-					pageItems = append(pageItems, candidate)
-				}
+				pageItems = append(pageItems, candidate)
 			}
 			writeNacosResult(w, nacosAPIV3, map[string]any{
 				"totalCount":     len(pageItems),
@@ -633,7 +625,7 @@ func TestNacosV3ListServicesEscapesExactGroupPattern(t *testing.T) {
 	}
 
 	request := mustLastNacosAPIRequest(t, recorder, http.MethodGet, routesForNacosAPI(nacosAPIV3).serviceList)
-	if got, want := request.values.Get("groupNameParam"), regexp.QuoteMeta(targetGroup); got != want {
+	if got, want := request.values.Get("groupNameParam"), targetGroup; got != want {
 		t.Fatalf("groupNameParam = %q, want %q", got, want)
 	}
 }

--- a/internal/nacos/naming.go
+++ b/internal/nacos/naming.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -47,6 +46,9 @@ func (c *ClientImpl) ListServices(ctx context.Context, query ServiceQuery) (*Ser
 
 	groupName := strings.TrimSpace(query.GroupName)
 	serviceName := strings.TrimSpace(query.ServiceName)
+	if (family == nacosAPIV1 || family == nacosAPIV2) && groupName != "" && serviceName != "" {
+		return c.listCatalogServicesByExactGroup(ctx, query.NamespaceID, groupName, serviceName, pageNo, pageSize)
+	}
 	if family == nacosAPIV3 && groupName != "" {
 		return c.listV3ServicesByExactGroup(ctx, query.NamespaceID, groupName, serviceName, pageNo, pageSize)
 	}
@@ -62,11 +64,7 @@ func (c *ClientImpl) ListServices(ctx context.Context, query ServiceQuery) (*Ser
 		// Nacos 2.x has no cross-group v2 service list, but retains v1 Catalog.
 		apiPath = routesForNacosAPI(nacosAPIV1).serviceList
 		params.Set("serviceNameParam", serviceName)
-		if groupName == "" {
-			params.Set("groupNameParam", "")
-		} else {
-			params.Set("groupNameParam", "^"+regexp.QuoteMeta(groupName)+"$")
-		}
+		params.Set("groupNameParam", "")
 	} else if family == nacosAPIV1 || family == nacosAPIV2 {
 		apiPath = routes.serviceListByGroup
 		params.Set("groupName", normalizeServiceGroup(groupName))
@@ -183,6 +181,76 @@ func (c *ClientImpl) ListServices(ctx context.Context, query ServiceQuery) (*Ser
 	}, nil
 }
 
+func (c *ClientImpl) listCatalogServicesByExactGroup(
+	ctx context.Context,
+	namespaceID string,
+	groupName string,
+	serviceName string,
+	pageNo int,
+	pageSize int,
+) (*ServicePage, error) {
+	groupName = normalizeServiceGroup(groupName)
+	matched := make([]nacosServiceItem, 0)
+	for remotePageNo := 1; ; remotePageNo++ {
+		params := url.Values{}
+		params.Set("pageNo", strconv.Itoa(remotePageNo))
+		params.Set("pageSize", strconv.Itoa(maxServicePageSize))
+		params.Set("namespaceId", normalizeNamespaceID(namespaceID))
+		params.Set("serviceNameParam", serviceName)
+		// Nacos validates this parameter as a plain value; regex anchors are rejected.
+		params.Set("groupNameParam", groupName)
+
+		body, status, err := c.doRequest(ctx, http.MethodGet, routesForNacosAPI(nacosAPIV1).serviceList, params, nil)
+		if err != nil {
+			return nil, err
+		}
+		if status < 200 || status >= 300 {
+			return nil, localizedNacosBackendError("nacos.backend.error.http_status", map[string]any{
+				"status": status,
+				"body":   truncateForError(string(body)),
+			})
+		}
+		data, err := unwrapNacosResult(body)
+		if err != nil {
+			return nil, err
+		}
+		var payload struct {
+			ServiceList []nacosServiceItem `json:"serviceList"`
+		}
+		if err := json.Unmarshal(data, &payload); err != nil {
+			return nil, localizedNacosBackendError("nacos.backend.error.parse_services", map[string]any{
+				"detail": err.Error(),
+			})
+		}
+		for _, service := range payload.ServiceList {
+			if strings.TrimSpace(service.GroupName) == groupName {
+				matched = append(matched, service)
+			}
+		}
+		if len(payload.ServiceList) < maxServicePageSize {
+			break
+		}
+	}
+
+	start := (pageNo - 1) * pageSize
+	if start > len(matched) {
+		start = len(matched)
+	}
+	end := min(start+pageSize, len(matched))
+	names := make([]string, 0, end-start)
+	for _, service := range matched[start:end] {
+		if name := qualifyServiceName(service.Name, service.GroupName); name != "" {
+			names = append(names, name)
+		}
+	}
+	return &ServicePage{
+		Count:        int64(len(matched)),
+		ServiceNames: names,
+		PageNo:       pageNo,
+		PageSize:     pageSize,
+	}, nil
+}
+
 func (c *ClientImpl) listV3ServicesByExactGroup(
 	ctx context.Context,
 	namespaceID string,
@@ -199,7 +267,8 @@ func (c *ClientImpl) listV3ServicesByExactGroup(
 		params.Set("pageSize", strconv.Itoa(maxServicePageSize))
 		params.Set("namespaceId", normalizeNamespaceID(namespaceID))
 		params.Set("serviceNameParam", serviceName)
-		params.Set("groupNameParam", regexp.QuoteMeta(groupName))
+		// Nacos validates this parameter as a plain value; regex escaping is rejected.
+		params.Set("groupNameParam", groupName)
 
 		body, status, err := c.doRequest(ctx, http.MethodGet, c.currentAPIRoutes().serviceListByGroup, params, nil)
 		if err != nil {

--- a/internal/nacos/naming.go
+++ b/internal/nacos/naming.go
@@ -65,7 +65,7 @@ func (c *ClientImpl) ListServices(ctx context.Context, query ServiceQuery) (*Ser
 		if groupName == "" {
 			params.Set("groupNameParam", "")
 		} else {
-			params.Set("groupNameParam", regexp.QuoteMeta(groupName))
+			params.Set("groupNameParam", "^"+regexp.QuoteMeta(groupName)+"$")
 		}
 	} else if family == nacosAPIV1 || family == nacosAPIV2 {
 		apiPath = routes.serviceListByGroup
@@ -156,6 +156,16 @@ func (c *ClientImpl) ListServices(ctx context.Context, query ServiceQuery) (*Ser
 		}
 		count = payload.Count
 		services = payload.ServiceList
+	}
+	if useCatalog && groupName != "" {
+		filtered := make([]nacosServiceItem, 0, len(services))
+		for _, service := range services {
+			if strings.TrimSpace(service.GroupName) == groupName {
+				filtered = append(filtered, service)
+			}
+		}
+		services = filtered
+		count = int64(len(services))
 	}
 
 	names := make([]string, 0, len(services))

--- a/internal/nacos/naming.go
+++ b/internal/nacos/naming.go
@@ -57,11 +57,16 @@ func (c *ClientImpl) ListServices(ctx context.Context, query ServiceQuery) (*Ser
 	params.Set("namespaceId", normalizeNamespaceID(query.NamespaceID))
 	routes := c.currentAPIRoutes()
 	apiPath := routes.serviceList
-	if (family == nacosAPIV1 || family == nacosAPIV2) && groupName == "" {
+	useCatalog := (family == nacosAPIV1 || family == nacosAPIV2) && (groupName == "" || serviceName != "")
+	if useCatalog {
 		// Nacos 2.x has no cross-group v2 service list, but retains v1 Catalog.
 		apiPath = routesForNacosAPI(nacosAPIV1).serviceList
 		params.Set("serviceNameParam", serviceName)
-		params.Set("groupNameParam", "")
+		if groupName == "" {
+			params.Set("groupNameParam", "")
+		} else {
+			params.Set("groupNameParam", regexp.QuoteMeta(groupName))
+		}
 	} else if family == nacosAPIV1 || family == nacosAPIV2 {
 		apiPath = routes.serviceListByGroup
 		params.Set("groupName", normalizeServiceGroup(groupName))
@@ -97,6 +102,18 @@ func (c *ClientImpl) ListServices(ctx context.Context, query ServiceQuery) (*Ser
 		}
 		count = payload.TotalCount
 		services = payload.PageItems
+	} else if useCatalog {
+		var payload struct {
+			Count       int64              `json:"count"`
+			ServiceList []nacosServiceItem `json:"serviceList"`
+		}
+		if err := json.Unmarshal(data, &payload); err != nil {
+			return nil, localizedNacosBackendError("nacos.backend.error.parse_services", map[string]any{
+				"detail": err.Error(),
+			})
+		}
+		count = payload.Count
+		services = payload.ServiceList
 	} else if family == nacosAPIV1 && groupName != "" {
 		var payload struct {
 			Count int64    `json:"count"`

--- a/internal/nacos/naming.go
+++ b/internal/nacos/naming.go
@@ -46,8 +46,9 @@ func (c *ClientImpl) ListServices(ctx context.Context, query ServiceQuery) (*Ser
 	}
 
 	groupName := strings.TrimSpace(query.GroupName)
+	serviceName := strings.TrimSpace(query.ServiceName)
 	if family == nacosAPIV3 && groupName != "" {
-		return c.listV3ServicesByExactGroup(ctx, query.NamespaceID, groupName, pageNo, pageSize)
+		return c.listV3ServicesByExactGroup(ctx, query.NamespaceID, groupName, serviceName, pageNo, pageSize)
 	}
 
 	params := url.Values{}
@@ -59,13 +60,14 @@ func (c *ClientImpl) ListServices(ctx context.Context, query ServiceQuery) (*Ser
 	if (family == nacosAPIV1 || family == nacosAPIV2) && groupName == "" {
 		// Nacos 2.x has no cross-group v2 service list, but retains v1 Catalog.
 		apiPath = routesForNacosAPI(nacosAPIV1).serviceList
-		params.Set("serviceNameParam", "")
+		params.Set("serviceNameParam", serviceName)
 		params.Set("groupNameParam", "")
 	} else if family == nacosAPIV1 || family == nacosAPIV2 {
 		apiPath = routes.serviceListByGroup
 		params.Set("groupName", normalizeServiceGroup(groupName))
+		params.Set("serviceNameParam", serviceName)
 	} else {
-		params.Set("serviceNameParam", "")
+		params.Set("serviceNameParam", serviceName)
 		params.Set("groupNameParam", groupName)
 	}
 
@@ -158,6 +160,7 @@ func (c *ClientImpl) listV3ServicesByExactGroup(
 	ctx context.Context,
 	namespaceID string,
 	groupName string,
+	serviceName string,
 	pageNo int,
 	pageSize int,
 ) (*ServicePage, error) {
@@ -168,7 +171,7 @@ func (c *ClientImpl) listV3ServicesByExactGroup(
 		params.Set("pageNo", strconv.Itoa(remotePageNo))
 		params.Set("pageSize", strconv.Itoa(maxServicePageSize))
 		params.Set("namespaceId", normalizeNamespaceID(namespaceID))
-		params.Set("serviceNameParam", "")
+		params.Set("serviceNameParam", serviceName)
 		params.Set("groupNameParam", regexp.QuoteMeta(groupName))
 
 		body, status, err := c.doRequest(ctx, http.MethodGet, c.currentAPIRoutes().serviceListByGroup, params, nil)

--- a/internal/nacos/naming_test.go
+++ b/internal/nacos/naming_test.go
@@ -227,6 +227,7 @@ func TestListServicesUsesCatalogAcrossGroups(t *testing.T) {
 
 	page, err := client.ListServices(context.Background(), ServiceQuery{
 		NamespaceID: "mkefu-dev",
+		ServiceName: "order",
 		PageNo:      1,
 		PageSize:    50,
 	})
@@ -236,6 +237,9 @@ func TestListServicesUsesCatalogAcrossGroups(t *testing.T) {
 	groupValues, hasGroupParam := catalogQuery["groupNameParam"]
 	if catalogQuery.Get("namespaceId") != "mkefu-dev" || !hasGroupParam || len(groupValues) != 1 || groupValues[0] != "" {
 		t.Fatalf("catalog query = %#v", catalogQuery)
+	}
+	if catalogQuery.Get("serviceNameParam") != "order" {
+		t.Fatalf("catalog serviceNameParam = %q, want order", catalogQuery.Get("serviceNameParam"))
 	}
 	want := []string{"MKEFU_SERVICE@@orders", "DEFAULT_GROUP@@payments"}
 	if page.Count != 2 || len(page.ServiceNames) != len(want) {
@@ -249,6 +253,7 @@ func TestListServicesUsesCatalogAcrossGroups(t *testing.T) {
 
 	groupPage, err := client.ListServices(context.Background(), ServiceQuery{
 		NamespaceID: "mkefu-dev",
+		ServiceName: "order",
 		GroupName:   "MKEFU_SERVICE",
 		PageNo:      1,
 		PageSize:    50,
@@ -258,6 +263,9 @@ func TestListServicesUsesCatalogAcrossGroups(t *testing.T) {
 	}
 	if groupQuery.Get("groupName") != "MKEFU_SERVICE" || groupQuery.Get("namespaceId") != "mkefu-dev" {
 		t.Fatalf("exact group query = %#v", groupQuery)
+	}
+	if groupQuery.Get("serviceNameParam") != "order" {
+		t.Fatalf("exact group serviceNameParam = %q, want order", groupQuery.Get("serviceNameParam"))
 	}
 	if groupPage.Count != 1 || len(groupPage.ServiceNames) != 1 || groupPage.ServiceNames[0] != "MKEFU_SERVICE@@orders" {
 		t.Fatalf("exact group page = %#v", groupPage)

--- a/internal/nacos/naming_test.go
+++ b/internal/nacos/naming_test.go
@@ -264,7 +264,7 @@ func TestListServicesUsesCatalogAcrossGroups(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListServices with group: %v", err)
 	}
-	if catalogQuery.Get("groupNameParam") != "^MKEFU_SERVICE$" || catalogQuery.Get("namespaceId") != "mkefu-dev" {
+	if catalogQuery.Get("groupNameParam") != "MKEFU_SERVICE" || catalogQuery.Get("namespaceId") != "mkefu-dev" {
 		t.Fatalf("exact group query = %#v", catalogQuery)
 	}
 	if catalogQuery.Get("serviceNameParam") != "order" {

--- a/internal/nacos/naming_test.go
+++ b/internal/nacos/naming_test.go
@@ -202,10 +202,13 @@ func TestListServicesUsesCatalogAcrossGroups(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(map[string]any{"code": 200, "data": []any{}})
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/v1/ns/catalog/services"):
 			catalogQuery = r.URL.Query()
-			if catalogQuery.Get("groupNameParam") == "MKEFU_SERVICE" {
+			if catalogQuery.Get("groupNameParam") == "^MKEFU_SERVICE$" {
 				_ = json.NewEncoder(w).Encode(map[string]any{
-					"count":       1,
-					"serviceList": []map[string]any{{"name": "orders", "groupName": "MKEFU_SERVICE"}},
+					"count": 2,
+					"serviceList": []map[string]any{
+						{"name": "orders", "groupName": "MKEFU_SERVICE"},
+						{"name": "other", "groupName": "MKEFU_SERVICE_ARCHIVE"},
+					},
 				})
 				return
 			}
@@ -261,7 +264,7 @@ func TestListServicesUsesCatalogAcrossGroups(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListServices with group: %v", err)
 	}
-	if catalogQuery.Get("groupNameParam") != "MKEFU_SERVICE" || catalogQuery.Get("namespaceId") != "mkefu-dev" {
+	if catalogQuery.Get("groupNameParam") != "^MKEFU_SERVICE$" || catalogQuery.Get("namespaceId") != "mkefu-dev" {
 		t.Fatalf("exact group query = %#v", catalogQuery)
 	}
 	if catalogQuery.Get("serviceNameParam") != "order" {

--- a/internal/nacos/naming_test.go
+++ b/internal/nacos/naming_test.go
@@ -196,25 +196,25 @@ func TestNamingServiceAndInstanceFlow(t *testing.T) {
 
 func TestListServicesUsesCatalogAcrossGroups(t *testing.T) {
 	var catalogQuery url.Values
-	var groupQuery url.Values
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/v1/console/namespaces"):
 			_ = json.NewEncoder(w).Encode(map[string]any{"code": 200, "data": []any{}})
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/v1/ns/catalog/services"):
 			catalogQuery = r.URL.Query()
+			if catalogQuery.Get("groupNameParam") == "MKEFU_SERVICE" {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"count":       1,
+					"serviceList": []map[string]any{{"name": "orders", "groupName": "MKEFU_SERVICE"}},
+				})
+				return
+			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"count": 2,
 				"serviceList": []map[string]any{
 					{"name": "orders", "groupName": "MKEFU_SERVICE"},
 					{"name": "payments", "groupName": "DEFAULT_GROUP"},
 				},
-			})
-		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/v1/ns/service/list"):
-			groupQuery = r.URL.Query()
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"count": 1,
-				"doms":  []string{"orders"},
 			})
 		default:
 			http.NotFound(w, r)
@@ -261,11 +261,11 @@ func TestListServicesUsesCatalogAcrossGroups(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListServices with group: %v", err)
 	}
-	if groupQuery.Get("groupName") != "MKEFU_SERVICE" || groupQuery.Get("namespaceId") != "mkefu-dev" {
-		t.Fatalf("exact group query = %#v", groupQuery)
+	if catalogQuery.Get("groupNameParam") != "MKEFU_SERVICE" || catalogQuery.Get("namespaceId") != "mkefu-dev" {
+		t.Fatalf("exact group query = %#v", catalogQuery)
 	}
-	if groupQuery.Get("serviceNameParam") != "order" {
-		t.Fatalf("exact group serviceNameParam = %q, want order", groupQuery.Get("serviceNameParam"))
+	if catalogQuery.Get("serviceNameParam") != "order" {
+		t.Fatalf("exact group serviceNameParam = %q, want order", catalogQuery.Get("serviceNameParam"))
 	}
 	if groupPage.Count != 1 || len(groupPage.ServiceNames) != 1 || groupPage.ServiceNames[0] != "MKEFU_SERVICE@@orders" {
 		t.Fatalf("exact group page = %#v", groupPage)

--- a/internal/nacos/types.go
+++ b/internal/nacos/types.go
@@ -167,6 +167,7 @@ type ConfigListenTarget struct {
 // ServiceQuery lists services under a namespace.
 type ServiceQuery struct {
 	NamespaceID string `json:"namespaceId"`
+	ServiceName string `json:"serviceName,omitempty"`
 	GroupName   string `json:"groupName,omitempty"`
 	PageNo      int    `json:"pageNo,omitempty"`
 	PageSize    int    `json:"pageSize,omitempty"`


### PR DESCRIPTION
## 问题背景

Nacos 服务查询缺少服务名称筛选，组合筛选请求还可能携带不兼容的正则分组参数，导致查询失败。

## 修复内容

- 增加 Nacos 服务名称查询能力。
- 组合服务名称与分组筛选改用目录接口。
- 保持分组精确匹配，避免向服务查询接口发送正则分组参数。
- 补充前端交互和后端命名查询回归测试。

## 验证方式

- 本次 PR 交付未重新执行测试或构建。
- 提交中包含对应的前端交互及后端查询测试覆盖。

## 影响与风险

- 仅影响 Nacos 服务查询筛选流程，不改变其他数据源行为。
- 如需回滚，可回退本 PR 的 5 条提交。

## 关联 Issue

Closes #1089

