### PR TITLE
[Bug] ClickHouse 批量变更接入同步取消上下文 (#1106)

### DIFF
--- a/internal/db/clickhouse_applychanges_context_test.go
+++ b/internal/db/clickhouse_applychanges_context_test.go
@@ -1,0 +1,234 @@
+//go:build gonavi_full_drivers || gonavi_clickhouse_driver
+
+package db
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"GoNavi-Wails/internal/connection"
+)
+
+const clickHouseApplyTestTable = "`analytics`.`events`"
+
+type clickHouseApplyRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn clickHouseApplyRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+func TestApplyClickHouseChangesContextCancellationBeforeDispatchIsKnown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	calls := 0
+	err := applyClickHouseChangesContext(ctx, clickHouseApplyTestTable, connection.ChangeSet{
+		Deletes: []map[string]interface{}{{"id": 1}},
+	}, func(context.Context, string) (int64, error) {
+		calls++
+		return 1, nil
+	})
+	if !errors.Is(err, context.Canceled) || IsWriteOutcomeUnknown(err) {
+		t.Fatalf("preflight cancellation = %v, unknown=%t", err, IsWriteOutcomeUnknown(err))
+	}
+	if calls != 0 {
+		t.Fatalf("driver calls = %d, want 0", calls)
+	}
+}
+
+func TestApplyClickHouseChangesContextCancellationInFlightIsUnknown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- applyClickHouseChangesContext(ctx, clickHouseApplyTestTable, connection.ChangeSet{
+			Deletes: []map[string]interface{}{{"id": 1}},
+		}, func(callCtx context.Context, _ string) (int64, error) {
+			close(started)
+			<-callCtx.Done()
+			return 0, callCtx.Err()
+		})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ClickHouse write did not start")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) || !IsWriteOutcomeUnknown(err) {
+			t.Fatalf("in-flight cancellation = %v, unknown=%t", err, IsWriteOutcomeUnknown(err))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ClickHouse write did not stop after cancellation")
+	}
+}
+
+func TestApplyClickHouseChangesContextFirstSemanticFailureIsKnown(t *testing.T) {
+	cause := errors.New("mutation rejected")
+	err := applyClickHouseChangesContext(context.Background(), clickHouseApplyTestTable, connection.ChangeSet{
+		Deletes: []map[string]interface{}{{"id": 1}},
+	}, func(context.Context, string) (int64, error) {
+		return 0, cause
+	})
+	if !errors.Is(err, cause) || IsWriteOutcomeUnknown(err) {
+		t.Fatalf("semantic failure = %v, unknown=%t", err, IsWriteOutcomeUnknown(err))
+	}
+}
+
+func TestApplyClickHouseChangesContextFailureAfterSuccessfulWriteIsUnknown(t *testing.T) {
+	cause := errors.New("update rejected")
+	calls := 0
+	err := applyClickHouseChangesContext(context.Background(), clickHouseApplyTestTable, connection.ChangeSet{
+		Deletes: []map[string]interface{}{{"id": 1}},
+		Updates: []connection.UpdateRow{{
+			Keys: map[string]interface{}{"id": 2}, Values: map[string]interface{}{"name": "updated"},
+		}},
+	}, func(context.Context, string) (int64, error) {
+		calls++
+		if calls == 2 {
+			return 0, cause
+		}
+		return 1, nil
+	})
+	if !errors.Is(err, cause) || !IsWriteOutcomeUnknown(err) {
+		t.Fatalf("failure after successful delete = %v, unknown=%t", err, IsWriteOutcomeUnknown(err))
+	}
+	if calls != 2 {
+		t.Fatalf("driver calls = %d, want 2", calls)
+	}
+}
+
+func TestApplyClickHouseChangesContextCancellationAfterSuccessfulWriteStopsBeforeNextDispatch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	err := applyClickHouseChangesContext(ctx, clickHouseApplyTestTable, connection.ChangeSet{
+		Deletes: []map[string]interface{}{{"id": 1}, {"id": 2}},
+	}, func(context.Context, string) (int64, error) {
+		calls++
+		cancel()
+		return 1, nil
+	})
+	if !errors.Is(err, context.Canceled) || !IsWriteOutcomeUnknown(err) {
+		t.Fatalf("cancellation after successful write = %v, unknown=%t", err, IsWriteOutcomeUnknown(err))
+	}
+	if calls != 1 {
+		t.Fatalf("driver calls = %d, want 1", calls)
+	}
+}
+
+func TestApplyClickHouseChangesContextLaterInsertBatchFailureIsUnknown(t *testing.T) {
+	rows := make([]map[string]interface{}, defaultBatchInsertRows+1)
+	for index := range rows {
+		rows[index] = map[string]interface{}{"id": index}
+	}
+	cause := errors.New("second insert batch rejected")
+	calls := 0
+	err := applyClickHouseChangesContext(context.Background(), clickHouseApplyTestTable, connection.ChangeSet{Inserts: rows}, func(context.Context, string) (int64, error) {
+		calls++
+		if calls == 2 {
+			return 0, cause
+		}
+		return 1, nil
+	})
+	if !errors.Is(err, cause) || !IsWriteOutcomeUnknown(err) {
+		t.Fatalf("later insert failure = %v, unknown=%t", err, IsWriteOutcomeUnknown(err))
+	}
+	if calls != 2 {
+		t.Fatalf("insert calls = %d, want 2", calls)
+	}
+}
+
+func TestApplyClickHouseChangesContextFirstInsertSemanticFailureIsKnown(t *testing.T) {
+	cause := errors.New("insert rejected")
+	err := applyClickHouseChangesContext(context.Background(), clickHouseApplyTestTable, connection.ChangeSet{
+		Inserts: []map[string]interface{}{{"id": 1}},
+	}, func(context.Context, string) (int64, error) {
+		return 0, cause
+	})
+	if !errors.Is(err, cause) || IsWriteOutcomeUnknown(err) {
+		t.Fatalf("first insert failure = %v, unknown=%t", err, IsWriteOutcomeUnknown(err))
+	}
+}
+
+func TestApplyClickHouseChangesContextInsertCancellationInFlightIsUnknown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	err := applyClickHouseChangesContext(ctx, clickHouseApplyTestTable, connection.ChangeSet{
+		Inserts: []map[string]interface{}{{"id": 1}},
+	}, func(callCtx context.Context, _ string) (int64, error) {
+		cancel()
+		return 0, callCtx.Err()
+	})
+	if !errors.Is(err, context.Canceled) || !IsWriteOutcomeUnknown(err) {
+		t.Fatalf("insert cancellation = %v, unknown=%t", err, IsWriteOutcomeUnknown(err))
+	}
+}
+
+func TestApplyClickHouseChangesContextSuccess(t *testing.T) {
+	calls := 0
+	err := applyClickHouseChangesContext(context.Background(), clickHouseApplyTestTable, connection.ChangeSet{
+		Deletes: []map[string]interface{}{{"id": 1}},
+		Updates: []connection.UpdateRow{{
+			Keys: map[string]interface{}{"id": 2}, Values: map[string]interface{}{"name": "updated"},
+		}},
+		Inserts: []map[string]interface{}{{"id": 3}},
+	}, func(context.Context, string) (int64, error) {
+		calls++
+		return 1, nil
+	})
+	if err != nil || calls != 3 {
+		t.Fatalf("successful changes = %v, calls=%d", err, calls)
+	}
+}
+
+func TestClickHouseApplyChangesContextCancelsLegacyHTTPRequest(t *testing.T) {
+	started := make(chan struct{})
+	requestCanceled := make(chan struct{})
+	legacyClient := &clickHouseLegacyHTTPClient{
+		endpoint: &url.URL{Scheme: "http", Host: "clickhouse.test"},
+		http: &http.Client{Transport: clickHouseApplyRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+			close(started)
+			<-request.Context().Done()
+			close(requestCanceled)
+			return nil, request.Context().Err()
+		})},
+		headers: make(http.Header),
+		params:  make(url.Values),
+	}
+
+	client := &ClickHouseDB{legacyHTTP: legacyClient, database: "analytics"}
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- client.ApplyChangesContext(ctx, "events", connection.ChangeSet{
+			Deletes: []map[string]interface{}{{"id": 1}},
+		})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("legacy HTTP write did not start")
+	}
+	cancel()
+
+	select {
+	case <-requestCanceled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("legacy HTTP request context was not canceled")
+	}
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) || !IsWriteOutcomeUnknown(err) {
+			t.Fatalf("legacy HTTP cancellation = %v, unknown=%t", err, IsWriteOutcomeUnknown(err))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("legacy HTTP ApplyChangesContext did not return")
+	}
+}

--- a/internal/db/clickhouse_impl.go
+++ b/internal/db/clickhouse_impl.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -48,6 +49,39 @@ type ClickHouseDB struct {
 	pingTimeout time.Duration
 	forwarder   *ssh.LocalForwarder
 	database    string
+}
+
+var _ BatchApplierContext = (*ClickHouseDB)(nil)
+
+var errClickHouseWritePreflightStopped = errors.New("ClickHouse write stopped before dispatch")
+
+type clickHouseWriteCauseError struct {
+	message string
+	cause   error
+}
+
+func (err *clickHouseWriteCauseError) Error() string {
+	if err == nil {
+		return ""
+	}
+	return err.message
+}
+
+func (err *clickHouseWriteCauseError) Unwrap() error {
+	if err == nil {
+		return nil
+	}
+	return err.cause
+}
+
+func preserveClickHouseWriteCause(messageErr, cause error) error {
+	if messageErr == nil {
+		return cause
+	}
+	if cause == nil {
+		return messageErr
+	}
+	return &clickHouseWriteCauseError{message: messageErr.Error(), cause: cause}
 }
 
 func normalizeClickHouseConfig(config connection.ConnectionConfig) connection.ConnectionConfig {
@@ -1401,8 +1435,18 @@ func isClickHouseTruthy(value interface{}) bool {
 }
 
 func (c *ClickHouseDB) ApplyChanges(tableName string, changes connection.ChangeSet) error {
+	return c.ApplyChangesContext(context.Background(), tableName, changes)
+}
+
+func (c *ClickHouseDB) ApplyChangesContext(ctx context.Context, tableName string, changes connection.ChangeSet) error {
 	if c.conn == nil && c.legacyHTTP == nil {
 		return fmt.Errorf("连接未打开")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	database, table, err := c.resolveDatabaseAndTable(c.database, tableName)
@@ -1410,6 +1454,22 @@ func (c *ClickHouseDB) ApplyChanges(tableName string, changes connection.ChangeS
 		return err
 	}
 	qualifiedTable := fmt.Sprintf("%s.%s", quoteClickHouseIdentifier(database), quoteClickHouseIdentifier(table))
+	return applyClickHouseChangesContext(ctx, qualifiedTable, changes, c.ExecContext)
+}
+
+func applyClickHouseChangesContext(
+	ctx context.Context,
+	qualifiedTable string,
+	changes connection.ChangeSet,
+	exec func(context.Context, string) (int64, error),
+) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if exec == nil {
+		return fmt.Errorf("连接未打开")
+	}
+	writeApplied := false
 
 	for _, pk := range changes.Deletes {
 		whereExpr := buildClickHouseWhereClause(pk)
@@ -1417,16 +1477,17 @@ func (c *ClickHouseDB) ApplyChanges(tableName string, changes connection.ChangeS
 			continue
 		}
 		query := fmt.Sprintf("ALTER TABLE %s DELETE WHERE %s", qualifiedTable, whereExpr)
-		if _, err := c.Exec(query); err != nil {
+		if err := clickHouseWritePreflightError(ctx, writeApplied); err != nil {
+			return err
+		}
+		if _, err := exec(ctx, query); err != nil {
 			resultErr := localizedDatabaseRuntimeError("db.backend.error.clickhouse_delete_failed_with_sql", map[string]any{
 				"detail": err.Error(),
 				"sql":    query,
 			})
-			if IsAmbiguousWriteResponse(err) {
-				return MarkWriteOutcomeUnknown(resultErr)
-			}
-			return resultErr
+			return classifyClickHouseWriteError(ctx, preserveClickHouseWriteCause(resultErr, err), writeApplied)
 		}
+		writeApplied = true
 	}
 
 	for _, update := range changes.Updates {
@@ -1436,19 +1497,20 @@ func (c *ClickHouseDB) ApplyChanges(tableName string, changes connection.ChangeS
 			continue
 		}
 		query := fmt.Sprintf("ALTER TABLE %s UPDATE %s WHERE %s", qualifiedTable, setExpr, whereExpr)
-		if _, err := c.Exec(query); err != nil {
+		if err := clickHouseWritePreflightError(ctx, writeApplied); err != nil {
+			return err
+		}
+		if _, err := exec(ctx, query); err != nil {
 			resultErr := localizedDatabaseRuntimeError("db.backend.error.clickhouse_update_failed_with_sql", map[string]any{
 				"detail": err.Error(),
 				"sql":    query,
 			})
-			if IsAmbiguousWriteResponse(err) {
-				return MarkWriteOutcomeUnknown(resultErr)
-			}
-			return resultErr
+			return classifyClickHouseWriteError(ctx, preserveClickHouseWriteCause(resultErr, err), writeApplied)
 		}
+		writeApplied = true
 	}
 
-	if err := execClickHouseInsertBatches(c.Exec, qualifiedTable, changes.Inserts); err != nil {
+	if err := execClickHouseInsertBatchesContext(ctx, exec, qualifiedTable, changes.Inserts, &writeApplied); err != nil {
 		return err
 	}
 	return nil
@@ -1458,16 +1520,83 @@ func execClickHouseInsertBatches(exec func(string) (int64, error), qualifiedTabl
 	if exec == nil {
 		return fmt.Errorf("连接未打开")
 	}
-	return execLiteralInsertBatches(literalInsertConfig{
+	writeApplied := false
+	return execClickHouseInsertBatchesContext(context.Background(), func(_ context.Context, query string) (int64, error) {
+		return exec(query)
+	}, qualifiedTable, rows, &writeApplied)
+}
+
+func execClickHouseInsertBatchesContext(
+	ctx context.Context,
+	exec func(context.Context, string) (int64, error),
+	qualifiedTable string,
+	rows []map[string]interface{},
+	writeApplied *bool,
+) error {
+	if exec == nil {
+		return fmt.Errorf("连接未打开")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if writeApplied == nil {
+		writeApplied = new(bool)
+	}
+
+	var preflightErr error
+	var execCause error
+	err := execLiteralInsertBatches(literalInsertConfig{
 		Table:       qualifiedTable,
 		Rows:        rows,
 		QuoteColumn: quoteClickHouseIdentifier,
 		Literal:     clickHouseLiteral,
 		Exec: func(query string) (sql.Result, error) {
-			affected, err := exec(query)
-			return driver.RowsAffected(affected), err
+			if err := clickHouseWritePreflightError(ctx, *writeApplied); err != nil {
+				preflightErr = err
+				return nil, errClickHouseWritePreflightStopped
+			}
+			affected, err := exec(ctx, query)
+			if err != nil {
+				execCause = err
+				return nil, err
+			}
+			*writeApplied = true
+			return driver.RowsAffected(affected), nil
 		},
 	})
+	if preflightErr != nil {
+		return preflightErr
+	}
+	if err == nil {
+		return nil
+	}
+	if execCause != nil {
+		err = preserveClickHouseWriteCause(err, execCause)
+	}
+	return classifyClickHouseWriteError(ctx, err, *writeApplied)
+}
+
+func clickHouseWritePreflightError(ctx context.Context, writeApplied bool) error {
+	if ctx == nil {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		if writeApplied {
+			return MarkWriteOutcomeUnknown(err)
+		}
+		return err
+	}
+	return nil
+}
+
+func classifyClickHouseWriteError(ctx context.Context, err error, writeApplied bool) error {
+	if err == nil || IsWriteOutcomeUnknown(err) {
+		return err
+	}
+	if writeApplied || IsAmbiguousWriteResponse(err) || (ctx != nil && ctx.Err() != nil) {
+		return MarkWriteOutcomeUnknown(err)
+	}
+	return err
 }
 
 func buildClickHouseInsertSQL(qualifiedTable string, row map[string]interface{}) (string, error) {

--- a/internal/db/driver_agent_revisions_gen.go
+++ b/internal/db/driver_agent_revisions_gen.go
@@ -22,7 +22,7 @@ func init() {
 		"mongodb":       "src-ebf664aa1ae713eb",
 		"tdengine":      "src-d31c6a45a99a1e0e",
 		"iotdb":         "src-0cdf32eb1c4d9965",
-		"clickhouse":    "src-e78f984ffc735117",
+		"clickhouse":    "src-5e7fd89b6f3d82e9",
 		"elasticsearch": "src-ba63c309637a5cc8",
 		"trino":         "src-f38f259400f25695",
 	}


### PR DESCRIPTION
## 背景

ClickHouse 批量变更尚未接入同步 Context，原生驱动和 legacy HTTP 请求无法随同步任务及时取消；若批次已发生部分写入后再失败或取消，结果状态也可能被误判并触发不安全重试。

## 改动内容

- 让 ClickHouseDB 实现 BatchApplierContext，并由 ApplyChanges 委托给 ApplyChangesContext。
- 删除、更新、插入均使用调用方 Context，覆盖原生驱动与 legacy HTTP 路径。
- 跟踪批次写入进度：执行中取消、网络模糊错误及部分成功后的失败标记为 unknown；首次发送前取消和首条明确业务失败保持普通错误。
- 保留现有本地化错误文本，同时恢复 errors.Is 可识别的底层 cause 链。
- 更新 ClickHouse driver-agent revision，并补充 Context 取消、unknown 状态和 HTTP 请求回归测试。

## 验证结果

- ClickHouse Context/unknown 定向测试通过。
- legacy HTTP 请求 Context 测试通过。
- 新增测试连续运行 10 次通过。
- go test ./internal/sync -count=1 通过。
- 同步 unknown 禁止重试测试与 driver-agent revision 契约测试通过。
- git diff --check 通过。
- 全量 ClickHouse 标签测试仅剩 2 条既有环境失败：测试使用伪 driver-agent 文件，Windows 可执行文件校验拒绝该占位内容；与本次改动无关。

## 风险控制

- 仅调整 ClickHouse 批量写入路径及其 revision，不改变其他数据库实现。
- unknown 仅用于无法确认写入结果或已有成功写入的场景，避免扩大重试风险。
- 原生驱动与 legacy HTTP 两条路径均有回归覆盖，且保留既有错误文案兼容性。

Closes #1106
