### PR TITLE
修复历史 SQL 文件表别名补全

### DIFF
--- a/frontend/src/components/QueryEditor.external-sql-save.test.tsx
+++ b/frontend/src/components/QueryEditor.external-sql-save.test.tsx
@@ -4051,6 +4051,55 @@ describe('QueryEditor external SQL save', () => {
     expect(conflictResult.suggestions.find((item: any) => item.label === 'system_user')?.insertText)
       .toBe('system_user AS su2');
 
+    storeState.connections[0].config.type = 'tidb';
+    editorState.value = 'SELECT * FROM sys';
+    editorState.latestOnChange?.(editorState.value);
+    const tidbResult = await sqlProvider.provideCompletionItems(
+      editorState.editor.getModel(),
+      { lineNumber: 1, column: editorState.value.length + 1 },
+    );
+    expect(tidbResult.suggestions.find((item: any) => item.label === 'system_user')?.insertText)
+      .toBe('system_user AS su');
+
+    editorState.value = '\uFEFF-- legacy completion test\r\nSELECT *\r\nFROM sys';
+    editorState.latestOnChange?.(editorState.value);
+    const crlfResult = await sqlProvider.provideCompletionItems(
+      editorState.editor.getModel(),
+      { lineNumber: 3, column: 9 },
+    );
+    expect(crlfResult.suggestions.find((item: any) => item.label === 'system_user')?.insertText)
+      .toBe('system_user AS su');
+    expect(editorState.value).toBe('\uFEFF-- legacy completion test\r\nSELECT *\r\nFROM sys');
+
+    storeState.connections[0].config.type = 'oracle';
+    editorState.value = 'SELECT * FROM sys';
+    editorState.latestOnChange?.(editorState.value);
+    const oracleResult = await sqlProvider.provideCompletionItems(
+      editorState.editor.getModel(),
+      { lineNumber: 1, column: editorState.value.length + 1 },
+    );
+    expect(oracleResult.suggestions.find((item: any) => item.label === 'system_user')?.insertText)
+      .toBe('system_user su');
+
+    storeState.connections[0].config.type = 'oceanbase';
+    (storeState.connections[0].config as Record<string, unknown>).oceanBaseProtocol = 'oracle';
+    const oceanBaseOracleResult = await sqlProvider.provideCompletionItems(
+      editorState.editor.getModel(),
+      { lineNumber: 1, column: editorState.value.length + 1 },
+    );
+    expect(oceanBaseOracleResult.suggestions.find((item: any) => item.label === 'system_user')?.insertText)
+      .toBe('system_user su');
+
+    storeState.connections[0].config.type = 'iotdb';
+    const unsupportedDialectResult = await sqlProvider.provideCompletionItems(
+      editorState.editor.getModel(),
+      { lineNumber: 1, column: editorState.value.length + 1 },
+    );
+    expect(unsupportedDialectResult.suggestions.find((item: any) => item.label === 'system_user')?.insertText)
+      .toBe('system_user');
+
+    storeState.connections[0].config.type = 'mysql';
+    (storeState.connections[0].config as Record<string, unknown>).oceanBaseProtocol = undefined;
     editorState.value = 'SELECT * FROM code';
     editorState.latestOnChange?.(editorState.value);
     const initialsResult = await sqlProvider.provideCompletionItems(
@@ -8674,7 +8723,7 @@ describe('QueryEditor external SQL save', () => {
       const tableSuggestion = completionItems?.suggestions?.find((item: any) => item?.label === 'AAA3_NJ');
 
       expect(tableSuggestion).toBeTruthy();
-      expect(tableSuggestion.insertText).toBe('AAA3_NJ AS an');
+      expect(tableSuggestion.insertText).toBe('AAA3_NJ an');
       expect(tableSuggestion.detail).toContain('表 (sbdev)');
       expect(completionItems?.suggestions?.some((item: any) => item?.label === 'sbdev.SBDEV.AAA3_NJ')).toBe(false);
     });

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -44,7 +44,7 @@ import { downloadBrowserTextFile, isWebRuntime } from '../utils/browserFileTrans
 import { filterVisibleDatabaseNames } from '../utils/databaseVisibility';
 import { isPostgresSchemaDialect } from '../utils/connectionDriverType';
 import { resolveOceanBaseProtocolFromConfig } from '../utils/oceanBaseProtocol';
-import { isOracleLikeDialect, resolveSqlDialect, resolveSqlFunctions, resolveSqlKeywords } from '../utils/sqlDialect';
+import { appendTableAlias, isOracleLikeDialect, resolveSqlDialect, resolveSqlFunctions, resolveSqlKeywords } from '../utils/sqlDialect';
 import { applyQueryAutoLimit } from '../utils/queryAutoLimit';
 import {
     buildQueryResultCountSql,
@@ -376,6 +376,12 @@ const normalizeQueryEditorInlineMemorySqlKey = (sql: string): string => (
         .trim()
         .toLowerCase()
 );
+
+const normalizeQueryEditorCompletionAnalysisText = (sql: string): string => {
+    const normalized = String(sql || '').replace(/\r\n?/g, '\n');
+    // Preserve offsets while preventing a UTF-8 BOM from becoming part of SQL syntax analysis.
+    return normalized.startsWith('\uFEFF') ? ` ${normalized.slice(1)}` : normalized;
+};
 
 const matchesQueryEditorInlineMemoryDb = (currentDb: string, candidateDb?: string): boolean => {
     const normalizedCurrentDb = String(currentDb || '').trim().toLowerCase();
@@ -2705,6 +2711,11 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
           host: resolveQueryEditorAiConnectionHost(conn),
           port: conn?.config?.port,
           sourceType: conn?.config?.type,
+          sqlDialect: resolveSqlDialect(
+              String(conn?.config?.type || ''),
+              String(conn?.config?.driver || ''),
+              { oceanBaseProtocol: conn?.config?.oceanBaseProtocol },
+          ),
           currentDb: currentDbName,
           visibleDbs: visibleDbsRef.current,
           tables: [...mergedTablesByKey.values()],
@@ -6789,15 +6800,15 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                   return [] as CompletionColumnMeta[];
               };
 
-              const fullText = model.getValue();
+              const fullText = normalizeQueryEditorCompletionAnalysisText(model.getValue());
               const cursorOffset = getNormalizedOffsetAtPosition(fullText, {
                   lineNumber: Number(position?.lineNumber || 1),
                   column: Number(position?.column || 1),
               });
               const currentStatementRange = resolveCurrentSqlStatementRange(fullText, cursorOffset, activeDialect);
 
-              // 获取当前行光标前的内容
-              const linePrefix = model.getLineContent(position.lineNumber).slice(0, position.column - 1);
+              const lineStartOffset = fullText.lastIndexOf('\n', Math.max(0, cursorOffset - 1)) + 1;
+              const linePrefix = fullText.slice(lineStartOffset, cursorOffset);
               const currentStatementPrefix = currentStatementRange
                   ? fullText.slice(currentStatementRange.start, cursorOffset)
                   : fullText.slice(0, cursorOffset);
@@ -6809,7 +6820,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
               const appendTableSourceAlias = (insertText: string, tableName: string) => {
                   if (!isTableAliasCompletion || useStore.getState().appearance.autoAddTableAlias === false) return insertText;
                   const alias = buildQueryEditorTableSourceAlias(tableName, completionReferenceText);
-                  return alias ? `${insertText} AS ${alias}` : insertText;
+                  return appendTableAlias(insertText, alias, activeDialect);
               };
 
               // 0) 三段式 db.table.column 格式：当输入 db.table. 时提示列

--- a/frontend/src/components/queryEditor/QueryEditorAiAssist.test.ts
+++ b/frontend/src/components/queryEditor/QueryEditorAiAssist.test.ts
@@ -785,6 +785,28 @@ describe('QueryEditorAiAssist', () => {
         expect(service.AIChatSend).not.toHaveBeenCalled();
     });
 
+    it('uses the resolved OceanBase Oracle dialect for table aliases', async () => {
+        const service = readyService('SELECT * FROM system_user su;');
+        await expect(requestQueryEditorInlineCompletion({
+            service,
+            aiContext: {
+                connectionName: 'OceanBase Oracle',
+                sourceType: 'oceanbase',
+                sqlDialect: 'oracle',
+                currentDb: 'ORCL',
+                tables: [{ dbName: 'ORCL', tableName: 'system_user' }],
+                columns: [],
+            },
+            editorSnapshot: {
+                prefix: 'SELECT * FROM system_user ',
+                suffix: '',
+                currentLineBeforeCursor: 'SELECT * FROM system_user ',
+                currentLineAfterCursor: '',
+            },
+        })).resolves.toBe('su');
+        expect(service.AIChatSend).not.toHaveBeenCalled();
+    });
+
     it('does not suggest an alias after a manually completed table source when disabled', async () => {
         const service = readyService('SELECT * FROM system_user su;');
         await expect(requestQueryEditorInlineCompletion({

--- a/frontend/src/components/queryEditor/QueryEditorAiAssist.ts
+++ b/frontend/src/components/queryEditor/QueryEditorAiAssist.ts
@@ -13,6 +13,7 @@ import {
     isQueryEditorTableAliasCompletionContext,
 } from './QueryEditorHelpers';
 import { isPostgresSchemaDialect } from '../../utils/connectionDriverType';
+import { appendTableAlias, resolveTableAliasSyntax } from '../../utils/sqlDialect';
 
 export type QueryEditorAiApplyMode = 'insert' | 'replaceSelection' | 'replaceAll';
 
@@ -44,6 +45,7 @@ export interface QueryEditorAiContext {
     host?: string;
     port?: string | number;
     sourceType?: string;
+    sqlDialect?: string;
     currentDb?: string;
     visibleDbs?: string[];
     tables?: CompletionTableMeta[];
@@ -376,7 +378,7 @@ export const resolveQueryEditorInlineLocalCompletion = ({
 
     const isTableAliasContext = isQueryEditorInlineTableAliasPending(editorSnapshot);
     const tableAliasInsertText = autoAddTableAlias
-        ? resolveDeterministicInlineTableAliasInsertText(editorSnapshot)
+        ? resolveDeterministicInlineTableAliasInsertText(editorSnapshot, aiContext.sqlDialect || aiContext.sourceType)
         : '';
     if (tableAliasInsertText) {
         return {
@@ -384,7 +386,10 @@ export const resolveQueryEditorInlineLocalCompletion = ({
             insertText: tableAliasInsertText,
         };
     }
-    if (!autoAddTableAlias && isTableAliasContext) {
+    if (isTableAliasContext && (
+        !autoAddTableAlias
+        || resolveTableAliasSyntax(aiContext.sqlDialect || aiContext.sourceType || '') === 'none'
+    )) {
         return {
             handled: true,
             insertText: '',
@@ -1500,6 +1505,7 @@ const resolveDeterministicInlineTableInsertText = (
 
 const resolveDeterministicInlineTableAliasInsertText = (
     editorSnapshot: QueryEditorAiEditorSnapshot,
+    dialect?: string,
 ): string => {
     const statementPrefix = getCurrentStatementPrefix(editorSnapshot.prefix);
     if (!/\s$/.test(statementPrefix) || !isQueryEditorTableAliasCompletionContext(statementPrefix)) {
@@ -1511,7 +1517,7 @@ const resolveDeterministicInlineTableAliasInsertText = (
         return '';
     }
     const alias = buildQueryEditorTableSourceAlias(currentReference.tableIdent, statementPrefix);
-    return alias;
+    return appendTableAlias('', alias, dialect || '');
 };
 
 export const isQueryEditorInlineTableAliasPending = (

--- a/frontend/src/utils/sqlDialect.test.ts
+++ b/frontend/src/utils/sqlDialect.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, it } from 'vitest';
 import { setCurrentLanguage } from '../i18n';
 import {
   isMysqlFamilyDialect,
+  appendTableAlias,
   resolveColumnTypeOptions,
   resolveSqlDialect,
   resolveSqlFunctions,
   resolveSqlKeywords,
+  resolveTableAliasSyntax,
 } from './sqlDialect';
 
 const values = (options: Array<{ value: string }>) => options.map((item) => item.value);
@@ -58,6 +60,23 @@ describe('sqlDialect', () => {
     expect(isMysqlFamilyDialect('oceanbase')).toBe(true);
     expect(isMysqlFamilyDialect('starrocks')).toBe(true);
     expect(isMysqlFamilyDialect('oracle')).toBe(false);
+  });
+
+  it('uses dialect-compatible table alias syntax', () => {
+    expect(resolveTableAliasSyntax('mysql')).toBe('as');
+    expect(resolveTableAliasSyntax('tidb')).toBe('as');
+    expect(resolveTableAliasSyntax('postgres')).toBe('as');
+    expect(resolveTableAliasSyntax('oceanbase')).toBe('as');
+    expect(resolveTableAliasSyntax('oracle')).toBe('bare');
+    expect(resolveTableAliasSyntax(resolveSqlDialect('oceanbase', '', { oceanBaseProtocol: 'oracle' }))).toBe('bare');
+    expect(resolveTableAliasSyntax('dameng')).toBe('bare');
+    expect(resolveTableAliasSyntax('iotdb')).toBe('none');
+    expect(resolveTableAliasSyntax('unknown')).toBe('none');
+    expect(appendTableAlias('system_user', 'su', 'mysql')).toBe('system_user AS su');
+    expect(appendTableAlias('system_user', 'su', 'tidb')).toBe('system_user AS su');
+    expect(appendTableAlias('system_user', 'su', 'oracle')).toBe('system_user su');
+    expect(appendTableAlias('system_user', 'su', 'unknown')).toBe('system_user');
+    expect(appendTableAlias('', 'su', 'mysql')).toBe('AS su');
   });
 
   it('resolves field type options per datasource family', () => {

--- a/frontend/src/utils/sqlDialect.ts
+++ b/frontend/src/utils/sqlDialect.ts
@@ -215,6 +215,32 @@ export const isOracleLikeDialect = (dbType: string): boolean => (
 
 export const isSqlServerDialect = (dbType: string): boolean => resolveSqlDialect(dbType) === 'sqlserver';
 
+export type TableAliasSyntax = 'as' | 'bare' | 'none';
+
+export const resolveTableAliasSyntax = (dbType: string): TableAliasSyntax => {
+  const dialect = resolveSqlDialect(dbType);
+  if ([
+    'mysql', 'mariadb', 'tidb', 'oceanbase', 'diros', 'starrocks',
+    'postgres', 'kingbase', 'highgo', 'vastbase', 'opengauss', 'gaussdb',
+    'sqlserver', 'sqlite', 'duckdb', 'clickhouse', 'tdengine', 'trino',
+  ].includes(dialect)) {
+    return 'as';
+  }
+  if (['oracle', 'dameng', 'sphinx', 'iris'].includes(dialect)) {
+    return 'bare';
+  }
+  return 'none';
+};
+
+export const appendTableAlias = (tableName: string, alias: string, dbType: string): string => {
+  if (!alias) return tableName;
+  const syntax = resolveTableAliasSyntax(dbType);
+  const prefix = tableName ? `${tableName} ` : '';
+  if (syntax === 'as') return `${prefix}AS ${alias}`;
+  if (syntax === 'bare') return `${prefix}${alias}`;
+  return tableName;
+};
+
 export const isBacktickIdentifierDialect = (dbType: string): boolean => (
   isMysqlFamilyDialect(dbType) || ['clickhouse', 'tdengine', 'iotdb'].includes(resolveSqlDialect(dbType))
 );


### PR DESCRIPTION
## 修复内容

- 统一普通候选和内联补全的表别名生成规则。
- 对历史 SQL 的 BOM 与 CRLF 仅创建分析副本，避免补全偏移失准且不改写原文。
- 支持 MySQL、TiDB 等方言使用 AS；Oracle、OceanBase Oracle 使用裸别名；不支持的方言不追加别名。

## 验证

- 相关前端测试：385 项通过。
- 前端生产构建通过。
- Windows Wails 打包通过。
- 已完成独立代码审查，未发现确定性 P0/P1/P2 问题。

## 手工验收

- 待通过历史外部 SQL 文件验证候选点击和快捷键接受候选后的实际编辑器写回。