### PR TITLE
🐛 修复 V2 侧栏重复分割线

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8409,7 +8409,7 @@ function App() {
                 </>
                 )}
 
-                <div style={{ flex: 1, overflow: 'hidden', paddingBottom: isV2Ui ? 0 : 58, paddingRight: isSidebarCollapsed ? 0 : sidebarResizeHandleWidth, position: 'relative' }}>
+                <div style={{ flex: 1, overflow: 'hidden', paddingBottom: isV2Ui ? 0 : 58, paddingRight: isV2Ui || isSidebarCollapsed ? 0 : sidebarResizeHandleWidth, position: 'relative' }}>
                     <div style={{ height: '100%', opacity: connectionWorkbenchState.ready ? 1 : 0.72, pointerEvents: connectionWorkbenchState.ready ? 'auto' : 'none' }}>
                         <Sidebar
                             onCreateConnection={handleCreateConnection}

--- a/frontend/src/components/SidebarDivider.layout.test.ts
+++ b/frontend/src/components/SidebarDivider.layout.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const readSourceFile = (relativePath: string): string => readFileSync(
+  new URL(relativePath, import.meta.url),
+  'utf8',
+);
+
+const readCssRule = (css: string, selector: string): string => {
+  const start = css.indexOf(selector);
+  const openingBrace = css.indexOf('{', start + selector.length);
+  const closingBrace = css.indexOf('}', openingBrace + 1);
+  expect(start, 'Missing CSS rule for ' + selector).toBeGreaterThanOrEqual(0);
+  expect(openingBrace).toBeGreaterThan(start);
+  expect(closingBrace).toBeGreaterThan(openingBrace);
+  return css.slice(start, closingBrace + 1);
+};
+
+describe('sidebar divider layout', () => {
+  it('lets the expanded V2 sidebar reach the Sider boundary without resize padding', () => {
+    const appSource = readSourceFile('../App.tsx');
+
+    expect(appSource).toContain(
+      "paddingRight: isV2Ui || isSidebarCollapsed ? 0 : sidebarResizeHandleWidth",
+    );
+  });
+
+  it('uses one outer divider for expanded V2 and keeps the collapsed rail divider', () => {
+    const appCss = readSourceFile('../App.css');
+    const v2ThemeCss = readSourceFile('../v2-theme.css');
+    const siderRule = readCssRule(v2ThemeCss, 'body[data-ui-version="v2"] .ant-layout-sider');
+    const sidebarRule = readCssRule(v2ThemeCss, 'body[data-ui-version="v2"] .gn-v2-sidebar-redesign');
+    const railRule = readCssRule(v2ThemeCss, 'body[data-ui-version="v2"] .gn-v2-connection-rail');
+    const collapsedSiderRule = readCssRule(
+      appCss,
+      "body[data-ui-version] .ant-layout-sider[data-sidebar-collapsed='true']",
+    );
+
+    expect(siderRule).toContain('border-right: 0.5px solid var(--gn-br-1) !important;');
+    expect(sidebarRule).not.toContain('border-right:');
+    expect(railRule).toContain('border-right: 0.5px solid var(--gn-br-1);');
+    expect(collapsedSiderRule).toContain('border-right: 0 !important;');
+  });
+});

--- a/frontend/src/components/SidebarDivider.layout.test.ts
+++ b/frontend/src/components/SidebarDivider.layout.test.ts
@@ -31,6 +31,10 @@ describe('sidebar divider layout', () => {
     const siderRule = readCssRule(v2ThemeCss, 'body[data-ui-version="v2"] .ant-layout-sider');
     const sidebarRule = readCssRule(v2ThemeCss, 'body[data-ui-version="v2"] .gn-v2-sidebar-redesign');
     const railRule = readCssRule(v2ThemeCss, 'body[data-ui-version="v2"] .gn-v2-connection-rail');
+    const expandedRailRule = readCssRule(
+      appCss,
+      "body[data-ui-version='v2'] .ant-layout-sider[data-sidebar-collapsed='false'] .gn-v2-connection-rail",
+    );
     const collapsedSiderRule = readCssRule(
       appCss,
       "body[data-ui-version] .ant-layout-sider[data-sidebar-collapsed='true']",
@@ -39,6 +43,8 @@ describe('sidebar divider layout', () => {
     expect(siderRule).toContain('border-right: 0.5px solid var(--gn-br-1) !important;');
     expect(sidebarRule).not.toContain('border-right:');
     expect(railRule).toContain('border-right: 0.5px solid var(--gn-br-1);');
+    expect(railRule).toContain('display: flex;');
+    expect(expandedRailRule).toContain('display: none;');
     expect(collapsedSiderRule).toContain('border-right: 0 !important;');
   });
 });

--- a/frontend/src/components/SidebarDivider.layout.test.ts
+++ b/frontend/src/components/SidebarDivider.layout.test.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
+import { readV2ThemeCss } from '../test/readV2ThemeCss';
 
-const readSourceFile = (relativePath: string): string => readFileSync(
+const readCssFile = (relativePath: string): string => readFileSync(
   new URL(relativePath, import.meta.url),
   'utf8',
 );
@@ -17,17 +18,9 @@ const readCssRule = (css: string, selector: string): string => {
 };
 
 describe('sidebar divider layout', () => {
-  it('lets the expanded V2 sidebar reach the Sider boundary without resize padding', () => {
-    const appSource = readSourceFile('../App.tsx');
-
-    expect(appSource).toContain(
-      "paddingRight: isV2Ui || isSidebarCollapsed ? 0 : sidebarResizeHandleWidth",
-    );
-  });
-
   it('uses one outer divider for expanded V2 and keeps the collapsed rail divider', () => {
-    const appCss = readSourceFile('../App.css');
-    const v2ThemeCss = readSourceFile('../v2-theme.css');
+    const appCss = readCssFile('../App.css');
+    const v2ThemeCss = readV2ThemeCss();
     const siderRule = readCssRule(v2ThemeCss, 'body[data-ui-version="v2"] .ant-layout-sider');
     const sidebarRule = readCssRule(v2ThemeCss, 'body[data-ui-version="v2"] .gn-v2-sidebar-redesign');
     const railRule = readCssRule(v2ThemeCss, 'body[data-ui-version="v2"] .gn-v2-connection-rail');

--- a/frontend/src/v2-theme.css
+++ b/frontend/src/v2-theme.css
@@ -2159,7 +2159,6 @@ body[data-ui-version="v2"] .gn-v2-sidebar-redesign {
   --gn-v2-rail-scale: calc(var(--gn-ui-scale, 1) * var(--gn-sidebar-rail-scale, 1));
   width: 100%;
   background: var(--gn-bg-panel-2);
-  border-right: 0.5px solid var(--gn-br-1);
   overflow: hidden;
 }
 


### PR DESCRIPTION
## 问题背景

V2 界面左侧连接侧栏与右侧编辑器之间存在额外空白和重复边界线，浪费可用空间。

## 修复内容

- V2 展开状态移除内容区域为缩放手柄预留的右侧空白。
- 移除 V2 侧栏内层重复边界线，仅保留外层 Sider 的单条分割线。
- 折叠状态保留连接 rail 的分割线，并保持折叠、展开和拖拽调整宽度行为。
- 增加布局回归测试，覆盖展开和折叠状态的边界规则。

## 验证方式

- 定向 Vitest：`src/testPolicy.test.ts`、`src/components/SidebarDivider.layout.test.ts`、`src/components/Sidebar.locate-toolbar.test.tsx`，共 102 个测试通过。
- `wails build -clean` 构建成功，生成 Windows amd64 产物。
- 浏览器人工验证展开、折叠、恢复展开及宽度拖拽控件；工作区 diff 检查通过。

## 影响与风险

- 仅调整 V2 侧栏布局样式和回归测试，Legacy 布局不变。
- 折叠动画期间边线会随状态切换，属于现有动画行为。

## 关联 Issue

Closes #1118
