### PR TITLE
🐛 fix(web-rpc): 传递请求取消到应用层耗时操作

### DIFF
--- a/frontend/src/components/DataSyncModal.tsx
+++ b/frontend/src/components/DataSyncModal.tsx
@@ -43,6 +43,7 @@ import {
   resolveTextInputSafeBackdropFilter,
 } from "../utils/appearance";
 import { buildRpcConnectionConfig } from "../utils/connectionRpcConfig";
+import { invokeAppWithSignal, isWebRPCAbortError } from "../utils/webRpc";
 import {
   isPostgresSchemaDialect,
   supportsIndependentSchemaSelection,
@@ -511,6 +512,9 @@ const DataSyncModal: React.FC<{
   const jobIdRef = useRef<string>("");
   const runSyncGuardRef = useRef(false);
   const analysisRequestSeqRef = useRef(0);
+  const previewRequestSeqRef = useRef(0);
+  const analysisAbortRef = useRef<AbortController | null>(null);
+  const previewAbortRef = useRef<AbortController | null>(null);
   const sourceDatabaseRequestSeqRef = useRef(0);
   const targetDatabaseRequestSeqRef = useRef(0);
   const tableMetadataRequestSeqRef = useRef(0);
@@ -640,6 +644,24 @@ const DataSyncModal: React.FC<{
       if (typeof offProgress === "function") offProgress();
     };
   }, [open]);
+
+  useEffect(() => {
+    if (open) return undefined;
+    analysisRequestSeqRef.current += 1;
+    previewRequestSeqRef.current += 1;
+    analysisAbortRef.current?.abort();
+    previewAbortRef.current?.abort();
+    analysisAbortRef.current = null;
+    previewAbortRef.current = null;
+    return undefined;
+  }, [open]);
+
+  useEffect(() => () => {
+    analysisRequestSeqRef.current += 1;
+    previewRequestSeqRef.current += 1;
+    analysisAbortRef.current?.abort();
+    previewAbortRef.current?.abort();
+  }, []);
 
   useEffect(() => {
     if (!logBoxRef.current) return;
@@ -1047,6 +1069,9 @@ const DataSyncModal: React.FC<{
 
     const requestSeq = ++analysisRequestSeqRef.current;
     const requestFingerprint = currentAnalysisFingerprint;
+    analysisAbortRef.current?.abort();
+    const controller = new AbortController();
+    analysisAbortRef.current = controller;
 
     const sConn = connections.find((c) => c.id === sourceConnId)!;
     const tConn = connections.find((c) => c.id === targetConnId)!;
@@ -1080,7 +1105,12 @@ const DataSyncModal: React.FC<{
     });
 
     try {
-      const res = await DataSyncAnalyze(config as any);
+      const res = await invokeAppWithSignal(
+        "DataSyncAnalyze",
+        [config],
+        controller.signal,
+        () => DataSyncAnalyze(config as any),
+      );
       if (
         requestSeq !== analysisRequestSeqRef.current ||
         requestFingerprint !== currentAnalysisFingerprintRef.current
@@ -1114,6 +1144,7 @@ const DataSyncModal: React.FC<{
       ) {
         return;
       }
+      if (isWebRPCAbortError(e)) return;
       setAnalyzedFingerprint("");
       message.error(
         tr("data_sync.message.analysis_failed_detail", {
@@ -1121,6 +1152,9 @@ const DataSyncModal: React.FC<{
         }),
       );
     } finally {
+      if (analysisAbortRef.current === controller) {
+        analysisAbortRef.current = null;
+      }
       if (requestSeq === analysisRequestSeqRef.current) {
         setLoading(false);
         setAnalyzing(false);
@@ -1138,6 +1172,10 @@ const DataSyncModal: React.FC<{
     setPreviewTable(table);
     setPreviewLoading(true);
     setPreviewData(null);
+    const requestSeq = ++previewRequestSeqRef.current;
+    previewAbortRef.current?.abort();
+    const controller = new AbortController();
+    previewAbortRef.current = controller;
 
     const config = buildDataSyncRequest({
       sourceConfig: normalizeConnConfig(sConn, sourceDb),
@@ -1157,7 +1195,13 @@ const DataSyncModal: React.FC<{
     });
 
     try {
-      const res = await DataSyncPreview(config as any, table, 200);
+      const res = await invokeAppWithSignal(
+        "DataSyncPreview",
+        [config, table, 200],
+        controller.signal,
+        () => DataSyncPreview(config as any, table, 200),
+      );
+      if (requestSeq !== previewRequestSeqRef.current) return;
       if (res.success) {
         setPreviewData(res.data);
       } else {
@@ -1170,6 +1214,7 @@ const DataSyncModal: React.FC<{
         );
       }
     } catch (e: any) {
+      if (requestSeq !== previewRequestSeqRef.current || isWebRPCAbortError(e)) return;
       message.error(
         tr("data_sync.message.preview_load_failed_detail", {
           detail: e?.message || String(e),
@@ -1177,7 +1222,8 @@ const DataSyncModal: React.FC<{
       );
     }
 
-    setPreviewLoading(false);
+    if (previewAbortRef.current === controller) previewAbortRef.current = null;
+    if (requestSeq === previewRequestSeqRef.current) setPreviewLoading(false);
   };
 
   const runSync = async () => {
@@ -2839,6 +2885,9 @@ const DataSyncModal: React.FC<{
         }}
         open={previewOpen}
         onClose={() => {
+          previewRequestSeqRef.current += 1;
+          previewAbortRef.current?.abort();
+          previewAbortRef.current = null;
           setPreviewOpen(false);
           setPreviewTable("");
           setPreviewData(null);

--- a/frontend/src/components/DatabaseImportExecutionPanel.tsx
+++ b/frontend/src/components/DatabaseImportExecutionPanel.tsx
@@ -15,6 +15,7 @@ import { t as defaultTranslate } from '../i18n';
 import { useOptionalI18n } from '../i18n/provider';
 import type { SavedConnection } from '../types';
 import { confirmProductionRisk } from '../utils/productionRiskConfirm';
+import { invokeAppWithSignal } from '../utils/webRpc';
 import { formatImportBytes, formatImportDuration } from './importProgressMetrics';
 import Modal from './common/ResizableDraggableModal';
 import {
@@ -72,6 +73,7 @@ const DatabaseImportExecutionPanel: React.FC<DatabaseImportExecutionPanelProps> 
   const [preflightError, setPreflightError] = useState('');
   const [cancelRequested, setCancelRequested] = useState(false);
   const lastReportedRunningRef = useRef<boolean | null>(null);
+  const executionRPCAbortRef = useRef<AbortController | null>(null);
   const {
     state,
     reset,
@@ -119,6 +121,11 @@ const DatabaseImportExecutionPanel: React.FC<DatabaseImportExecutionPanelProps> 
     onRunningChange?.(taskRunning);
   }, [onRunningChange, taskRunning]);
 
+  useEffect(() => () => {
+    executionRPCAbortRef.current?.abort();
+    executionRPCAbortRef.current = null;
+  }, []);
+
   const startImport = useCallback(async () => {
     if (!connectionConfig || !String(filePath || '').trim() || taskRunning) return;
     const approved = await confirmProductionRisk({
@@ -159,14 +166,34 @@ const DatabaseImportExecutionPanel: React.FC<DatabaseImportExecutionPanelProps> 
         filePath,
         fileSizeMB,
         run: async (jobId) => {
-          const result = await ImportDatabaseSQLWithOptions(
-            connectionConfig as any,
+          executionRPCAbortRef.current?.abort();
+          const controller = new AbortController();
+          executionRPCAbortRef.current = controller;
+          const args = [
+            connectionConfig,
             String(dbName || '').trim(),
             filePath,
             jobId,
             continueOnError,
             mysqlGTIDMode,
-          );
+          ];
+          const result = await invokeAppWithSignal(
+            'ImportDatabaseSQLWithOptions',
+            args,
+            controller.signal,
+            () => ImportDatabaseSQLWithOptions(
+              connectionConfig as any,
+              String(dbName || '').trim(),
+              filePath,
+              jobId,
+              continueOnError,
+              mysqlGTIDMode,
+            ),
+          ).finally(() => {
+            if (executionRPCAbortRef.current === controller) {
+              executionRPCAbortRef.current = null;
+            }
+          });
           // Reaching EOF with recorded statement errors is a completed import,
           // not a transport/fatal failure. Preserve the counters and render it
           // as a warning result instead of offering a misleading fatal retry.

--- a/frontend/src/components/ImportJobHistoryPanel.tsx
+++ b/frontend/src/components/ImportJobHistoryPanel.tsx
@@ -22,6 +22,7 @@ import {
 import { t as defaultTranslate } from '../i18n';
 import { useOptionalI18n } from '../i18n/provider';
 import { downloadBrowserFileFromResult } from '../utils/browserFileTransfer';
+import { invokeAppWithSignal, isWebRPCAbortError } from '../utils/webRpc';
 import Modal from './common/ResizableDraggableModal';
 
 const { Text } = Typography;
@@ -153,6 +154,7 @@ const ImportJobHistoryPanel: React.FC<ImportJobHistoryPanelProps> = ({ refreshTo
   const [error, setError] = useState('');
   const [pendingAction, setPendingAction] = useState('');
   const requestRef = useRef(0);
+  const recoveryRPCAbortRef = useRef<AbortController | null>(null);
 
   const loadJobs = useCallback(async () => {
     const requestID = requestRef.current + 1;
@@ -185,6 +187,11 @@ const ImportJobHistoryPanel: React.FC<ImportJobHistoryPanelProps> = ({ refreshTo
       requestRef.current += 1;
     };
   }, [loadJobs, refreshToken]);
+
+  useEffect(() => () => {
+    recoveryRPCAbortRef.current?.abort();
+    recoveryRPCAbortRef.current = null;
+  }, []);
 
   useEffect(() => {
     const hasRunningJob = jobs.some((job) => pollingStatuses.has(job.status as ImportJobStatus));
@@ -298,8 +305,16 @@ const ImportJobHistoryPanel: React.FC<ImportJobHistoryPanelProps> = ({ refreshTo
       cancelText: t('common.cancel'),
       onOk: async () => {
         setPendingAction(`resume:${job.id}`);
+        recoveryRPCAbortRef.current?.abort();
+        const controller = new AbortController();
+        recoveryRPCAbortRef.current = controller;
         try {
-          const result = await ResumeImportJob(job.id);
+          const result = await invokeAppWithSignal(
+            'ResumeImportJob',
+            [job.id],
+            controller.signal,
+            () => ResumeImportJob(job.id),
+          );
           if (!result?.success) {
             throw new Error(result?.message || t('data_import.history.error.resume_failed'));
           }
@@ -307,11 +322,15 @@ const ImportJobHistoryPanel: React.FC<ImportJobHistoryPanelProps> = ({ refreshTo
           await loadJobs();
           void message.success(t('data_import.history.message.resumed'));
         } catch (resumeError: any) {
+          if (isWebRPCAbortError(resumeError)) return;
           void message.error(t('data_import.history.error.resume_failed_detail', {
             detail: resumeError?.message || String(resumeError),
           }));
           throw resumeError;
         } finally {
+          if (recoveryRPCAbortRef.current === controller) {
+            recoveryRPCAbortRef.current = null;
+          }
           setPendingAction('');
         }
       },
@@ -326,8 +345,16 @@ const ImportJobHistoryPanel: React.FC<ImportJobHistoryPanelProps> = ({ refreshTo
       cancelText: t('common.cancel'),
       onOk: async () => {
         setPendingAction(`retry:${job.id}`);
+        recoveryRPCAbortRef.current?.abort();
+        const controller = new AbortController();
+        recoveryRPCAbortRef.current = controller;
         try {
-          const result = await RetryImportJobFailedRows(job.id);
+          const result = await invokeAppWithSignal(
+            'RetryImportJobFailedRows',
+            [job.id],
+            controller.signal,
+            () => RetryImportJobFailedRows(job.id),
+          );
           if (!result?.success) {
             throw new Error(result?.message || t('data_import.history.error.retry_failed_rows_failed'));
           }
@@ -335,11 +362,15 @@ const ImportJobHistoryPanel: React.FC<ImportJobHistoryPanelProps> = ({ refreshTo
           await loadJobs();
           void message.success(t('data_import.history.message.retry_failed_rows_started'));
         } catch (retryError: any) {
+          if (isWebRPCAbortError(retryError)) return;
           void message.error(t('data_import.history.error.retry_failed_rows_failed_detail', {
             detail: retryError?.message || String(retryError),
           }));
           throw retryError;
         } finally {
+          if (recoveryRPCAbortRef.current === controller) {
+            recoveryRPCAbortRef.current = null;
+          }
           setPendingAction('');
         }
       },

--- a/frontend/src/components/ImportPreviewModal.tsx
+++ b/frontend/src/components/ImportPreviewModal.tsx
@@ -13,6 +13,7 @@ import { useStore } from "../store";
 import { t as defaultTranslate } from "../i18n";
 import { useOptionalI18n } from "../i18n/provider";
 import { buildRpcConnectionConfig } from "../utils/connectionRpcConfig";
+import { invokeAppWithSignal, isWebRPCAbortError } from "../utils/webRpc";
 import { downloadBrowserFileFromResult } from "../utils/browserFileTransfer";
 import {
   getColumnDefinitionExtra,
@@ -151,6 +152,7 @@ const ImportPreviewModal: React.FC<ImportPreviewModalProps> = ({
   const [importResult, setImportResult] = useState<any>(null);
   const previewRequestRef = useRef(0);
   const importRequestRef = useRef(0);
+  const importRPCAbortRef = useRef<AbortController | null>(null);
   const importingRef = useRef(false);
   const stoppingRef = useRef(false);
   const activeImportJobIdRef = useRef("");
@@ -179,15 +181,23 @@ const ImportPreviewModal: React.FC<ImportPreviewModalProps> = ({
     if (importingRef.current) return undefined;
     const requestId = previewRequestRef.current + 1;
     previewRequestRef.current = requestId;
+    const controller = new AbortController();
     if (visible && filePath) {
-      void loadPreview(requestId);
+      void loadPreview(requestId, controller.signal);
     }
     return () => {
+      controller.abort();
       if (previewRequestRef.current === requestId) {
         previewRequestRef.current += 1;
       }
     };
   }, [visible, filePath, connectionId, dbName, tableName, connection, parserOptionsKey]);
+
+  useEffect(() => () => {
+    importRequestRef.current += 1;
+    importRPCAbortRef.current?.abort();
+    importRPCAbortRef.current = null;
+  }, []);
 
   useEffect(() => {
     if (importing) {
@@ -245,7 +255,7 @@ const ImportPreviewModal: React.FC<ImportPreviewModalProps> = ({
     };
   }, [importing, onImportingChange]);
 
-  const loadPreview = async (requestId: number) => {
+  const loadPreview = async (requestId: number, signal: AbortSignal) => {
     importRequestRef.current += 1;
     importingRef.current = false;
     stoppingRef.current = false;
@@ -289,8 +299,18 @@ const ImportPreviewModal: React.FC<ImportPreviewModalProps> = ({
         return;
       }
       const [previewRes, columnsRes] = await Promise.all([
-        previewImportFileWithOptions(filePath, parserOptions),
-        DBGetColumns(rpcConfig, dbName, tableName),
+        invokeAppWithSignal(
+          "PreviewImportFileWithOptions",
+          [filePath, parserOptions],
+          signal,
+          () => previewImportFileWithOptions(filePath, parserOptions),
+        ),
+        invokeAppWithSignal(
+          "DBGetColumns",
+          [rpcConfig, dbName, tableName],
+          signal,
+          () => DBGetColumns(rpcConfig, dbName, tableName),
+        ),
       ]);
       if (previewRequestRef.current !== requestId) return;
       if (!previewRes.success || !previewRes.data) {
@@ -339,6 +359,7 @@ const ImportPreviewModal: React.FC<ImportPreviewModalProps> = ({
       setColumnMappings(nextMappings);
     } catch (e: any) {
       if (previewRequestRef.current !== requestId) return;
+      if (isWebRPCAbortError(e)) return;
       setError(
         t("import_preview.error.preview_failed_detail", {
           detail: String(e?.message || e),
@@ -437,6 +458,9 @@ const ImportPreviewModal: React.FC<ImportPreviewModalProps> = ({
     latestProgressRef.current = initialProgress;
     setProgress(initialProgress);
     setImportResult(null);
+    importRPCAbortRef.current?.abort();
+    const controller = new AbortController();
+    importRPCAbortRef.current = controller;
 
     try {
       const config = previewConnectionConfigRef.current;
@@ -448,19 +472,26 @@ const ImportPreviewModal: React.FC<ImportPreviewModalProps> = ({
       const selectedMappings = Object.fromEntries(
         Object.entries(columnMappings).filter(([, targetColumn]) => Boolean(targetColumn)),
       );
-      const res = await ImportDataWithProgressOptions(
-        buildRpcConnectionConfig(config) as any,
-        dbName,
-        tableName,
-        filePath,
-        {
+      const rpcConfig = buildRpcConnectionConfig(config) as any;
+      const options = {
           ...parserOptions,
           columnMappings: selectedMappings,
           jobId: importJobId,
           ...(previewData.sourceIdentityToken
             ? { sourceIdentityToken: previewData.sourceIdentityToken }
             : {}),
-        },
+      };
+      const res = await invokeAppWithSignal(
+        "ImportDataWithProgressOptions",
+        [rpcConfig, dbName, tableName, filePath, options],
+        controller.signal,
+        () => ImportDataWithProgressOptions(
+          rpcConfig,
+          dbName,
+          tableName,
+          filePath,
+          options,
+        ),
       );
       if (importRequestRef.current !== importRequestId) return;
 
@@ -498,6 +529,7 @@ const ImportPreviewModal: React.FC<ImportPreviewModalProps> = ({
       }
     } catch (e: any) {
       if (importRequestRef.current !== importRequestId) return;
+      if (isWebRPCAbortError(e)) return;
       const failureMessage = t("import_preview.error.import_failed_detail", {
         detail: String(e?.message || e),
       });
@@ -514,6 +546,7 @@ const ImportPreviewModal: React.FC<ImportPreviewModalProps> = ({
         outcomeUnknown: true,
       });
     } finally {
+      if (importRPCAbortRef.current === controller) importRPCAbortRef.current = null;
       if (importRequestRef.current === importRequestId) {
         importingRef.current = false;
         stoppingRef.current = false;

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -40,6 +40,7 @@ import { applyMongoQueryAutoLimit, convertMongoShellToJsonCommand } from "../uti
 import { getShortcutDisplayLabel, getShortcutPlatform, getShortcutPrimaryModifierDisplayLabel, isEditableElement, isImeComposingKeyEvent, isShortcutMatch, comboToMonacoKeyBinding, normalizeShortcutCombo, resolveShortcutBinding } from "../utils/shortcuts";
 import { useAutoFetchVisibility } from '../utils/autoFetchVisibility';
 import { buildRpcConnectionConfig } from '../utils/connectionRpcConfig';
+import { invokeAppWithSignal, isWebRPCAbortError } from '../utils/webRpc';
 import { downloadBrowserTextFile, isWebRuntime } from '../utils/browserFileTransfer';
 import { filterVisibleDatabaseNames } from '../utils/databaseVisibility';
 import { isPostgresSchemaDialect } from '../utils/connectionDriverType';
@@ -1842,6 +1843,21 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
   const [sqlSnippetPickerKeyword, setSqlSnippetPickerKeyword] = useState('');
   const runSeqRef = useRef(0);
   const currentQueryIdRef = useRef('');
+  const requestScopedRPCControllersRef = useRef(new Set<AbortController>());
+  const invokeRequestScopedApp = useCallback(<T,>(
+      method: string,
+      args: unknown[],
+      fallback: () => Promise<T>,
+  ): Promise<T> => {
+      const controller = new AbortController();
+      requestScopedRPCControllersRef.current.add(controller);
+      return invokeAppWithSignal(method, args, controller.signal, fallback)
+          .finally(() => requestScopedRPCControllersRef.current.delete(controller));
+  }, []);
+  useEffect(() => () => {
+      requestScopedRPCControllersRef.current.forEach((controller) => controller.abort());
+      requestScopedRPCControllersRef.current.clear();
+  }, []);
   const resultTotalCountSeqRef = useRef(0);
   const resultTotalCountRequestsRef = useRef<Record<string, { sequence: number; queryId: string }>>({});
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
@@ -8668,13 +8684,13 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
       ) {
           return DBQueryMultiInTransaction(pendingTransaction.id, sql, queryId);
       }
-      return DBQueryMulti(
-          buildRpcConnectionConfig(executionConfig) as any,
-          dbName,
-          sql,
-          queryId,
+      const rpcConfig = buildRpcConnectionConfig(executionConfig) as any;
+      return invokeRequestScopedApp(
+          'DBQueryMulti',
+          [rpcConfig, dbName, sql, queryId],
+          () => DBQueryMulti(rpcConfig, dbName, sql, queryId),
       );
-  }, [buildSqlExecutionConnectionConfig]);
+  }, [buildSqlExecutionConnectionConfig, invokeRequestScopedApp]);
 
   // 精准重查询单个结果集（提交事务 / 刷新按钮使用），不会重跑整个编辑器 SQL
   const handleReloadResult = async (resultKey: string, sql: string) => {
@@ -8791,6 +8807,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
           ));
       } catch (err: any) {
           if (!isCurrentRun()) return;
+          if (isWebRPCAbortError(err)) return;
           message.error(translate('query_editor.message.refresh_failed', {
               error: formatSqlExecutionError(err?.message || err || translate('common.unknown'), { translate }),
           }));
@@ -9111,6 +9128,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
           }));
       } catch (err: any) {
           if (!isCurrentRun()) return;
+          if (isWebRPCAbortError(err)) return;
           message.error(translate('query_editor.message.page_query_failed', {
               error: formatSqlExecutionError(err?.message || err || translate('common.unknown'), { translate }),
           }));
@@ -9574,7 +9592,12 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                 runQueryId = queryId;
                 setQueryId(queryId);
 
-                const res = await DBQueryWithCancel(buildRpcConnectionConfig(config) as any, currentDb, executedSql, queryId);
+                const mongoRPCConfig = buildRpcConnectionConfig(config) as any;
+                const res = await invokeRequestScopedApp(
+                    'DBQueryWithCancel',
+                    [mongoRPCConfig, currentDb, executedSql, queryId],
+                    () => DBQueryWithCancel(mongoRPCConfig, currentDb, executedSql, queryId),
+                );
                 if (!isCurrentRun()) return;
                 if (currentQueryIdRef.current === queryId) {
                     clearQueryId();
@@ -10178,6 +10201,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
         }
     } catch (e: any) {
         if (!isCurrentRun()) return;
+        if (isWebRPCAbortError(e)) return;
         const formattedError = formatSqlExecutionError(e?.message || e, { translate });
         message.error(translate('query_editor.message.execution_failed_with_error', { error: formattedError }));
         addSqlLog({

--- a/frontend/src/components/SQLFileExecutionWorkbench.tsx
+++ b/frontend/src/components/SQLFileExecutionWorkbench.tsx
@@ -19,6 +19,7 @@ import { t as defaultTranslate } from '../i18n';
 import { useOptionalI18n } from '../i18n/provider';
 import { buildRpcConnectionConfig } from '../utils/connectionRpcConfig';
 import { confirmProductionRisk } from '../utils/productionRiskConfirm';
+import { invokeAppWithSignal } from '../utils/webRpc';
 import { resolveConnectionHostSummary } from '../utils/tabDisplay';
 import { formatExportElapsed, resolveExportElapsedMs } from '../utils/exportProgress';
 import { resolveDataImportCapabilityReasonKey } from './dataImportCapability';
@@ -183,6 +184,7 @@ const SQLFileExecutionWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
   const [capabilityRequestToken, setCapabilityRequestToken] = useState(0);
   const [executionPending, setExecutionPending] = useState(false);
   const [preflightError, setPreflightError] = useState('');
+  const executionRPCAbortRef = useRef<AbortController | null>(null);
   const [capabilityState, setCapabilityState] = useState<{
     status: 'idle' | 'loading' | 'ready' | 'error';
     supported: boolean;
@@ -235,6 +237,11 @@ const SQLFileExecutionWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
   const terminal = state.status === 'done'
     || state.status === 'cancelled'
     || state.status === 'error';
+
+  useEffect(() => () => {
+    executionRPCAbortRef.current?.abort();
+    executionRPCAbortRef.current = null;
+  }, []);
   const completedWithErrors = state.status === 'done' && state.failed > 0;
   const capabilityAllowsExecution = capabilityState.status === 'ready'
     && capabilityState.supported;
@@ -375,14 +382,34 @@ const SQLFileExecutionWorkbench: React.FC<{ tab: TabData }> = ({ tab }) => {
         filePath,
         fileSizeMB: tab.sqlFileExecutionFileSizeMB,
         run: async (jobId) => {
-          const result = await ImportDatabaseSQLWithOptions(
-            connectionConfig as any,
+          executionRPCAbortRef.current?.abort();
+          const controller = new AbortController();
+          executionRPCAbortRef.current = controller;
+          const args = [
+            connectionConfig,
             String(tab.dbName || '').trim(),
             filePath,
             jobId,
             continueOnError,
             mysqlGTIDMode,
-          );
+          ];
+          const result = await invokeAppWithSignal(
+            'ImportDatabaseSQLWithOptions',
+            args,
+            controller.signal,
+            () => ImportDatabaseSQLWithOptions(
+              connectionConfig as any,
+              String(tab.dbName || '').trim(),
+              filePath,
+              jobId,
+              continueOnError,
+              mysqlGTIDMode,
+            ),
+          ).finally(() => {
+            if (executionRPCAbortRef.current === controller) {
+              executionRPCAbortRef.current = null;
+            }
+          });
           if (continueOnError && result.data?.completed === true) {
             return { ...result, success: true };
           }

--- a/frontend/src/components/data-sync/DataSyncTaskEditor.tsx
+++ b/frontend/src/components/data-sync/DataSyncTaskEditor.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { isWebRPCAbortError } from '../../utils/webRpc';
 
 import { DataSyncEndpointSelector } from './DataSyncEndpointSelector';
 import { DataSyncFieldMappingEditor } from './DataSyncFieldMappingEditor';
@@ -1226,6 +1227,7 @@ export const DataSyncTaskEditor: React.FC<{
   currentTaskRef.current = task;
   const [inspectedMappingId, setInspectedMappingId] = useState('');
   const mappingProbeEpochRef = useRef(0);
+  const mappingProbeAbortRef = useRef<AbortController | null>(null);
   const [mappingProbe, setMappingProbe] = useState<{
     taskId: string;
     epoch: number;
@@ -1238,9 +1240,13 @@ export const DataSyncTaskEditor: React.FC<{
   useEffect(() => {
     setInspectedMappingId('');
     mappingProbeEpochRef.current += 1;
+    mappingProbeAbortRef.current?.abort();
+    mappingProbeAbortRef.current = null;
     setMappingProbe(null);
     return () => {
       mappingProbeEpochRef.current += 1;
+      mappingProbeAbortRef.current?.abort();
+      mappingProbeAbortRef.current = null;
     };
   }, [
     task.id,
@@ -1345,6 +1351,9 @@ export const DataSyncTaskEditor: React.FC<{
     );
     if (addedMappings.length === 0) return;
     const probeEpoch = ++mappingProbeEpochRef.current;
+    mappingProbeAbortRef.current?.abort();
+    const probeController = new AbortController();
+    mappingProbeAbortRef.current = probeController;
     setMappingProbe({
       taskId: requestTask.id,
       epoch: probeEpoch,
@@ -1377,6 +1386,7 @@ export const DataSyncTaskEditor: React.FC<{
               const sourceFields = await gateway.listFields(
                 requestTask.source,
                 mapping.sourceObject,
+                { signal: probeController.signal },
               );
               let targetFields: DataSyncFieldMetadata[] = [];
               if (requestTask.kind === 'cdc' && mapping.targetObject.trim()) {
@@ -1384,8 +1394,16 @@ export const DataSyncTaskEditor: React.FC<{
                   targetFields = await gateway.listFields(
                     requestTask.target,
                     mapping.targetObject,
+                    { signal: probeController.signal },
                   );
-                } catch {
+                } catch (error) {
+                  if (
+                    probeController.signal.aborted ||
+                    isWebRPCAbortError(error) ||
+                    mappingProbeEpochRef.current !== probeEpoch
+                  ) {
+                    return;
+                  }
                   targetFields = [];
                 }
               }
@@ -1398,7 +1416,14 @@ export const DataSyncTaskEditor: React.FC<{
                 targetFields,
                 targetObject: mapping.targetObject,
               });
-            } catch {
+            } catch (error) {
+              if (
+                probeController.signal.aborted ||
+                isWebRPCAbortError(error) ||
+                mappingProbeEpochRef.current !== probeEpoch
+              ) {
+                return;
+              }
               metadataByMappingId.set(mapping.id, {
                 keyColumns: [],
                 sourceFields: [],
@@ -1426,6 +1451,15 @@ export const DataSyncTaskEditor: React.FC<{
         },
       );
       await Promise.all(workers);
+      if (mappingProbeAbortRef.current === probeController) {
+        mappingProbeAbortRef.current = null;
+      }
+      if (
+        probeController.signal.aborted ||
+        mappingProbeEpochRef.current !== probeEpoch
+      ) {
+        return;
+      }
 
       const currentTask = currentTaskRef.current;
       const currentSourceScope = JSON.stringify([

--- a/frontend/src/components/data-sync/DataSyncWorkbenchShell.tsx
+++ b/frontend/src/components/data-sync/DataSyncWorkbenchShell.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { isWebRPCAbortError } from '../../utils/webRpc';
 
 import {
   DataSyncCdcView,
@@ -334,6 +335,9 @@ export const DataSyncWorkbenchShell: React.FC<DataSyncWorkbenchShellProps> = ({
   const savingRef = useRef(false);
   const [preflighting, setPreflighting] = useState(false);
   const preflightingRef = useRef(false);
+  const preflightAbortRef = useRef<AbortController | null>(null);
+  const capabilityAbortRef = useRef<AbortController | null>(null);
+  const cdcAbortRef = useRef<AbortController | null>(null);
   const deletingTaskRef = useRef(false);
   const [preflights, setPreflights] = useState<
     Record<string, DataSyncPreflightSnapshot | undefined>
@@ -375,6 +379,12 @@ export const DataSyncWorkbenchShell: React.FC<DataSyncWorkbenchShellProps> = ({
     null,
   );
   const runStatusesRef = useRef<Map<string, DataSyncRunRecord['status']>>(new Map());
+
+  useEffect(() => () => {
+    preflightAbortRef.current?.abort();
+    capabilityAbortRef.current?.abort();
+    cdcAbortRef.current?.abort();
+  }, []);
 
   const applyRunPage = (
     page: DataSyncRunPage,
@@ -566,8 +576,12 @@ export const DataSyncWorkbenchShell: React.FC<DataSyncWorkbenchShellProps> = ({
 
   useEffect(() => {
     let active = true;
+    const taskController = new AbortController();
+    const cdcController = new AbortController();
+    cdcAbortRef.current?.abort();
+    cdcAbortRef.current = cdcController;
     void gatewayRef.current!
-      .listTasks()
+      .listTasks({ signal: taskController.signal })
       .then((loadedTasks) => {
         if (!active) return;
         if (loadedTasks.length > 0) {
@@ -593,7 +607,7 @@ export const DataSyncWorkbenchShell: React.FC<DataSyncWorkbenchShellProps> = ({
         return Promise.allSettled([
           requestRunPage(null, 10),
           gatewayRef.current!.listSchedules(),
-          gatewayRef.current!.listCdcSources(),
+          gatewayRef.current!.listCdcSources({ signal: cdcController.signal }),
         ] as const);
       })
       .then((results) => {
@@ -611,19 +625,22 @@ export const DataSyncWorkbenchShell: React.FC<DataSyncWorkbenchShellProps> = ({
         const rejected = results.find(
           (result): result is PromiseRejectedResult => result.status === 'rejected',
         );
-        if (rejected) {
+        if (rejected && !isWebRPCAbortError(rejected.reason)) {
           setOperationError(
             rejected.reason instanceof Error ? rejected.reason.message : String(rejected.reason),
           );
         }
       })
       .catch((error) => {
-        if (active) {
+        if (active && !isWebRPCAbortError(error)) {
           setOperationError(error instanceof Error ? error.message : String(error));
         }
       });
     return () => {
       active = false;
+      taskController.abort();
+      cdcController.abort();
+      if (cdcAbortRef.current === cdcController) cdcAbortRef.current = null;
     };
   }, [bootstrapRevision]);
 
@@ -633,19 +650,24 @@ export const DataSyncWorkbenchShell: React.FC<DataSyncWorkbenchShellProps> = ({
       return undefined;
     }
     let active = true;
+    const controller = new AbortController();
+    capabilityAbortRef.current?.abort();
+    capabilityAbortRef.current = controller;
     setCapability(EMPTY_CAPABILITY);
     void gatewayRef.current!
-      .resolveCapability(selectedTask)
+      .resolveCapability(selectedTask, { signal: controller.signal })
       .then((resolved) => {
         if (active) setCapability(resolved);
       })
       .catch((error) => {
-        if (!active) return;
+        if (!active || isWebRPCAbortError(error)) return;
         setCapability(EMPTY_CAPABILITY);
         setOperationError(error instanceof Error ? error.message : String(error));
       });
     return () => {
       active = false;
+      controller.abort();
+      if (capabilityAbortRef.current === controller) capabilityAbortRef.current = null;
     };
   }, [
     selectedTask?.id,
@@ -811,14 +833,23 @@ export const DataSyncWorkbenchShell: React.FC<DataSyncWorkbenchShellProps> = ({
       let refreshedPreflight: DataSyncPreflightSnapshot | null = null;
       let refreshError: unknown = null;
       if (saved.lifecycle === 'ready' || saved.lifecycle === 'enabled') {
+        preflightAbortRef.current?.abort();
+        const controller = new AbortController();
+        preflightAbortRef.current = controller;
         try {
           // PutJob advances the persisted revision. Revalidate that exact
           // revision before exposing the run action; the old snapshot is no
           // longer sufficient evidence, even when the visible fields did not
           // change.
-          refreshedPreflight = await gatewayRef.current!.preflightTask(saved);
+          refreshedPreflight = await gatewayRef.current!.preflightTask(saved, {
+            signal: controller.signal,
+          });
         } catch (error) {
-          refreshError = error;
+          if (!isWebRPCAbortError(error)) refreshError = error;
+        } finally {
+          if (preflightAbortRef.current === controller) {
+            preflightAbortRef.current = null;
+          }
         }
       }
       const tombstoned =
@@ -948,8 +979,13 @@ export const DataSyncWorkbenchShell: React.FC<DataSyncWorkbenchShellProps> = ({
     preflightingRef.current = true;
     setPreflighting(true);
     setOperationError('');
+    preflightAbortRef.current?.abort();
+    const controller = new AbortController();
+    preflightAbortRef.current = controller;
     try {
-      const snapshot = await gatewayRef.current!.preflightTask(selectedTask);
+      const snapshot = await gatewayRef.current!.preflightTask(selectedTask, {
+        signal: controller.signal,
+      });
       setPreflights((current) => ({ ...current, [selectedTask.id]: snapshot }));
       setApprovals((current) => {
         const approval = current[selectedTask.id];
@@ -971,8 +1007,10 @@ export const DataSyncWorkbenchShell: React.FC<DataSyncWorkbenchShellProps> = ({
         setActiveStage('preflight');
       }
     } catch (error) {
+      if (isWebRPCAbortError(error)) return;
       setOperationError(error instanceof Error ? error.message : String(error));
     } finally {
+      if (preflightAbortRef.current === controller) preflightAbortRef.current = null;
       preflightingRef.current = false;
       setPreflighting(false);
     }
@@ -1337,8 +1375,18 @@ export const DataSyncWorkbenchShell: React.FC<DataSyncWorkbenchShellProps> = ({
         return next;
       });
       setCheckpoint(null);
-      setCdcSources(await gatewayRef.current!.listCdcSources());
+      cdcAbortRef.current?.abort();
+      const controller = new AbortController();
+      cdcAbortRef.current = controller;
+      try {
+        setCdcSources(await gatewayRef.current!.listCdcSources({
+          signal: controller.signal,
+        }));
+      } finally {
+        if (cdcAbortRef.current === controller) cdcAbortRef.current = null;
+      }
     } catch (error) {
+      if (isWebRPCAbortError(error)) return;
       setOperationError(error instanceof Error ? error.message : String(error));
     } finally {
       setOperationBusy('');
@@ -1358,11 +1406,18 @@ export const DataSyncWorkbenchShell: React.FC<DataSyncWorkbenchShellProps> = ({
 
   const refreshCdc = async () => {
     setOperationBusy('refresh-cdc');
+    cdcAbortRef.current?.abort();
+    const controller = new AbortController();
+    cdcAbortRef.current = controller;
     try {
-      setCdcSources(await gatewayRef.current!.listCdcSources());
+      setCdcSources(await gatewayRef.current!.listCdcSources({
+        signal: controller.signal,
+      }));
     } catch (error) {
+      if (isWebRPCAbortError(error)) return;
       setOperationError(error instanceof Error ? error.message : String(error));
     } finally {
+      if (cdcAbortRef.current === controller) cdcAbortRef.current = null;
       setOperationBusy('');
     }
   };
@@ -1394,8 +1449,13 @@ export const DataSyncWorkbenchShell: React.FC<DataSyncWorkbenchShellProps> = ({
     setPreflighting(true);
     setOperationError('');
     setApprovalError('');
+    preflightAbortRef.current?.abort();
+    const controller = new AbortController();
+    preflightAbortRef.current = controller;
     try {
-      const snapshot = await gatewayRef.current!.preflightTask(candidate);
+      const snapshot = await gatewayRef.current!.preflightTask(candidate, {
+        signal: controller.signal,
+      });
       const latestTask = tasksRef.current.find((task) => task.id === selectedTask.id);
       if (!latestTask || latestTask.editEpoch !== selectedTask.editEpoch) {
         setOperationError(t('workbench.definition_changed_retry'));
@@ -1444,8 +1504,10 @@ export const DataSyncWorkbenchShell: React.FC<DataSyncWorkbenchShellProps> = ({
       }
       await saveTask(candidate, selectedTask.editEpoch, true);
     } catch (error) {
+      if (isWebRPCAbortError(error)) return;
       setOperationError(error instanceof Error ? error.message : String(error));
     } finally {
+      if (preflightAbortRef.current === controller) preflightAbortRef.current = null;
       preflightingRef.current = false;
       setPreflighting(false);
     }

--- a/frontend/src/components/data-sync/gateway.ts
+++ b/frontend/src/components/data-sync/gateway.ts
@@ -22,6 +22,7 @@ import {
   type DataSyncEndpointRef,
   type DataSyncValidationIssue,
 } from './model';
+import type { WebRPCRequestOptions } from '../../utils/webRpc';
 
 export interface DataSyncWorkbenchGateway {
   readonly capabilities: {
@@ -30,18 +31,31 @@ export interface DataSyncWorkbenchGateway {
   };
   /** Returns credential-free connection summaries only. */
   listSavedConnections(): Promise<DataSyncSavedConnectionView[]>;
-  listDatabases(connectionId: string): Promise<DataSyncDatabaseMetadata[]>;
-  listObjects(endpoint: DataSyncEndpointRef): Promise<DataSyncObjectMetadata[]>;
+  listDatabases(
+    connectionId: string,
+    options?: WebRPCRequestOptions,
+  ): Promise<DataSyncDatabaseMetadata[]>;
+  listObjects(
+    endpoint: DataSyncEndpointRef,
+    options?: WebRPCRequestOptions,
+  ): Promise<DataSyncObjectMetadata[]>;
   listFields(
     endpoint: DataSyncEndpointRef,
     objectName: string,
+    options?: WebRPCRequestOptions,
   ): Promise<DataSyncFieldMetadata[]>;
-  listTasks(): Promise<DataSyncTaskDefinition[]>;
+  listTasks(options?: WebRPCRequestOptions): Promise<DataSyncTaskDefinition[]>;
   saveTask(task: DataSyncTaskDefinition): Promise<DataSyncTaskDefinition>;
   /** Permanently deletes a persisted inactive task; local-only drafts resolve immediately. */
   deleteTask(taskId: string): Promise<void>;
-  resolveCapability(task: DataSyncTaskDefinition): Promise<DataSyncRouteCapability>;
-  preflightTask(task: DataSyncTaskDefinition): Promise<DataSyncPreflightSnapshot>;
+  resolveCapability(
+    task: DataSyncTaskDefinition,
+    options?: WebRPCRequestOptions,
+  ): Promise<DataSyncRouteCapability>;
+  preflightTask(
+    task: DataSyncTaskDefinition,
+    options?: WebRPCRequestOptions,
+  ): Promise<DataSyncPreflightSnapshot>;
   beginApproval(
     task: DataSyncTaskDefinition,
     preflight: DataSyncPreflightSnapshot,
@@ -63,8 +77,11 @@ export interface DataSyncWorkbenchGateway {
   listErrorRows(runId: string): Promise<DataSyncErrorRow[]>;
   listSchedules(): Promise<DataSyncScheduleSummary[]>;
   listCdcAdapters(): Promise<string[]>;
-  listCdcSources(): Promise<DataSyncCdcSourceStatus[]>;
-  getCheckpoint(taskId: string): Promise<DataSyncCheckpointSummary | null>;
+  listCdcSources(options?: WebRPCRequestOptions): Promise<DataSyncCdcSourceStatus[]>;
+  getCheckpoint(
+    taskId: string,
+    options?: WebRPCRequestOptions,
+  ): Promise<DataSyncCheckpointSummary | null>;
   resetCheckpoint(
     taskId: string,
     expectedJobRevision: number,

--- a/frontend/src/components/data-sync/useDataSyncMetadata.ts
+++ b/frontend/src/components/data-sync/useDataSyncMetadata.ts
@@ -12,6 +12,7 @@ import type {
   DataSyncObjectMetadata,
   DataSyncSavedConnectionView,
 } from './model';
+import type { WebRPCRequestOptions } from '../../utils/webRpc';
 
 export type DataSyncMetadataState<T> = {
   status: 'idle' | 'loading' | 'ready' | 'error';
@@ -36,7 +37,7 @@ const useMetadataCollection = <T,>(
   gateway: DataSyncWorkbenchGateway,
   requestKey: string,
   enabled: boolean,
-  load: () => Promise<T[]>,
+  load: (options: WebRPCRequestOptions) => Promise<T[]>,
 ): DataSyncMetadataResult<T> => {
   const [state, setState] = useState<DataSyncMetadataState<T>>(idleState);
   const [reloadRevision, setReloadRevision] = useState(0);
@@ -52,9 +53,10 @@ const useMetadataCollection = <T,>(
     }
 
     let active = true;
+    const controller = new AbortController();
     setState({ status: 'loading', items: [], error: '' });
     void Promise.resolve()
-      .then(() => loadRef.current())
+      .then(() => loadRef.current({ signal: controller.signal }))
       .then(
         (items) => {
           if (!active || requestSequence.current !== requestId) return;
@@ -68,6 +70,7 @@ const useMetadataCollection = <T,>(
 
     return () => {
       active = false;
+      controller.abort();
     };
   }, [enabled, gateway, reloadRevision, requestKey]);
 
@@ -94,7 +97,7 @@ export const useDataSyncDatabases = (
     gateway,
     normalizedConnectionId,
     Boolean(normalizedConnectionId),
-    () => gateway.listDatabases(normalizedConnectionId),
+    (options) => gateway.listDatabases(normalizedConnectionId, options),
   );
 };
 
@@ -104,8 +107,8 @@ export const useDataSyncObjects = (
 ): DataSyncMetadataResult<DataSyncObjectMetadata> => {
   const requestKey = dataSyncEndpointMetadataKey(endpoint);
   const enabled = Boolean(endpoint.connectionId.trim());
-  return useMetadataCollection(gateway, requestKey, enabled, () =>
-    gateway.listObjects({ ...endpoint }),
+  return useMetadataCollection(gateway, requestKey, enabled, (options) =>
+    gateway.listObjects({ ...endpoint }, options),
   );
 };
 
@@ -116,7 +119,7 @@ export const useDataSyncFields = (
 ): DataSyncMetadataResult<DataSyncFieldMetadata> => {
   const requestKey = dataSyncObjectMetadataKey(endpoint, objectName);
   const enabled = Boolean(endpoint.connectionId.trim() && objectName.trim());
-  return useMetadataCollection(gateway, requestKey, enabled, () =>
-    gateway.listFields({ ...endpoint }, objectName),
+  return useMetadataCollection(gateway, requestKey, enabled, (options) =>
+    gateway.listFields({ ...endpoint }, objectName, options),
   );
 };

--- a/frontend/src/components/data-sync/wailsGateway.test.ts
+++ b/frontend/src/components/data-sync/wailsGateway.test.ts
@@ -276,6 +276,75 @@ describe('real Wails data sync gateway', () => {
     expect(api.DataSyncCDCProbe).toHaveBeenCalledWith('source-id', 'sales', '', '');
   });
 
+  it('rethrows a Web RPC abort from CDC probing instead of reporting capability unavailable', async () => {
+    const task = reviseDataSyncTask(
+      createDataSyncTaskDraft({ id: 'persisted-cdc', kind: 'cdc' }),
+      {
+        source: {
+          connectionId: 'source-id',
+          connectionName: 'Mongo source',
+          type: 'mongodb',
+          database: 'sales',
+          schema: '',
+        },
+        target: {
+          connectionId: 'target-id',
+          connectionName: 'Target',
+          type: 'postgresql',
+          database: 'warehouse',
+          schema: 'ods',
+        },
+      },
+    );
+    const api = apiFixture({
+      DataSyncJobList: vi.fn(async () =>
+        success([encodeDataSyncJobDefinition(task)]),
+      ),
+    });
+    const gateway = createWailsDataSyncWorkbenchGateway({ api, now: () => NOW });
+    await gateway.listTasks();
+
+    const abortError = Object.assign(new Error('aborted'), {
+      name: 'AbortError',
+      code: 'WEB_RPC_ABORTED',
+      dispatchState: 'possibly_dispatched',
+    });
+    const invokeWithOptions = vi.fn(async (
+      _namespace: string,
+      _receiver: string,
+      method: string,
+    ) => {
+      if (method === 'DataSyncCheckpointGet') {
+        return { success: false, message: 'data sync job record not found' };
+      }
+      throw abortError;
+    });
+    const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: { __GONAVI_WEB_RPC__: { invokeWithOptions } },
+    });
+    const controller = new AbortController();
+    try {
+      await expect(
+        gateway.listCdcSources({ signal: controller.signal }),
+      ).rejects.toBe(abortError);
+    } finally {
+      if (originalWindow) {
+        Object.defineProperty(globalThis, 'window', originalWindow);
+      } else {
+        delete (globalThis as { window?: unknown }).window;
+      }
+    }
+    expect(invokeWithOptions).toHaveBeenCalledWith(
+      'app',
+      'App',
+      'DataSyncCDCProbe',
+      ['source-id', 'sales', '', ''],
+      { signal: controller.signal },
+    );
+  });
+
   it('returns localized-form validation codes before calling backend preflight', async () => {
     const base = taskFixture();
     const task = reviseDataSyncTask(base, {

--- a/frontend/src/components/data-sync/wailsGateway.ts
+++ b/frontend/src/components/data-sync/wailsGateway.ts
@@ -1,5 +1,10 @@
 import * as WailsApp from '../../../wailsjs/go/app/App';
 import { syncjob } from '../../../wailsjs/go/models';
+import {
+  invokeAppWithSignal,
+  isWebRPCAbortError,
+  type WebRPCRequestOptions,
+} from '../../utils/webRpc';
 
 import type { DataSyncWorkbenchGateway } from './gateway';
 import type {
@@ -304,9 +309,15 @@ export const createWailsDataSyncWorkbenchGateway = (
 
   const getCheckpoint = async (
     taskId: string,
+    requestOptions?: WebRPCRequestOptions,
   ): Promise<DataSyncCheckpointSummary | null> => {
     if (!taskId.trim() || isLocalDataSyncTaskId(taskId)) return null;
-    const result = await api.DataSyncCheckpointGet(taskId);
+    const result = await invokeAppWithSignal(
+      'DataSyncCheckpointGet',
+      [taskId],
+      requestOptions?.signal,
+      () => api.DataSyncCheckpointGet(taskId),
+    );
     if (isCheckpointMissing(result)) return null;
     return decodeCheckpoint(requireWailsQueryData(result, 'DataSyncCheckpointGet'));
   };
@@ -324,22 +335,32 @@ export const createWailsDataSyncWorkbenchGateway = (
       return connections;
     },
 
-    async listDatabases(connectionId) {
+    async listDatabases(connectionId, requestOptions) {
       return decodeDatabaseMetadata(
         requireWailsQueryData(
-          await api.DataSyncDatabaseList(connectionId),
+          await invokeAppWithSignal(
+            'DataSyncDatabaseList',
+            [connectionId],
+            requestOptions?.signal,
+            () => api.DataSyncDatabaseList(connectionId),
+          ),
           'DataSyncDatabaseList',
         ),
       );
     },
 
-    async listObjects(endpoint) {
+    async listObjects(endpoint, requestOptions) {
       return decodeObjectMetadata(
         requireWailsQueryData(
-          await api.DataSyncObjectList(
-            endpoint.connectionId,
-            endpoint.database,
-            endpoint.schema,
+          await invokeAppWithSignal(
+            'DataSyncObjectList',
+            [endpoint.connectionId, endpoint.database, endpoint.schema],
+            requestOptions?.signal,
+            () => api.DataSyncObjectList(
+              endpoint.connectionId,
+              endpoint.database,
+              endpoint.schema,
+            ),
           ),
           'DataSyncObjectList',
         ),
@@ -347,23 +368,38 @@ export const createWailsDataSyncWorkbenchGateway = (
       );
     },
 
-    async listFields(endpoint, objectName) {
+    async listFields(endpoint, objectName, requestOptions) {
       return decodeFieldMetadata(
         requireWailsQueryData(
-          await api.DataSyncFieldList(
-            endpoint.connectionId,
-            endpoint.database,
-            endpoint.schema,
-            stripEndpointSchema(endpoint.schema, objectName),
+          await invokeAppWithSignal(
+            'DataSyncFieldList',
+            [
+              endpoint.connectionId,
+              endpoint.database,
+              endpoint.schema,
+              stripEndpointSchema(endpoint.schema, objectName),
+            ],
+            requestOptions?.signal,
+            () => api.DataSyncFieldList(
+              endpoint.connectionId,
+              endpoint.database,
+              endpoint.schema,
+              stripEndpointSchema(endpoint.schema, objectName),
+            ),
           ),
           'DataSyncFieldList',
         ),
       );
     },
 
-    async listTasks() {
+    async listTasks(requestOptions) {
       const value = requireWailsQueryData(
-        await api.DataSyncJobList(),
+        await invokeAppWithSignal(
+          'DataSyncJobList',
+          [],
+          requestOptions?.signal,
+          () => api.DataSyncJobList(),
+        ),
         'DataSyncJobList',
       );
       if (!Array.isArray(value)) {
@@ -413,19 +449,31 @@ export const createWailsDataSyncWorkbenchGateway = (
       return saved;
     },
 
-    async resolveCapability(task) {
+    async resolveCapability(task, requestOptions) {
       if (!task.source.connectionId || !task.target.connectionId) {
         return { ...UNKNOWN_CAPABILITY };
       }
       const base = decodeRouteCapability(
         requireWailsQueryData(
-          await api.DataSyncCapabilityResolve(
-            task.source.connectionId,
-            task.source.database,
-            task.source.schema,
-            task.target.connectionId,
-            task.target.database,
-            task.target.schema,
+          await invokeAppWithSignal(
+            'DataSyncCapabilityResolve',
+            [
+              task.source.connectionId,
+              task.source.database,
+              task.source.schema,
+              task.target.connectionId,
+              task.target.database,
+              task.target.schema,
+            ],
+            requestOptions?.signal,
+            () => api.DataSyncCapabilityResolve(
+              task.source.connectionId,
+              task.source.database,
+              task.source.schema,
+              task.target.connectionId,
+              task.target.database,
+              task.target.schema,
+            ),
           ),
           'DataSyncCapabilityResolve',
         ),
@@ -437,11 +485,21 @@ export const createWailsDataSyncWorkbenchGateway = (
       try {
         const probe = decodeCDCProbe(
           requireWailsQueryData(
-            await api.DataSyncCDCProbe(
-              task.source.connectionId,
-              task.source.database,
-              task.source.schema,
-              '',
+            await invokeAppWithSignal(
+              'DataSyncCDCProbe',
+              [
+                task.source.connectionId,
+                task.source.database,
+                task.source.schema,
+                '',
+              ],
+              requestOptions?.signal,
+              () => api.DataSyncCDCProbe(
+                task.source.connectionId,
+                task.source.database,
+                task.source.schema,
+                '',
+              ),
             ),
             'DataSyncCDCProbe',
           ),
@@ -456,6 +514,7 @@ export const createWailsDataSyncWorkbenchGateway = (
           cdcAdapter: probe.adapter,
         };
       } catch (error) {
+        if (isWebRPCAbortError(error)) throw error;
         return {
           ...base,
           canExecute: false,
@@ -467,7 +526,7 @@ export const createWailsDataSyncWorkbenchGateway = (
       }
     },
 
-    async preflightTask(task) {
+    async preflightTask(task, requestOptions) {
       const localIssues = validateDataSyncTask(task);
       if (localIssues.some((issue) => issue.severity === 'blocker')) {
         preflights.delete(task.id);
@@ -488,7 +547,12 @@ export const createWailsDataSyncWorkbenchGateway = (
       const previous = wireJobs.get(task.id);
       const input = encodeDataSyncJobDefinition(task, previous);
       const decoded = decodeDataSyncPreflightQuery(
-        await api.DataSyncJobPreflight(asJobDefinition(input)),
+        await invokeAppWithSignal(
+          'DataSyncJobPreflight',
+          [asJobDefinition(input)],
+          requestOptions?.signal,
+          () => api.DataSyncJobPreflight(asJobDefinition(input)),
+        ),
         task,
       );
       if (task.kind === 'compare' && !decoded.capability.canExecute) {
@@ -755,10 +819,10 @@ export const createWailsDataSyncWorkbenchGateway = (
       );
     },
 
-    async listCdcSources() {
+    async listCdcSources(requestOptions) {
       const tasks =
         !tasksLoaded
-          ? await gateway.listTasks()
+          ? await gateway.listTasks(requestOptions)
           : Array.from(wireJobs.values()).map(decodeDataSyncJobDefinition);
       const cdcTasks = tasks.filter(
         (
@@ -773,24 +837,36 @@ export const createWailsDataSyncWorkbenchGateway = (
           let checkpoint: DataSyncCheckpointSummary | null = null;
           let checkpointError = '';
           try {
-            checkpoint = await getCheckpoint(task.id);
+            checkpoint = await getCheckpoint(task.id, requestOptions);
           } catch (error) {
+            if (isWebRPCAbortError(error)) throw error;
             checkpointError = error instanceof Error ? error.message : String(error);
           }
           try {
             const probe = decodeCDCProbe(
               requireWailsQueryData(
-              await api.DataSyncCDCProbe(
-                task.source.connectionId,
-                task.source.database,
-                task.source.schema,
-                '',
+                await invokeAppWithSignal(
+                  'DataSyncCDCProbe',
+                  [
+                    task.source.connectionId,
+                    task.source.database,
+                    task.source.schema,
+                    '',
+                  ],
+                  requestOptions?.signal,
+                  () => api.DataSyncCDCProbe(
+                    task.source.connectionId,
+                    task.source.database,
+                    task.source.schema,
+                    '',
+                  ),
                 ),
                 'DataSyncCDCProbe',
               ),
             );
             return cdcSourceFromProbe(task, probe, checkpoint, checkpointError);
           } catch (error) {
+            if (isWebRPCAbortError(error)) throw error;
             const reason = error instanceof Error ? error.message : String(error);
             return cdcSourceFromProbe(task, null, checkpoint, reason);
           }

--- a/frontend/src/utils/webRpc.test.ts
+++ b/frontend/src/utils/webRpc.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { invokeAppWithSignal, isWebRPCAbortError } from './webRpc';
+
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+
+afterEach(() => {
+  if (originalWindow) {
+    Object.defineProperty(globalThis, 'window', originalWindow);
+  } else {
+    delete (globalThis as { window?: unknown }).window;
+  }
+});
+
+describe('Web RPC cancellation facade', () => {
+  it('passes the signal and original business arguments to the Web bridge', async () => {
+    const invokeWithOptions = vi.fn().mockResolvedValue({ success: true });
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: { __GONAVI_WEB_RPC__: { invokeWithOptions } },
+    });
+    const fallback = vi.fn().mockResolvedValue({ success: false });
+    const controller = new AbortController();
+
+    await expect(invokeAppWithSignal(
+      'DataSyncPreview',
+      [{ source: 'a' }, 'orders', 200],
+      controller.signal,
+      fallback,
+    )).resolves.toEqual({ success: true });
+
+    expect(invokeWithOptions).toHaveBeenCalledWith(
+      'app',
+      'App',
+      'DataSyncPreview',
+      [{ source: 'a' }, 'orders', 200],
+      { signal: controller.signal },
+    );
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it('waits for the generated Wails binding even when the signal is aborted', async () => {
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {},
+    });
+    const controller = new AbortController();
+    controller.abort();
+    const fallback = vi.fn().mockResolvedValue('wails-result');
+
+    await expect(invokeAppWithSignal(
+      'DBQueryWithCancel',
+      [{}, 'db', 'select 1', 'query-1'],
+      controller.signal,
+      fallback,
+    )).resolves.toBe('wails-result');
+    expect(fallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('recognizes only the stable Web RPC abort code', () => {
+    expect(isWebRPCAbortError({
+      name: 'AbortError',
+      code: 'WEB_RPC_ABORTED',
+      dispatchState: 'possibly_dispatched',
+    })).toBe(true);
+    expect(isWebRPCAbortError(new DOMException('aborted', 'AbortError'))).toBe(false);
+    expect(isWebRPCAbortError(new Error('WEB_RPC_ABORTED'))).toBe(false);
+  });
+});

--- a/frontend/src/utils/webRpc.ts
+++ b/frontend/src/utils/webRpc.ts
@@ -1,0 +1,52 @@
+export type WebRPCDispatchState = 'not_started' | 'possibly_dispatched';
+
+export type WebRPCAbortError = Error & {
+  name: 'AbortError';
+  code: 'WEB_RPC_ABORTED';
+  dispatchState: WebRPCDispatchState;
+};
+
+export type WebRPCRequestOptions = {
+  signal?: AbortSignal;
+};
+
+type GoNaviWebRPCBridge = {
+  invokeWithOptions?: <T>(
+    namespace: string,
+    receiver: string,
+    method: string,
+    args: unknown[],
+    options: WebRPCRequestOptions,
+  ) => Promise<T>;
+};
+
+const webRPCBridge = (): GoNaviWebRPCBridge | undefined => {
+  if (typeof window === 'undefined') return undefined;
+  return (window as Window & { __GONAVI_WEB_RPC__?: GoNaviWebRPCBridge })
+    .__GONAVI_WEB_RPC__;
+};
+
+/**
+ * Uses request cancellation only when the browser Web RPC bridge is present.
+ * The Wails fallback always waits for the generated binding's real result;
+ * aborting the signal never creates a client-side "fake cancellation" there.
+ */
+export const invokeAppWithSignal = <T>(
+  method: string,
+  args: unknown[],
+  signal: AbortSignal | undefined,
+  wailsFallback: () => Promise<T>,
+): Promise<T> => {
+  const invokeWithOptions = webRPCBridge()?.invokeWithOptions;
+  if (signal && typeof invokeWithOptions === 'function') {
+    return invokeWithOptions<T>('app', 'App', method, args, { signal });
+  }
+  return wailsFallback();
+};
+
+export const isWebRPCAbortError = (error: unknown): error is WebRPCAbortError =>
+  Boolean(
+    error
+      && typeof error === 'object'
+      && (error as { code?: unknown }).code === 'WEB_RPC_ABORTED',
+  );

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1300,7 +1300,13 @@ func formatConnSummary(config connection.ConnectionConfig) string {
 
 func (a *App) getDatabaseForcePing(config connection.ConnectionConfig) (db.Database, error) {
 	if a != nil && a.metadataSession != nil {
-		instance, err := a.getDatabaseWithContext(a.metadataSession.ctx, config, true)
+		var instance db.Database
+		var err error
+		if a.metadataSession.synchronous {
+			instance, err = a.getDatabaseSynchronouslyWithContext(a.metadataSession.ctx, config, true)
+		} else {
+			instance, err = a.getDatabaseWithContext(a.metadataSession.ctx, config, true)
+		}
 		a.bindMetadataDatabase(instance)
 		return instance, err
 	}
@@ -1312,7 +1318,13 @@ func (a *App) getDatabaseForcePing(config connection.ConnectionConfig) (db.Datab
 // Helper: Get or create a database connection
 func (a *App) getDatabase(config connection.ConnectionConfig) (db.Database, error) {
 	if a != nil && a.metadataSession != nil {
-		instance, err := a.getDatabaseWithContext(a.metadataSession.ctx, config, false)
+		var instance db.Database
+		var err error
+		if a.metadataSession.synchronous {
+			instance, err = a.getDatabaseSynchronouslyWithContext(a.metadataSession.ctx, config, false)
+		} else {
+			instance, err = a.getDatabaseWithContext(a.metadataSession.ctx, config, false)
+		}
 		a.bindMetadataDatabase(instance)
 		return instance, err
 	}
@@ -1359,6 +1371,27 @@ func (a *App) getDatabaseWithContext(ctx context.Context, config connection.Conn
 		}
 		return result.instance, result.err
 	}
+}
+
+// getDatabaseSynchronouslyWithContext keeps non-context-aware Connect work in
+// the current request goroutine. It cannot interrupt Connect, but it guarantees
+// that a canceled Web RPC does not return while a detached connection worker is
+// still running. The context is checked again before any SQL is dispatched.
+func (a *App) getDatabaseSynchronouslyWithContext(ctx context.Context, config connection.ConnectionConfig, forcePing bool) (db.Database, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	instance, err := a.getDatabaseWithPing(config, forcePing)
+	if err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return instance, nil
 }
 
 func (a *App) openDatabaseIsolated(config connection.ConnectionConfig) (db.Database, error) {

--- a/internal/app/data_sync_job_context_test.go
+++ b/internal/app/data_sync_job_context_test.go
@@ -1,0 +1,199 @@
+package app
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"GoNavi-Wails/internal/connection"
+	"GoNavi-Wails/internal/db"
+	"GoNavi-Wails/internal/syncjob"
+)
+
+type blockingPreflightPingDatabase struct {
+	fakeMetadataRetryDB
+	started chan struct{}
+	once    sync.Once
+}
+
+type blockingPreflightMetadataDatabase struct {
+	fakeMetadataRetryDB
+	started chan struct{}
+	once    sync.Once
+}
+
+func (database *blockingPreflightMetadataDatabase) GetColumns(_, _ string) ([]connection.ColumnDefinition, error) {
+	ctx := db.MetadataContext(database)
+	database.once.Do(func() { close(database.started) })
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (database *blockingPreflightPingDatabase) PingContext(ctx context.Context) error {
+	database.once.Do(func() { close(database.started) })
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func TestDataSyncJobPreflightContextStopsAfterPingCancellation(t *testing.T) {
+	installFakeOptionalDriverRuntime(t)
+	source := &blockingPreflightPingDatabase{started: make(chan struct{})}
+	target := &fakeMetadataRetryDB{}
+	originalNewDatabaseFunc := newDatabaseFunc
+	originalResolveDialConfigWithProxyFunc := resolveDialConfigWithProxyFunc
+	newDatabaseFunc = func(databaseType string) (db.Database, error) {
+		if databaseType == "mysql" {
+			return source, nil
+		}
+		return target, nil
+	}
+	resolveDialConfigWithProxyFunc = func(config connection.ConnectionConfig) (connection.ConnectionConfig, error) {
+		return config, nil
+	}
+	t.Cleanup(func() {
+		newDatabaseFunc = originalNewDatabaseFunc
+		resolveDialConfigWithProxyFunc = originalResolveDialConfigWithProxyFunc
+	})
+
+	application := NewAppWithSecretStore(newFakeAppSecretStore())
+	application.configDir = t.TempDir()
+	for _, input := range []connection.SavedConnectionInput{
+		{ID: "source", Name: "source", Config: connection.ConnectionConfig{ID: "source", Type: "mysql", Host: "source.local", Port: 3306, Database: "source_db"}},
+		{ID: "target", Name: "target", Config: connection.ConnectionConfig{ID: "target", Type: "postgres", Host: "target.local", Port: 5432, Database: "target_db"}},
+	} {
+		if _, err := application.SaveConnection(input); err != nil {
+			t.Fatal(err)
+		}
+	}
+	definition := syncjob.JobDefinition{
+		Name:            "cancelled preflight",
+		Lifecycle:       syncjob.JobLifecycleReady,
+		Kind:            syncjob.JobKindReconcile,
+		IncrementalMode: syncjob.IncrementalSnapshot,
+		Source:          syncjob.EndpointRef{ConnectionID: "source", Database: "source_db"},
+		Target:          syncjob.EndpointRef{ConnectionID: "target", Database: "target_db"},
+		Mappings: []syncjob.TableMapping{{
+			SourceTable: "orders",
+			TargetTable: "orders_archive",
+			Enabled:     true,
+		}},
+		Options: syncjob.ExecutionOptions{
+			Content:             "data",
+			SyncMode:            "insert_update",
+			TargetTableStrategy: "existing_only",
+			BatchSize:           1000,
+			ErrorPolicy:         syncjob.ErrorPolicyStop,
+			RetryBackoffMillis:  500,
+		},
+		Schedule: syncjob.ScheduleSpec{Kind: syncjob.ScheduleManual},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan DataSyncJobPreflightResult, 1)
+	go func() {
+		resultCh <- application.preflightDataSyncJobContext(ctx, definition, time.Now())
+	}()
+	select {
+	case <-source.started:
+		cancel()
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for preflight ping")
+	}
+
+	select {
+	case result := <-resultCh:
+		if result.Success || result.Status != "blocked" {
+			t.Fatalf("preflight result = %+v, want blocked cancellation", result)
+		}
+		if len(result.Issues) != 1 || result.Issues[0].Code != "request_cancelled" || result.Issues[0].Message != context.Canceled.Error() {
+			t.Fatalf("preflight issues = %#v, want one request_cancelled issue", result.Issues)
+		}
+		if target.connectCalls != 0 {
+			t.Fatalf("target connect calls = %d, want no work after cancellation", target.connectCalls)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("preflight did not return after PingContext cancellation")
+	}
+}
+
+func TestDataSyncJobPreflightContextStopsAfterMetadataCancellation(t *testing.T) {
+	installFakeOptionalDriverRuntime(t)
+	source := &blockingPreflightMetadataDatabase{started: make(chan struct{})}
+	target := &fakeMetadataRetryDB{}
+	originalNewDatabaseFunc := newDatabaseFunc
+	originalResolveDialConfigWithProxyFunc := resolveDialConfigWithProxyFunc
+	newDatabaseFunc = func(databaseType string) (db.Database, error) {
+		if databaseType == "mysql" {
+			return source, nil
+		}
+		return target, nil
+	}
+	resolveDialConfigWithProxyFunc = func(config connection.ConnectionConfig) (connection.ConnectionConfig, error) {
+		return config, nil
+	}
+	t.Cleanup(func() {
+		newDatabaseFunc = originalNewDatabaseFunc
+		resolveDialConfigWithProxyFunc = originalResolveDialConfigWithProxyFunc
+	})
+
+	application := NewAppWithSecretStore(newFakeAppSecretStore())
+	application.configDir = t.TempDir()
+	for _, input := range []connection.SavedConnectionInput{
+		{ID: "source", Name: "source", Config: connection.ConnectionConfig{ID: "source", Type: "mysql", Host: "source.local", Port: 3306, Database: "source_db"}},
+		{ID: "target", Name: "target", Config: connection.ConnectionConfig{ID: "target", Type: "postgres", Host: "target.local", Port: 5432, Database: "target_db"}},
+	} {
+		if _, err := application.SaveConnection(input); err != nil {
+			t.Fatal(err)
+		}
+	}
+	definition := syncjob.JobDefinition{
+		Name:            "cancelled metadata preflight",
+		Lifecycle:       syncjob.JobLifecycleReady,
+		Kind:            syncjob.JobKindReconcile,
+		IncrementalMode: syncjob.IncrementalSnapshot,
+		Source:          syncjob.EndpointRef{ConnectionID: "source", Database: "source_db"},
+		Target:          syncjob.EndpointRef{ConnectionID: "target", Database: "target_db"},
+		Mappings: []syncjob.TableMapping{{
+			SourceTable: "orders",
+			TargetTable: "orders_archive",
+			Enabled:     true,
+		}},
+		Options: syncjob.ExecutionOptions{
+			Content:             "data",
+			SyncMode:            "insert_update",
+			TargetTableStrategy: "existing_only",
+			BatchSize:           1000,
+			ErrorPolicy:         syncjob.ErrorPolicyStop,
+			RetryBackoffMillis:  500,
+		},
+		Schedule: syncjob.ScheduleSpec{Kind: syncjob.ScheduleManual},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan DataSyncJobPreflightResult, 1)
+	go func() {
+		resultCh <- application.preflightDataSyncJobContext(ctx, definition, time.Now())
+	}()
+	select {
+	case <-source.started:
+		cancel()
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for preflight metadata query")
+	}
+
+	select {
+	case result := <-resultCh:
+		if result.Success || result.Status != "blocked" {
+			t.Fatalf("preflight result = %+v, want blocked cancellation", result)
+		}
+		if len(result.Issues) != 1 || result.Issues[0].Code != "request_cancelled" || result.Issues[0].Message != context.Canceled.Error() {
+			t.Fatalf("preflight issues = %#v, want one request_cancelled issue", result.Issues)
+		}
+		if target.columnCalls != 0 {
+			t.Fatalf("target metadata calls = %d, want no work after cancellation", target.columnCalls)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("preflight did not return after metadata cancellation")
+	}
+}

--- a/internal/app/data_sync_job_preflight.go
+++ b/internal/app/data_sync_job_preflight.go
@@ -13,6 +13,13 @@ import (
 )
 
 func (a *App) preflightDataSyncJob(input syncjob.JobDefinition, now time.Time) DataSyncJobPreflightResult {
+	return a.preflightDataSyncJobContext(context.Background(), input, now)
+}
+
+func (a *App) preflightDataSyncJobContext(ctx context.Context, input syncjob.JobDefinition, now time.Time) DataSyncJobPreflightResult {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	definition := syncjob.NormalizeDefinition(input)
 	// Approval is backend-owned evidence. Never echo or validate a caller-
 	// supplied approval object; only one-time tokens can mint this state.
@@ -23,6 +30,19 @@ func (a *App) preflightDataSyncJob(input syncjob.JobDefinition, now time.Time) D
 		NextRunAt:  []int64{},
 		CheckedAt:  now.UnixMilli(),
 	}
+	stopIfCancelled := func(stage string) bool {
+		if err := ctx.Err(); err != nil {
+			if hasPreflightIssueCode(result.Issues, "request_cancelled") {
+				return true
+			}
+			result.Issues = append(result.Issues, preflightIssue("request_cancelled", DataSyncJobPreflightBlocker, stage, err.Error(), ""))
+			return true
+		}
+		return false
+	}
+	if stopIfCancelled("preflight") {
+		return finishDataSyncJobPreflight(result)
+	}
 	if err := syncjob.ValidateDefinition(definition); err != nil {
 		result.Issues = append(result.Issues, preflightIssue("definition_invalid", DataSyncJobPreflightBlocker, "endpoints", err.Error(), ""))
 		return finishDataSyncJobPreflight(result)
@@ -31,6 +51,9 @@ func (a *App) preflightDataSyncJob(input syncjob.JobDefinition, now time.Time) D
 	source, err := a.resolveDataSyncJobEndpoint(definition.Source.ConnectionID, definition.Source.Database, definition.Source.Schema)
 	if err != nil {
 		result.Issues = append(result.Issues, preflightIssue("source_connection_failed", DataSyncJobPreflightBlocker, "endpoints", err.Error(), ""))
+		return finishDataSyncJobPreflight(result)
+	}
+	if stopIfCancelled("endpoints") {
 		return finishDataSyncJobPreflight(result)
 	}
 	target, err := a.resolveDataSyncJobEndpoint(definition.Target.ConnectionID, definition.Target.Database, definition.Target.Schema)
@@ -90,19 +113,48 @@ func (a *App) preflightDataSyncJob(input syncjob.JobDefinition, now time.Time) D
 		}
 	}
 
-	if sourceDB, dbErr := a.getDatabase(normalizeMetadataRunConfig(source.Config, source.Database)); dbErr != nil {
-		result.Issues = append(result.Issues, preflightIssue("source_connect_failed", DataSyncJobPreflightBlocker, "endpoints", dbErr.Error(), ""))
-	} else if pingErr := sourceDB.Ping(); pingErr != nil {
-		result.Issues = append(result.Issues, preflightIssue("source_ping_failed", DataSyncJobPreflightBlocker, "endpoints", pingErr.Error(), ""))
+	if stopIfCancelled("endpoints") {
+		return finishDataSyncJobPreflight(result)
 	}
-	if targetDB, dbErr := a.getDatabase(normalizeMetadataRunConfig(target.Config, target.Database)); dbErr != nil {
+	sourceDB, dbErr := a.getDatabaseSynchronouslyWithContext(ctx, normalizeMetadataRunConfig(source.Config, source.Database), false)
+	if stopIfCancelled("endpoints") {
+		return finishDataSyncJobPreflight(result)
+	}
+	if dbErr != nil {
+		result.Issues = append(result.Issues, preflightIssue("source_connect_failed", DataSyncJobPreflightBlocker, "endpoints", dbErr.Error(), ""))
+	} else {
+		pingErr := pingDatabaseWithContext(ctx, sourceDB)
+		if stopIfCancelled("endpoints") {
+			return finishDataSyncJobPreflight(result)
+		}
+		if pingErr != nil {
+			result.Issues = append(result.Issues, preflightIssue("source_ping_failed", DataSyncJobPreflightBlocker, "endpoints", pingErr.Error(), ""))
+		}
+	}
+	if stopIfCancelled("endpoints") {
+		return finishDataSyncJobPreflight(result)
+	}
+	targetDB, dbErr := a.getDatabaseSynchronouslyWithContext(ctx, normalizeMetadataRunConfig(target.Config, target.Database), false)
+	if stopIfCancelled("endpoints") {
+		return finishDataSyncJobPreflight(result)
+	}
+	if dbErr != nil {
 		result.Issues = append(result.Issues, preflightIssue("target_connect_failed", DataSyncJobPreflightBlocker, "endpoints", dbErr.Error(), ""))
-	} else if pingErr := targetDB.Ping(); pingErr != nil {
-		result.Issues = append(result.Issues, preflightIssue("target_ping_failed", DataSyncJobPreflightBlocker, "endpoints", pingErr.Error(), ""))
+	} else {
+		pingErr := pingDatabaseWithContext(ctx, targetDB)
+		if stopIfCancelled("endpoints") {
+			return finishDataSyncJobPreflight(result)
+		}
+		if pingErr != nil {
+			result.Issues = append(result.Issues, preflightIssue("target_ping_failed", DataSyncJobPreflightBlocker, "endpoints", pingErr.Error(), ""))
+		}
 	}
 
 	if !hasPreflightBlocker(result.Issues) {
-		result.Issues = append(result.Issues, a.preflightDataSyncMappings(definition, source, target)...)
+		result.Issues = append(result.Issues, a.preflightDataSyncMappingsContext(ctx, definition, source, target)...)
+	}
+	if stopIfCancelled("mappings") {
+		return finishDataSyncJobPreflight(result)
 	}
 	if definition.IncrementalMode == syncjob.IncrementalWatermark {
 		for _, mapping := range definition.Mappings {
@@ -177,7 +229,10 @@ func (a *App) preflightDataSyncJob(input syncjob.JobDefinition, now time.Time) D
 	}
 	if definition.IncrementalMode == syncjob.IncrementalCDC {
 		if definition.CDC != nil && strings.TrimSpace(definition.CDC.Adapter) != "" {
-			cdcCapability, probeErr := a.probeDataSyncCDC(dataSyncCDCProbeConfig(source), "")
+			cdcCapability, probeErr := a.probeDataSyncCDCContext(ctx, dataSyncCDCProbeConfig(source), "")
+			if stopIfCancelled("trigger") {
+				return finishDataSyncJobPreflight(result)
+			}
 			if probeErr != nil {
 				result.Issues = append(result.Issues, preflightIssue("cdc_probe_failed", DataSyncJobPreflightBlocker, "trigger", probeErr.Error(), ""))
 			} else {
@@ -221,12 +276,21 @@ func (a *App) preflightDataSyncJob(input syncjob.JobDefinition, now time.Time) D
 			manager, managerErr := a.ensureDataSyncJobManager()
 			if managerErr != nil {
 				result.Issues = append(result.Issues, preflightIssue("cdc_checkpoint_unavailable", DataSyncJobPreflightBlocker, "trigger", managerErr.Error(), ""))
-			} else if checkpoint, checkpointErr := manager.GetCheckpoint(context.Background(), definition.ID); checkpointErr != nil {
-				result.Issues = append(result.Issues, preflightIssue("cdc_checkpoint_required", DataSyncJobPreflightBlocker, "trigger", "start position checkpoint requires a durable checkpoint from this task", ""))
-			} else if planHash, hashErr := dataSyncJobDefinitionHash(definition); checkpoint.Kind != "cdc" || hashErr != nil || !secureTextEqual(checkpoint.SchemaHash, planHash) {
-				result.Issues = append(result.Issues, preflightIssue("cdc_checkpoint_incompatible", DataSyncJobPreflightBlocker, "trigger", "the durable checkpoint belongs to a different task revision or incremental mode; reset it explicitly", ""))
+			} else {
+				checkpoint, checkpointErr := manager.GetCheckpoint(ctx, definition.ID)
+				if stopIfCancelled("trigger") {
+					return finishDataSyncJobPreflight(result)
+				}
+				if checkpointErr != nil {
+					result.Issues = append(result.Issues, preflightIssue("cdc_checkpoint_required", DataSyncJobPreflightBlocker, "trigger", "start position checkpoint requires a durable checkpoint from this task", ""))
+				} else if planHash, hashErr := dataSyncJobDefinitionHash(definition); checkpoint.Kind != "cdc" || hashErr != nil || !secureTextEqual(checkpoint.SchemaHash, planHash) {
+					result.Issues = append(result.Issues, preflightIssue("cdc_checkpoint_incompatible", DataSyncJobPreflightBlocker, "trigger", "the durable checkpoint belongs to a different task revision or incremental mode; reset it explicitly", ""))
+				}
 			}
 		}
+	}
+	if stopIfCancelled("preflight") {
+		return finishDataSyncJobPreflight(result)
 	}
 	if hash, hashErr := dataSyncJobDefinitionHash(definition); hashErr != nil {
 		result.Issues = append(result.Issues, preflightIssue("definition_hash_failed", DataSyncJobPreflightBlocker, "preflight", hashErr.Error(), ""))
@@ -235,6 +299,20 @@ func (a *App) preflightDataSyncJob(input syncjob.JobDefinition, now time.Time) D
 	}
 	result.NextRunAt = previewDataSyncJobSchedule(definition, now, 5)
 	return finishDataSyncJobPreflight(result)
+}
+
+func pingDatabaseWithContext(ctx context.Context, database interface{ Ping() error }) error {
+	if pinger, ok := database.(interface{ PingContext(context.Context) error }); ok {
+		return pinger.PingContext(ctx)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	err := database.Ping()
+	if err == nil {
+		return ctx.Err()
+	}
+	return err
 }
 
 func appendOnlyTargetPreflightIssues(definition syncjob.JobDefinition, capability sync.MigrationCapability) []DataSyncJobPreflightIssue {
@@ -264,8 +342,15 @@ func appendOnlyTargetPreflightIssues(definition syncjob.JobDefinition, capabilit
 }
 
 func (a *App) preflightDataSyncMappings(definition syncjob.JobDefinition, source, target resolvedDataSyncJobEndpoint) []DataSyncJobPreflightIssue {
+	return a.preflightDataSyncMappingsContext(context.Background(), definition, source, target)
+}
+
+func (a *App) preflightDataSyncMappingsContext(ctx context.Context, definition syncjob.JobDefinition, source, target resolvedDataSyncJobEndpoint) []DataSyncJobPreflightIssue {
 	issues := make([]DataSyncJobPreflightIssue, 0)
 	for _, mapping := range definition.Mappings {
+		if err := ctx.Err(); err != nil {
+			return append(issues, preflightIssue("request_cancelled", DataSyncJobPreflightBlocker, "mappings", err.Error(), dataSyncJobMappingLabel(mapping)))
+		}
 		if !mapping.Enabled {
 			continue
 		}
@@ -275,11 +360,20 @@ func (a *App) preflightDataSyncMappings(definition syncjob.JobDefinition, source
 			if !readOnly {
 				issues = append(issues, preflightIssue("source_query_not_read_only", DataSyncJobPreflightBlocker, "mappings", "sourceQuery must be a single read-only query", mappingID))
 			}
-			targetIssues := a.preflightDataSyncQueryTarget(definition, mapping, target)
+			targetIssues := a.preflightDataSyncQueryTargetContext(ctx, definition, mapping, target)
 			issues = append(issues, targetIssues...)
+			if err := ctx.Err(); err != nil {
+				if hasPreflightIssueCode(issues, "request_cancelled") {
+					return issues
+				}
+				return append(issues, preflightIssue("request_cancelled", DataSyncJobPreflightBlocker, "mappings", err.Error(), mappingID))
+			}
 			if readOnly && !hasPreflightBlocker(targetIssues) {
-				queryColumns, queryErr := a.preflightDataSyncQueryColumns(source, definition.SourceQuery)
+				queryColumns, queryErr := a.preflightDataSyncQueryColumnsContext(ctx, source, definition.SourceQuery)
 				if queryErr != nil {
+					if err := ctx.Err(); err != nil {
+						return append(issues, preflightIssue("request_cancelled", DataSyncJobPreflightBlocker, "mappings", err.Error(), mappingID))
+					}
 					issues = append(issues, preflightIssue("query_schema_probe_failed", DataSyncJobPreflightBlocker, "mappings", queryErr.Error(), mappingID))
 				} else {
 					issues = append(issues, preflightQuerySourceColumnIssues(mapping, queryColumns, mappingID)...)
@@ -288,8 +382,13 @@ func (a *App) preflightDataSyncMappings(definition syncjob.JobDefinition, source
 			continue
 		}
 		sourceTable := qualifyDataSyncJobObject(mapping.SourceSchema, mapping.SourceTable)
-		sourceResult := a.DBGetColumns(source.Config, source.Database, sourceTable)
+		sourceResult := a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult {
+			return session.DBGetColumns(source.Config, source.Database, sourceTable)
+		})
 		if !sourceResult.Success {
+			if err := ctx.Err(); err != nil {
+				return append(issues, preflightIssue("request_cancelled", DataSyncJobPreflightBlocker, "mappings", err.Error(), mappingID))
+			}
 			issues = append(issues, preflightIssue("source_columns_failed", DataSyncJobPreflightBlocker, "mappings", sourceResult.Message, mappingID))
 			continue
 		}
@@ -306,8 +405,13 @@ func (a *App) preflightDataSyncMappings(definition syncjob.JobDefinition, source
 			}
 		}
 		targetTable := qualifyDataSyncJobObject(mapping.TargetSchema, mapping.TargetTable)
-		existsResult := a.DBTableExists(target.Config, target.Database, targetTable)
+		existsResult := a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult {
+			return session.DBTableExists(target.Config, target.Database, targetTable)
+		})
 		if !existsResult.Success {
+			if err := ctx.Err(); err != nil {
+				return append(issues, preflightIssue("request_cancelled", DataSyncJobPreflightBlocker, "mappings", err.Error(), mappingID))
+			}
 			issues = append(issues, preflightIssue("target_table_check_failed", DataSyncJobPreflightBlocker, "mappings", existsResult.Message, mappingID))
 			continue
 		}
@@ -321,12 +425,17 @@ func (a *App) preflightDataSyncMappings(definition syncjob.JobDefinition, source
 				issues = append(issues, preflightIssue("target_table_missing", DataSyncJobPreflightBlocker, "mappings", "target table does not exist and this mapping cannot auto-create it", mappingID))
 			} else {
 				issues = append(issues, preflightIssue("target_table_will_be_created", DataSyncJobPreflightInfo, "mappings", "target table will be created by the migration planner", mappingID))
-				issues = append(issues, a.preflightUnmigratedIndexes(definition, source, target, mapping)...)
+				issues = append(issues, a.preflightUnmigratedIndexesContext(ctx, definition, source, target, mapping)...)
 			}
 			continue
 		}
-		targetResult := a.DBGetColumns(target.Config, target.Database, targetTable)
+		targetResult := a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult {
+			return session.DBGetColumns(target.Config, target.Database, targetTable)
+		})
 		if !targetResult.Success {
+			if err := ctx.Err(); err != nil {
+				return append(issues, preflightIssue("request_cancelled", DataSyncJobPreflightBlocker, "mappings", err.Error(), mappingID))
+			}
 			issues = append(issues, preflightIssue("target_columns_failed", DataSyncJobPreflightBlocker, "mappings", targetResult.Message, mappingID))
 			continue
 		}
@@ -370,24 +479,46 @@ func dataSyncJobSourceIndexLocation(source resolvedDataSyncJobEndpoint, mapping 
 }
 
 func (a *App) preflightUnmigratedIndexes(definition syncjob.JobDefinition, source, target resolvedDataSyncJobEndpoint, mapping syncjob.TableMapping) []DataSyncJobPreflightIssue {
+	return a.preflightUnmigratedIndexesContext(context.Background(), definition, source, target, mapping)
+}
+
+func (a *App) preflightUnmigratedIndexesContext(ctx context.Context, definition syncjob.JobDefinition, source, target resolvedDataSyncJobEndpoint, mapping syncjob.TableMapping) []DataSyncJobPreflightIssue {
+	mappingID := dataSyncJobMappingLabel(mapping)
+	if err := ctx.Err(); err != nil {
+		return []DataSyncJobPreflightIssue{preflightIssue("request_cancelled", DataSyncJobPreflightBlocker, "mappings", err.Error(), mappingID)}
+	}
 	if !definition.Options.CreateIndexes {
 		return nil
 	}
 	config, err := buildDataSyncJobEngineConfig(definition, "preflight", source, target, mapping)
 	if err != nil {
-		return []DataSyncJobPreflightIssue{preflightIssue("mapping_compile_failed", DataSyncJobPreflightBlocker, "mappings", err.Error(), dataSyncJobMappingLabel(mapping))}
+		return []DataSyncJobPreflightIssue{preflightIssue("mapping_compile_failed", DataSyncJobPreflightBlocker, "mappings", err.Error(), mappingID)}
 	}
-	sourceDB, sourceErr := a.getDatabase(normalizeMetadataRunConfig(source.Config, source.Database))
+	session := newMetadataSessionWithMode(a, ctx, true)
+	if session == nil {
+		return []DataSyncJobPreflightIssue{preflightIssue("metadata_session_unavailable", DataSyncJobPreflightBlocker, "mappings", "metadata session is unavailable", mappingID)}
+	}
+	defer session.Close()
+	sourceDB, sourceErr := session.app.getDatabase(normalizeMetadataRunConfig(source.Config, source.Database))
+	if err := ctx.Err(); err != nil {
+		return []DataSyncJobPreflightIssue{preflightIssue("request_cancelled", DataSyncJobPreflightBlocker, "mappings", err.Error(), mappingID)}
+	}
 	if sourceErr != nil {
-		return []DataSyncJobPreflightIssue{preflightIssue("source_connect_failed", DataSyncJobPreflightBlocker, "endpoints", sourceErr.Error(), dataSyncJobMappingLabel(mapping))}
+		return []DataSyncJobPreflightIssue{preflightIssue("source_connect_failed", DataSyncJobPreflightBlocker, "endpoints", sourceErr.Error(), mappingID)}
 	}
 	sourceSchema, sourceTable := dataSyncJobSourceIndexLocation(source, mapping)
 	if _, indexErr := sourceDB.GetIndexes(sourceSchema, sourceTable); indexErr != nil {
-		return []DataSyncJobPreflightIssue{preflightIssue("index_inspection_failed", DataSyncJobPreflightWarning, "mappings", indexErr.Error(), dataSyncJobMappingLabel(mapping))}
+		if err := ctx.Err(); err != nil {
+			return []DataSyncJobPreflightIssue{preflightIssue("request_cancelled", DataSyncJobPreflightBlocker, "mappings", err.Error(), mappingID)}
+		}
+		return []DataSyncJobPreflightIssue{preflightIssue("index_inspection_failed", DataSyncJobPreflightWarning, "mappings", indexErr.Error(), mappingID)}
 	}
-	targetDB, targetErr := a.getDatabase(normalizeMetadataRunConfig(target.Config, target.Database))
+	targetDB, targetErr := session.app.getDatabase(normalizeMetadataRunConfig(target.Config, target.Database))
+	if err := ctx.Err(); err != nil {
+		return []DataSyncJobPreflightIssue{preflightIssue("request_cancelled", DataSyncJobPreflightBlocker, "mappings", err.Error(), mappingID)}
+	}
 	if targetErr != nil {
-		return []DataSyncJobPreflightIssue{preflightIssue("target_connect_failed", DataSyncJobPreflightBlocker, "endpoints", targetErr.Error(), dataSyncJobMappingLabel(mapping))}
+		return []DataSyncJobPreflightIssue{preflightIssue("target_connect_failed", DataSyncJobPreflightBlocker, "endpoints", targetErr.Error(), mappingID)}
 	}
 	qualifiedSourceTable := strings.TrimSpace(mapping.SourceTable)
 	if strings.TrimSpace(mapping.SourceSchema) != "" {
@@ -395,7 +526,10 @@ func (a *App) preflightUnmigratedIndexes(definition syncjob.JobDefinition, sourc
 	}
 	plan, planErr := sync.InspectSchemaMigrationPlan(config, qualifiedSourceTable, sourceDB, targetDB)
 	if planErr != nil {
-		return []DataSyncJobPreflightIssue{preflightIssue("schema_inspection_failed", DataSyncJobPreflightWarning, "mappings", planErr.Error(), dataSyncJobMappingLabel(mapping))}
+		if err := ctx.Err(); err != nil {
+			return []DataSyncJobPreflightIssue{preflightIssue("request_cancelled", DataSyncJobPreflightBlocker, "mappings", err.Error(), mappingID)}
+		}
+		return []DataSyncJobPreflightIssue{preflightIssue("schema_inspection_failed", DataSyncJobPreflightWarning, "mappings", planErr.Error(), mappingID)}
 	}
 	issues := make([]DataSyncJobPreflightIssue, 0, len(plan.UnmigratedIndexes))
 	for _, index := range plan.UnmigratedIndexes {
@@ -405,7 +539,7 @@ func (a *App) preflightUnmigratedIndexes(definition syncjob.JobDefinition, sourc
 			Severity:  DataSyncJobPreflightWarning,
 			Stage:     "mappings",
 			Message:   index.Reason,
-			MappingID: dataSyncJobMappingLabel(mapping),
+			MappingID: mappingID,
 			Detail:    &DataSyncJobPreflightIssueDetail{UnmigratedIndex: &indexCopy},
 		})
 	}
@@ -413,11 +547,20 @@ func (a *App) preflightUnmigratedIndexes(definition syncjob.JobDefinition, sourc
 }
 
 func (a *App) preflightDataSyncQueryTarget(definition syncjob.JobDefinition, mapping syncjob.TableMapping, target resolvedDataSyncJobEndpoint) []DataSyncJobPreflightIssue {
+	return a.preflightDataSyncQueryTargetContext(context.Background(), definition, mapping, target)
+}
+
+func (a *App) preflightDataSyncQueryTargetContext(ctx context.Context, definition syncjob.JobDefinition, mapping syncjob.TableMapping, target resolvedDataSyncJobEndpoint) []DataSyncJobPreflightIssue {
 	mappingID := dataSyncJobMappingLabel(mapping)
 	issues := make([]DataSyncJobPreflightIssue, 0)
 	targetTable := qualifyDataSyncJobObject(mapping.TargetSchema, mapping.TargetTable)
-	existsResult := a.DBTableExists(target.Config, target.Database, targetTable)
+	existsResult := a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult {
+		return session.DBTableExists(target.Config, target.Database, targetTable)
+	})
 	if !existsResult.Success {
+		if err := ctx.Err(); err != nil {
+			return append(issues, preflightIssue("request_cancelled", DataSyncJobPreflightBlocker, "mappings", err.Error(), mappingID))
+		}
 		return append(issues, preflightIssue("target_table_check_failed", DataSyncJobPreflightBlocker, "mappings", existsResult.Message, mappingID))
 	}
 	targetExists := false
@@ -427,8 +570,13 @@ func (a *App) preflightDataSyncQueryTarget(definition syncjob.JobDefinition, map
 	if !targetExists {
 		return append(issues, preflightIssue("target_table_missing", DataSyncJobPreflightBlocker, "mappings", "query sink requires an existing target table", mappingID))
 	}
-	targetResult := a.DBGetColumns(target.Config, target.Database, targetTable)
+	targetResult := a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult {
+		return session.DBGetColumns(target.Config, target.Database, targetTable)
+	})
 	if !targetResult.Success {
+		if err := ctx.Err(); err != nil {
+			return append(issues, preflightIssue("request_cancelled", DataSyncJobPreflightBlocker, "mappings", err.Error(), mappingID))
+		}
 		return append(issues, preflightIssue("target_columns_failed", DataSyncJobPreflightBlocker, "mappings", targetResult.Message, mappingID))
 	}
 	targetColumns, _ := targetResult.Data.([]connection.ColumnDefinition)
@@ -439,8 +587,13 @@ func (a *App) preflightDataSyncQueryTarget(definition syncjob.JobDefinition, map
 		}
 	}
 	if dataSyncJobUsesInsertUpdate(definition) {
-		indexResult := a.DBGetIndexes(target.Config, target.Database, targetTable)
+		indexResult := a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult {
+			return session.DBGetIndexes(target.Config, target.Database, targetTable)
+		})
 		if !indexResult.Success {
+			if err := ctx.Err(); err != nil {
+				return append(issues, preflightIssue("request_cancelled", DataSyncJobPreflightBlocker, "mappings", err.Error(), mappingID))
+			}
 			return append(issues, preflightIssue("target_indexes_failed", DataSyncJobPreflightBlocker, "mappings", indexResult.Message, mappingID))
 		}
 		targetIndexes, _ := indexResult.Data.([]connection.IndexDefinition)
@@ -453,7 +606,11 @@ func (a *App) preflightDataSyncQueryTarget(definition syncjob.JobDefinition, map
 // fetching any data. Running the same query only after a task starts turned a
 // simple column alias typo into a failed write run.
 func (a *App) preflightDataSyncQueryColumns(source resolvedDataSyncJobEndpoint, sourceQuery string) ([]string, error) {
-	result := a.DBQueryIsolated(source.Config, source.Database, dataSyncJobQueryMetadataProbeSQL(source.Config, sourceQuery))
+	return a.preflightDataSyncQueryColumnsContext(context.Background(), source, sourceQuery)
+}
+
+func (a *App) preflightDataSyncQueryColumnsContext(ctx context.Context, source resolvedDataSyncJobEndpoint, sourceQuery string) ([]string, error) {
+	result := a.dbQueryIsolatedContext(ctx, source.Config, source.Database, dataSyncJobQueryMetadataProbeSQL(source.Config, sourceQuery))
 	if !result.Success {
 		return nil, fmt.Errorf("read query result metadata: %s", strings.TrimSpace(result.Message))
 	}
@@ -573,6 +730,15 @@ func preflightIssue(code string, severity DataSyncJobPreflightSeverity, stage, m
 func hasPreflightBlocker(issues []DataSyncJobPreflightIssue) bool {
 	for _, issue := range issues {
 		if issue.Severity == DataSyncJobPreflightBlocker {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPreflightIssueCode(issues []DataSyncJobPreflightIssue, code string) bool {
+	for _, issue := range issues {
+		if issue.Code == code {
 			return true
 		}
 	}

--- a/internal/app/data_sync_web_context.go
+++ b/internal/app/data_sync_web_context.go
@@ -1,0 +1,250 @@
+package app
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"GoNavi-Wails/internal/connection"
+	syncengine "GoNavi-Wails/internal/sync"
+	"GoNavi-Wails/internal/synccdc"
+	"GoNavi-Wails/internal/syncjob"
+)
+
+func contextQueryFailure(ctx context.Context) connection.QueryResult {
+	if ctx == nil || ctx.Err() == nil {
+		return connection.QueryResult{}
+	}
+	return connection.QueryResult{Success: false, Message: ctx.Err().Error()}
+}
+
+func (a *App) dataSyncDatabaseListContext(ctx context.Context, connectionID string) connection.QueryResult {
+	if result := contextQueryFailure(ctx); result.Message != "" {
+		return result
+	}
+	endpoint, err := a.resolveDataSyncJobEndpoint(connectionID, "", "")
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	return a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetDatabases(endpoint.Config) })
+}
+
+func (a *App) dataSyncObjectListContext(ctx context.Context, connectionID, database, schema string) connection.QueryResult {
+	if result := contextQueryFailure(ctx); result.Message != "" {
+		return result
+	}
+	endpoint, err := a.resolveDataSyncJobEndpoint(connectionID, database, schema)
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	return a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult {
+		return session.DBGetTables(endpoint.Config, endpoint.Database)
+	})
+}
+
+func (a *App) dataSyncFieldListContext(ctx context.Context, connectionID, database, schema, objectName string) connection.QueryResult {
+	if result := contextQueryFailure(ctx); result.Message != "" {
+		return result
+	}
+	endpoint, err := a.resolveDataSyncJobEndpoint(connectionID, database, schema)
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	objectName = strings.TrimSpace(objectName)
+	if objectName == "" {
+		return connection.QueryResult{Success: false, Message: "data sync object name is required"}
+	}
+	qualified := qualifyDataSyncJobObject(schema, objectName)
+	return a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult {
+		return session.DBGetColumns(endpoint.Config, endpoint.Database, qualified)
+	})
+}
+
+func (a *App) dataSyncCapabilityResolveContext(ctx context.Context, sourceConnectionID, sourceDatabase, sourceSchema, targetConnectionID, targetDatabase, targetSchema string) connection.QueryResult {
+	if result := contextQueryFailure(ctx); result.Message != "" {
+		return result
+	}
+	source, err := a.resolveDataSyncJobEndpoint(sourceConnectionID, sourceDatabase, sourceSchema)
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	if result := contextQueryFailure(ctx); result.Message != "" {
+		return result
+	}
+	target, err := a.resolveDataSyncJobEndpoint(targetConnectionID, targetDatabase, targetSchema)
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	if result := contextQueryFailure(ctx); result.Message != "" {
+		return result
+	}
+	return connection.QueryResult{Success: true, Data: syncengine.ResolveMigrationCapability(source.Config, target.Config)}
+}
+
+func (a *App) probeDataSyncCDCContext(parent context.Context, config connection.ConnectionConfig, _ string) (synccdc.Capability, error) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	adapter, err := a.resolveDataSyncCDCAdapter(config)
+	if err != nil {
+		return synccdc.Capability{}, err
+	}
+	ctx, cancel := context.WithTimeout(parent, dataSyncCDCProbeTimeout)
+	defer cancel()
+	return adapter.Probe(ctx, config)
+}
+
+func (a *App) dataSyncCDCProbeContext(ctx context.Context, connectionID, database, schema, mode string) connection.QueryResult {
+	if result := contextQueryFailure(ctx); result.Message != "" {
+		return result
+	}
+	endpoint, err := a.resolveDataSyncJobEndpoint(connectionID, database, schema)
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	capability, err := a.probeDataSyncCDCContext(ctx, dataSyncCDCProbeConfig(endpoint), mode)
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	return connection.QueryResult{Success: true, Data: capability}
+}
+
+func (a *App) dataSyncJobPreflightContext(ctx context.Context, definition syncjob.JobDefinition) connection.QueryResult {
+	result := a.preflightDataSyncJobContext(ctx, definition, time.Now())
+	message := "data sync job preflight passed"
+	if !result.Success {
+		message = "data sync job preflight is blocked"
+	}
+	return connection.QueryResult{Success: result.Success, Message: message, Data: publicDataSyncJobPreflight(result)}
+}
+
+func (a *App) dataSyncJobListContext(ctx context.Context) connection.QueryResult {
+	manager, err := a.ensureDataSyncJobManager()
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	jobs, err := manager.ListJobs(ctx)
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	for index := range jobs {
+		jobs[index] = publicDataSyncJobDefinition(jobs[index])
+	}
+	return connection.QueryResult{Success: true, Data: jobs}
+}
+
+func (a *App) dataSyncJobGetContext(ctx context.Context, jobID string) connection.QueryResult {
+	manager, err := a.ensureDataSyncJobManager()
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	job, err := manager.GetJob(ctx, strings.TrimSpace(jobID))
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	return connection.QueryResult{Success: true, Data: publicDataSyncJobDefinition(job)}
+}
+
+func (a *App) dataSyncRunGetContext(ctx context.Context, runID string) connection.QueryResult {
+	manager, err := a.ensureDataSyncJobManager()
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	run, err := manager.GetRun(ctx, strings.TrimSpace(runID))
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	return connection.QueryResult{Success: true, Data: publicDataSyncRun(run)}
+}
+
+func (a *App) dataSyncRunListContext(ctx context.Context, jobID string, limit int) connection.QueryResult {
+	manager, err := a.ensureDataSyncJobManager()
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	runs, err := manager.ListRuns(ctx, strings.TrimSpace(jobID), limit)
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	for index := range runs {
+		runs[index] = publicDataSyncRun(runs[index])
+	}
+	return connection.QueryResult{Success: true, Data: runs}
+}
+
+func (a *App) dataSyncRunPageContext(ctx context.Context, jobID string, beforeCreatedAt int64, beforeID string, limit int) connection.QueryResult {
+	manager, err := a.ensureDataSyncJobManager()
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	var cursor *syncjob.RunCursor
+	if beforeCreatedAt != 0 || strings.TrimSpace(beforeID) != "" {
+		if beforeCreatedAt <= 0 || strings.TrimSpace(beforeID) == "" {
+			return connection.QueryResult{Success: false, Message: "data sync run cursor requires createdAt and id"}
+		}
+		cursor = &syncjob.RunCursor{CreatedAt: beforeCreatedAt, ID: strings.TrimSpace(beforeID)}
+	}
+	if limit != 10 && limit != 50 && limit != 100 {
+		return connection.QueryResult{Success: false, Message: "data sync run page size must be 10, 50, or 100"}
+	}
+	page, err := manager.ListRunsPage(ctx, strings.TrimSpace(jobID), cursor, limit)
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	return connection.QueryResult{Success: true, Data: publicDataSyncRunPage(page)}
+}
+
+func (a *App) dataSyncRunEventListContext(ctx context.Context, runID string, afterSequence int64, limit int) connection.QueryResult {
+	manager, err := a.ensureDataSyncJobManager()
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	events, err := manager.ListRunEvents(ctx, strings.TrimSpace(runID), afterSequence, limit)
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	for index := range events {
+		events[index] = publicDataSyncRunEvent(events[index])
+	}
+	return connection.QueryResult{Success: true, Data: events}
+}
+
+func (a *App) dataSyncErrorRowListContext(ctx context.Context, runID, status string, limit int) connection.QueryResult {
+	manager, err := a.ensureDataSyncJobManager()
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	rows, err := manager.ListErrorRows(ctx, strings.TrimSpace(runID), syncjob.ErrorRowStatus(strings.TrimSpace(status)), limit)
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	for index := range rows {
+		rows[index] = publicDataSyncErrorRow(rows[index])
+	}
+	return connection.QueryResult{Success: true, Data: rows}
+}
+
+func (a *App) dataSyncErrorRowGetContext(ctx context.Context, errorRowID string) connection.QueryResult {
+	manager, err := a.ensureDataSyncJobManager()
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	row, err := manager.GetErrorRow(ctx, strings.TrimSpace(errorRowID))
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	return connection.QueryResult{Success: true, Data: row}
+}
+
+func (a *App) dataSyncCheckpointGetContext(ctx context.Context, jobID string) connection.QueryResult {
+	manager, err := a.ensureDataSyncJobManager()
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	checkpoint, err := manager.GetCheckpoint(ctx, strings.TrimSpace(jobID))
+	if err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	checkpoint.SchemaHash = ""
+	return connection.QueryResult{Success: true, Data: checkpoint}
+}

--- a/internal/app/import_job_recovery.go
+++ b/internal/app/import_job_recovery.go
@@ -37,6 +37,16 @@ type tableImportRecoveryPlan struct {
 // task's latest safe source-row checkpoint. The effective connection is loaded
 // server-side by saved ID so task metadata never needs to persist credentials.
 func (a *App) ResumeImportJob(jobID string) connection.QueryResult {
+	return a.resumeImportJobContext(context.Background(), jobID)
+}
+
+func (a *App) resumeImportJobContext(ctx context.Context, jobID string) connection.QueryResult {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
 	store, err := a.ensureImportJobStore()
 	if err != nil {
 		return connection.QueryResult{Success: false, Message: err.Error()}
@@ -59,7 +69,11 @@ func (a *App) ResumeImportJob(jobID string) connection.QueryResult {
 	options.JobID = newImportJobRecoveryID("resume")
 	options.ResumeJobID = job.ID
 	options.SourceIdentityToken = job.SourceIdentityToken
-	return a.importDataWithProgressOptions(
+	if err := ctx.Err(); err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	return a.importDataWithProgressOptionsContext(
+		ctx,
 		config,
 		job.DatabaseName,
 		job.TableName,
@@ -270,6 +284,16 @@ func (c *importResumeSkippingConsumer) SetImportSourceProgress(bytesRead int64, 
 // never reparses the original source and therefore cannot resubmit a row that
 // was already successful in the parent task.
 func (a *App) RetryImportJobFailedRows(jobID string) (result connection.QueryResult) {
+	return a.retryImportJobFailedRowsContext(context.Background(), jobID)
+}
+
+func (a *App) retryImportJobFailedRowsContext(ctx context.Context, jobID string) (result connection.QueryResult) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
 	store, err := a.ensureImportJobStore()
 	if err != nil {
 		return connection.QueryResult{Success: false, Message: err.Error()}
@@ -294,14 +318,17 @@ func (a *App) RetryImportJobFailedRows(jobID string) (result connection.QueryRes
 	if optionsHash := buildImportFileOptionsHash(options); optionsHash != job.OptionsHash {
 		return connection.QueryResult{Success: false, Message: importJobRecoveryErrorMessage(a, errImportJobRecoveryOptionsChanged)}
 	}
-	scope, err := a.inspectRetryableImportErrorArtifact(job.ErrorArtifactID)
+	scope, err := a.inspectRetryableImportErrorArtifactContext(ctx, job.ErrorArtifactID)
 	if err != nil {
 		return connection.QueryResult{Success: false, Message: importJobRecoveryErrorMessage(a, err)}
 	}
 	if scope.retryableCount == 0 {
 		return connection.QueryResult{Success: false, Message: importJobRecoveryErrorMessage(a, errImportJobRetryUnavailable)}
 	}
-	return a.retryImportJobFailedRows(job, config, options, scope)
+	if err := ctx.Err(); err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	return a.retryImportJobFailedRowsContextRun(ctx, job, config, options, scope)
 }
 
 type retryImportArtifactScope struct {
@@ -336,6 +363,10 @@ func (reader *retryImportArtifactReader) next() (ImportRowError, error) {
 }
 
 func streamImportErrorArtifactRows(file *os.File, consume func(ImportRowError) error) error {
+	return streamImportErrorArtifactRowsContext(context.Background(), file, consume)
+}
+
+func streamImportErrorArtifactRowsContext(ctx context.Context, file *os.File, consume func(ImportRowError) error) error {
 	if file == nil {
 		return errImportJobRetryUnavailable
 	}
@@ -347,6 +378,9 @@ func streamImportErrorArtifactRows(file *os.File, consume func(ImportRowError) e
 	reader.scanner.Buffer(make([]byte, 64*1024), int(maxImportErrorArtifactBytes)+1)
 	var count int64
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		row, err := reader.next()
 		if errors.Is(err, io.EOF) {
 			return nil
@@ -367,6 +401,10 @@ func streamImportErrorArtifactRows(file *os.File, consume func(ImportRowError) e
 }
 
 func (a *App) inspectRetryableImportErrorArtifact(artifactID string) (retryImportArtifactScope, error) {
+	return a.inspectRetryableImportErrorArtifactContext(context.Background(), artifactID)
+}
+
+func (a *App) inspectRetryableImportErrorArtifactContext(ctx context.Context, artifactID string) (retryImportArtifactScope, error) {
 	store, err := a.ensureImportErrorArtifactStore()
 	if err != nil {
 		return retryImportArtifactScope{}, err
@@ -379,7 +417,7 @@ func (a *App) inspectRetryableImportErrorArtifact(artifactID string) (retryImpor
 
 	columns := make(map[string]struct{})
 	var scope retryImportArtifactScope
-	err = streamImportErrorArtifactRows(file, func(row ImportRowError) error {
+	err = streamImportErrorArtifactRowsContext(ctx, file, func(row ImportRowError) error {
 		if !isRetryableImportErrorRow(row) {
 			scope.unretryableCount++
 			return nil
@@ -408,6 +446,10 @@ func (a *App) inspectRetryableImportErrorArtifact(artifactID string) (retryImpor
 }
 
 func (a *App) streamRetryableImportErrorArtifact(artifactID string, consume func(ImportRowError) error) error {
+	return a.streamRetryableImportErrorArtifactContext(context.Background(), artifactID, consume)
+}
+
+func (a *App) streamRetryableImportErrorArtifactContext(ctx context.Context, artifactID string, consume func(ImportRowError) error) error {
 	store, err := a.ensureImportErrorArtifactStore()
 	if err != nil {
 		return err
@@ -418,7 +460,7 @@ func (a *App) streamRetryableImportErrorArtifact(artifactID string, consume func
 	}
 	defer file.Close()
 
-	return streamImportErrorArtifactRows(file, func(row ImportRowError) error {
+	return streamImportErrorArtifactRowsContext(ctx, file, func(row ImportRowError) error {
 		if !isRetryableImportErrorRow(row) {
 			return nil
 		}
@@ -435,6 +477,22 @@ func (a *App) retryImportJobFailedRows(
 	options ImportFileOptions,
 	scope retryImportArtifactScope,
 ) (result connection.QueryResult) {
+	return a.retryImportJobFailedRowsContextRun(context.Background(), parent, config, options, scope)
+}
+
+func (a *App) retryImportJobFailedRowsContextRun(
+	requestCtx context.Context,
+	parent importjob.Job,
+	config connection.ConnectionConfig,
+	options ImportFileOptions,
+	scope retryImportArtifactScope,
+) (result connection.QueryResult) {
+	if requestCtx == nil {
+		requestCtx = context.Background()
+	}
+	if err := requestCtx.Err(); err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
 	dbType := resolveDDLDBType(config)
 	if err := ensureConnectionAllowsDataImport(config, "connection.backend.action.import_data"); err != nil {
 		return connection.QueryResult{Success: false, Message: err.Error()}
@@ -456,7 +514,7 @@ func (a *App) retryImportJobFailedRows(
 		SafeError: &auditSafeError,
 	})()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(requestCtx)
 	defer cancel()
 	jobID := newImportJobRecoveryID("retry")
 	cleanupRegistration, registered := a.registerImportTask(jobID, cancel, importjob.KindTable)
@@ -498,7 +556,7 @@ func (a *App) retryImportJobFailedRows(
 	defer managedArtifact.abort()
 
 	runConfig := normalizeRunConfig(config, parent.DatabaseName)
-	dbInst, err := a.getDatabase(runConfig)
+	dbInst, err := a.getDatabaseSynchronouslyWithContext(ctx, runConfig, false)
 	if err != nil {
 		if errors.Is(ctx.Err(), context.Canceled) {
 			return a.cancelledImportResult(importExecutionResult{})
@@ -517,8 +575,7 @@ func (a *App) retryImportJobFailedRows(
 		return connection.QueryResult{Success: false, Message: a.appText("data_import.capability.reason."+reason, nil)}
 	}
 
-	metadataSchemaName, metadataTableName := normalizeMetadataSchemaAndTable(config, parent.DatabaseName, parent.TableName)
-	targetColumns, colErr := getColumnsWithMetadataFallback(dbInst, config, metadataSchemaName, metadataTableName, a.appText)
+	targetColumns, colErr := a.importTargetColumnsContext(ctx, dbInst, config, parent.DatabaseName, parent.TableName)
 	if colErr != nil && options.ColumnMappings != nil {
 		return connection.QueryResult{Success: false, Message: colErr.Error()}
 	}
@@ -554,7 +611,7 @@ func (a *App) retryImportJobFailedRows(
 	finishArtifact := func(resultData *importExecutionResult) error {
 		return managedArtifact.finish(resultData)
 	}
-	if err := a.streamRetryableImportErrorArtifact(parent.ErrorArtifactID, func(row ImportRowError) error {
+	if err := a.streamRetryableImportErrorArtifactContext(ctx, parent.ErrorArtifactID, func(row ImportRowError) error {
 		return batchConsumer.ConsumeRow(row.Values)
 	}); err != nil {
 		return a.finishImportErrorArtifactRecovery(resultDataFromConsumer(batchConsumer), err, jobPersistErr, finishArtifact)

--- a/internal/app/import_pipeline.go
+++ b/internal/app/import_pipeline.go
@@ -58,6 +58,31 @@ type importFileConsumer interface {
 	ConsumeRow(row map[string]interface{}) error
 }
 
+type contextImportFileConsumer struct {
+	ctx      context.Context
+	delegate importFileConsumer
+}
+
+func (c *contextImportFileConsumer) SetColumns(columns []string) error {
+	if err := c.ctx.Err(); err != nil {
+		return err
+	}
+	return c.delegate.SetColumns(columns)
+}
+
+func (c *contextImportFileConsumer) ConsumeRow(row map[string]interface{}) error {
+	if err := c.ctx.Err(); err != nil {
+		return err
+	}
+	return c.delegate.ConsumeRow(row)
+}
+
+func (c *contextImportFileConsumer) SetImportSourceProgress(bytesRead int64, totalBytes int64, stage string) {
+	if progress, ok := c.delegate.(importSourceProgressConsumer); ok {
+		progress.SetImportSourceProgress(bytesRead, totalBytes, stage)
+	}
+}
+
 type importSourceProgressConsumer interface {
 	SetImportSourceProgress(bytesRead int64, totalBytes int64, stage string)
 }
@@ -947,8 +972,12 @@ func buildImportPreview(filePath string, previewLimit int) (importPreviewData, e
 }
 
 func buildImportPreviewWithOptions(filePath string, previewLimit int, options ImportFileOptions) (importPreviewData, error) {
+	return buildImportPreviewWithOptionsContext(context.Background(), filePath, previewLimit, options)
+}
+
+func buildImportPreviewWithOptionsContext(ctx context.Context, filePath string, previewLimit int, options ImportFileOptions) (importPreviewData, error) {
 	collector := newImportPreviewCollector(previewLimit)
-	if err := streamImportFileWithOptions(filePath, collector, options); err != nil && !errors.Is(err, errImportPreviewLimitReached) {
+	if err := streamImportFileWithOptionsContext(ctx, filePath, collector, options); err != nil && !errors.Is(err, errImportPreviewLimitReached) {
 		return importPreviewData{}, err
 	} else if err == nil {
 		collectorResult := collector.Result()
@@ -971,12 +1000,23 @@ func streamImportFile(filePath string, consumer importFileConsumer) error {
 }
 
 func streamImportFileWithOptions(filePath string, consumer importFileConsumer, options ImportFileOptions) error {
+	return streamImportFileWithOptionsContext(context.Background(), filePath, consumer, options)
+}
+
+func streamImportFileWithOptionsContext(ctx context.Context, filePath string, consumer importFileConsumer, options ImportFileOptions) error {
 	if consumer == nil {
 		return fmt.Errorf("import file consumer is required")
 	}
 	if err := validateImportFileOptions(options); err != nil {
 		return err
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	consumer = &contextImportFileConsumer{ctx: ctx, delegate: consumer}
 	lower := strings.ToLower(filePath)
 	switch {
 	case strings.HasSuffix(lower, ".json"):

--- a/internal/app/import_pipeline_parser_test.go
+++ b/internal/app/import_pipeline_parser_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -30,6 +31,21 @@ type importSourceProgressSnapshot struct {
 type importSourceProgressRecorder struct {
 	importCollectConsumer
 	progress []importSourceProgressSnapshot
+}
+
+type cancelAfterFirstImportRowConsumer struct {
+	cancel context.CancelFunc
+	rows   int
+}
+
+func (c *cancelAfterFirstImportRowConsumer) SetColumns([]string) error { return nil }
+
+func (c *cancelAfterFirstImportRowConsumer) ConsumeRow(map[string]interface{}) error {
+	c.rows++
+	if c.rows == 1 {
+		c.cancel()
+	}
+	return nil
 }
 
 func (c *importSourceProgressRecorder) SetImportSourceProgress(bytesRead int64, totalBytes int64, stage string) {
@@ -78,6 +94,33 @@ func TestBuildImportPreviewStopsAtLimitAndMarksTotalUnknown(t *testing.T) {
 	}
 	if known.Bool() {
 		t.Fatal("short-circuited preview must mark total rows unknown")
+	}
+}
+
+func TestBuildImportPreviewWithOptionsContextRejectsPreCancelledRequest(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := buildImportPreviewWithOptionsContext(ctx, "does-not-need-to-exist.csv", 5, ImportFileOptions{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("preview error = %v, want context.Canceled", err)
+	}
+}
+
+func TestStreamImportFileWithOptionsContextStopsBetweenRows(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rows.csv")
+	if err := os.WriteFile(path, []byte("id\n1\n2\n3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	consumer := &cancelAfterFirstImportRowConsumer{cancel: cancel}
+
+	err := streamImportFileWithOptionsContext(ctx, path, consumer, ImportFileOptions{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("stream error = %v, want context.Canceled", err)
+	}
+	if consumer.rows != 1 {
+		t.Fatalf("consumed rows = %d, want cancellation before row 2", consumer.rows)
 	}
 }
 

--- a/internal/app/methods_db.go
+++ b/internal/app/methods_db.go
@@ -1111,20 +1111,22 @@ func (a *App) MySQLShowCreateTable(config connection.ConnectionConfig, dbName st
 }
 
 type dbQueryAuditOptions struct {
-	trackHistory             bool
-	auditAll                 bool
-	auditWrites              bool
-	source                   string
-	executionContext         context.Context
-	classifyConnectionErrors bool
+	trackHistory              bool
+	auditAll                  bool
+	auditWrites               bool
+	source                    string
+	executionContext          context.Context
+	synchronousConnectionWait bool
+	classifyConnectionErrors  bool
 }
 
 type dbQueryMultiAuditOptions struct {
-	auditAll                 bool
-	auditWrites              bool
-	source                   string
-	executionContext         context.Context
-	classifyConnectionErrors bool
+	auditAll                  bool
+	auditWrites               bool
+	source                    string
+	executionContext          context.Context
+	synchronousConnectionWait bool
+	classifyConnectionErrors  bool
 }
 
 func buildQueryConnectionFailure(err error, queryID string, classify bool) connection.QueryResult {
@@ -1379,7 +1381,13 @@ func (a *App) dbQueryWithCancel(
 		cleanupRunningQuery()
 	}()
 
-	dbInst, err := a.getDatabaseWithContext(ctx, runConfig, false)
+	var dbInst db.Database
+	var err error
+	if auditOptions.synchronousConnectionWait {
+		dbInst, err = a.getDatabaseSynchronouslyWithContext(ctx, runConfig, false)
+	} else {
+		dbInst, err = a.getDatabaseWithContext(ctx, runConfig, false)
+	}
 	if err != nil {
 		logger.Error(err, "DBQuery 获取连接失败：%s", formatConnSummary(runConfig))
 		return buildQueryConnectionFailure(err, queryID, auditOptions.classifyConnectionErrors)
@@ -1452,7 +1460,13 @@ func (a *App) dbQueryWithCancel(
 			if a.invalidateCachedDatabase(runConfig, err) {
 				requestTrace.MarkRetry("cached connection refresh")
 				setRunningQueryCancellable(true)
-				retryInst, retryErr := a.getDatabaseWithContext(ctx, runConfig, true)
+				var retryInst db.Database
+				var retryErr error
+				if auditOptions.synchronousConnectionWait {
+					retryInst, retryErr = a.getDatabaseSynchronouslyWithContext(ctx, runConfig, true)
+				} else {
+					retryInst, retryErr = a.getDatabaseWithContext(ctx, runConfig, true)
+				}
 				if retryErr != nil {
 					logger.Error(retryErr, "DBQuery 重建连接失败：%s SQL片段=%q", formatConnSummary(runConfig), sqlSnippet(query))
 					return buildQueryConnectionFailure(retryErr, queryID, auditOptions.classifyConnectionErrors)
@@ -1619,7 +1633,13 @@ func (a *App) dbQueryMulti(
 		cleanupRunningQuery()
 	}()
 
-	dbInst, err := a.getDatabaseWithContext(ctx, runConfig, false)
+	var dbInst db.Database
+	var err error
+	if auditOptions.synchronousConnectionWait {
+		dbInst, err = a.getDatabaseSynchronouslyWithContext(ctx, runConfig, false)
+	} else {
+		dbInst, err = a.getDatabaseWithContext(ctx, runConfig, false)
+	}
 	if err != nil {
 		logger.Error(err, "DBQueryMulti 获取连接失败：%s", formatConnSummary(runConfig))
 		return buildQueryConnectionFailure(err, queryID, auditOptions.classifyConnectionErrors)
@@ -1746,7 +1766,13 @@ func (a *App) dbQueryMulti(
 		if a.invalidateCachedDatabase(runConfig, err) {
 			requestTrace.MarkRetry("cached connection refresh")
 			setRunningQueryCancellable(true)
-			retryInst, retryErr := a.getDatabaseWithContext(ctx, runConfig, true)
+			var retryInst db.Database
+			var retryErr error
+			if auditOptions.synchronousConnectionWait {
+				retryInst, retryErr = a.getDatabaseSynchronouslyWithContext(ctx, runConfig, true)
+			} else {
+				retryInst, retryErr = a.getDatabaseWithContext(ctx, runConfig, true)
+			}
 			if retryErr != nil {
 				logger.Error(retryErr, "DBQueryMulti 重建连接失败：%s SQL片段=%q", formatConnSummary(runConfig), sqlSnippet(query))
 				return buildQueryConnectionFailure(retryErr, queryID, auditOptions.classifyConnectionErrors)
@@ -2409,6 +2435,16 @@ func looksLikeSQLServerProcedureInvocation(query string) bool {
 }
 
 func (a *App) DBQueryIsolated(config connection.ConnectionConfig, dbName string, query string) connection.QueryResult {
+	return a.dbQueryIsolatedContext(context.Background(), config, dbName, query)
+}
+
+func (a *App) dbQueryIsolatedContext(parent context.Context, config connection.ConnectionConfig, dbName string, query string) connection.QueryResult {
+	if parent == nil {
+		parent = context.Background()
+	}
+	if err := parent.Err(); err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error(), Data: map[string]any{"cancelled": true}}
+	}
 	runConfig := normalizeRunConfig(config, dbName)
 
 	query = sanitizeSQLForPgLike(resolveDDLDBType(config), query)
@@ -2429,8 +2465,11 @@ func (a *App) DBQueryIsolated(config connection.ConnectionConfig, dbName string,
 			logger.Error(closeErr, "DBQueryIsolated 关闭临时连接失败：%s", formatConnSummary(runConfig))
 		}
 	}()
+	if err := parent.Err(); err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error(), Data: map[string]any{"cancelled": true}}
+	}
 
-	ctx, cancel := newQueryExecutionContext(runConfig)
+	ctx, cancel := newQueryExecutionContextWithParent(parent, runConfig)
 	defer cancel()
 
 	isReadQuery := isReadOnlySQLQuery(runConfig.Type, query)
@@ -2449,7 +2488,15 @@ func (a *App) DBQueryIsolated(config connection.ConnectionConfig, dbName string,
 		}); ok {
 			data, columns, err = q.QueryContext(ctx, query)
 		} else {
+			if contextErr := ctx.Err(); contextErr != nil {
+				return buildQueryExecutionFailure(ctx, contextErr, contextErr.Error(), "")
+			}
 			data, columns, err = dbInst.Query(query)
+			if ctx.Err() != nil {
+				return a.buildCancellationUnsupportedExecutionResult(connection.QueryResult{
+					Data: data, Fields: columns, Messages: messages,
+				}, err)
+			}
 		}
 		if err == nil {
 			return connection.QueryResult{Success: true, Data: data, Fields: columns, Messages: messages}
@@ -2469,7 +2516,15 @@ func (a *App) DBQueryIsolated(config connection.ConnectionConfig, dbName string,
 	}); ok {
 		affected, err = e.ExecContext(ctx, query)
 	} else {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return buildQueryExecutionFailure(ctx, contextErr, contextErr.Error(), "")
+		}
 		affected, err = dbInst.Exec(query)
+		if ctx.Err() != nil {
+			return a.buildCancellationUnsupportedExecutionResult(connection.QueryResult{
+				Data: map[string]int64{"affectedRows": affected},
+			}, err)
+		}
 	}
 	if err != nil {
 		err = classifyDispatchedWriteError(err)

--- a/internal/app/methods_db_metadata_context.go
+++ b/internal/app/methods_db_metadata_context.go
@@ -12,8 +12,9 @@ import (
 // metadataSession 仅持有一个 MCP 元数据请求的资源。
 // Close 只会在执行请求的协程、元数据方法返回后调用，避免与运行中的查询并发关闭驱动。
 type metadataSession struct {
-	app *App
-	ctx context.Context
+	app         *App
+	ctx         context.Context
+	synchronous bool
 
 	closeOnce sync.Once
 	mu        sync.Mutex
@@ -28,6 +29,10 @@ type metadataRedisOpenResult struct {
 }
 
 func newMetadataSession(owner *App, ctx context.Context) *metadataSession {
+	return newMetadataSessionWithMode(owner, ctx, false)
+}
+
+func newMetadataSessionWithMode(owner *App, ctx context.Context, synchronous bool) *metadataSession {
 	if owner == nil {
 		return nil
 	}
@@ -45,7 +50,7 @@ func newMetadataSession(owner *App, ctx context.Context) *metadataSession {
 	sessionApp.localizer = owner.localizer
 	owner.i18nMu.RUnlock()
 
-	session := &metadataSession{app: sessionApp, ctx: ctx}
+	session := &metadataSession{app: sessionApp, ctx: ctx, synchronous: synchronous}
 	sessionApp.metadataSession = session
 	return session
 }
@@ -82,6 +87,21 @@ func (s *metadataSession) openRedisClient(config connection.ConnectionConfig) (r
 	}
 	if err := s.ctx.Err(); err != nil {
 		return nil, err
+	}
+	if s.synchronous {
+		client, err := s.app.openRedisClientIsolated(config)
+		if err != nil {
+			return nil, err
+		}
+		if err := s.ctx.Err(); err != nil {
+			_ = client.Close()
+			return nil, err
+		}
+		if !s.bindRedisClient(client) {
+			_ = client.Close()
+			return nil, context.Canceled
+		}
+		return client, nil
 	}
 	resultCh := make(chan metadataRedisOpenResult, 1)
 	go func() {
@@ -173,6 +193,28 @@ func (a *App) runMetadataWithContext(ctx context.Context, operation func(*App) c
 		// Query 会收到 ctx，工作协程只在查询返回后关闭资源。
 		return connection.QueryResult{Success: false, Message: ctx.Err().Error()}
 	}
+}
+
+// runWebMetadataWithContext is deliberately synchronous. Context-aware
+// drivers observe cancellation through their bound metadata context; legacy
+// Connect/query calls finish in this goroutine before the HTTP handler returns.
+func (a *App) runWebMetadataWithContext(ctx context.Context, operation func(*App) connection.QueryResult) connection.QueryResult {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	session := newMetadataSessionWithMode(a, ctx, true)
+	if session == nil {
+		return connection.QueryResult{Success: false, Message: "元数据会话不可用"}
+	}
+	defer session.Close()
+	result := operation(session.app)
+	if err := ctx.Err(); err != nil && result.Success {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	return result
 }
 
 func (a *App) DBGetDatabasesContext(ctx context.Context, config connection.ConnectionConfig) connection.QueryResult {

--- a/internal/app/methods_explain.go
+++ b/internal/app/methods_explain.go
@@ -9,7 +9,6 @@ import (
 	"GoNavi-Wails/internal/connection"
 	"GoNavi-Wails/internal/db"
 	"GoNavi-Wails/internal/logger"
-	"GoNavi-Wails/internal/utils"
 	"GoNavi-Wails/shared/i18n"
 )
 
@@ -65,6 +64,16 @@ func defaultExplainBackendText(key string, params map[string]any) string {
 //
 // Wails 绑定：前端通过 DiagnoseQuery(config, dbName, sql) 调用，返回 QueryResult.Data 为 DiagnoseReport。
 func (a *App) DiagnoseQuery(config connection.ConnectionConfig, dbName, query string) connection.QueryResult {
+	return a.diagnoseQueryContext(context.Background(), config, dbName, query)
+}
+
+func (a *App) diagnoseQueryContext(ctx context.Context, config connection.ConnectionConfig, dbName, query string) connection.QueryResult {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
 	query = strings.TrimSpace(query)
 	if query == "" {
 		return connection.QueryResult{Success: false, Message: a.appText("sql_analysis.backend.error.query_required", nil)}
@@ -82,12 +91,12 @@ func (a *App) DiagnoseQuery(config connection.ConnectionConfig, dbName, query st
 		}
 	}
 
-	dbInst, err := a.getDatabase(runConfig)
+	dbInst, err := a.getDatabaseSynchronouslyWithContext(ctx, runConfig, false)
 	if err != nil {
 		return connection.QueryResult{Success: false, Message: err.Error()}
 	}
 
-	plan, err := a.executeExplain(dbInst, runConfig, dbType, query)
+	plan, err := a.executeExplainContext(ctx, dbInst, runConfig, dbType, query)
 	if err != nil {
 		logger.Warnf("DiagnoseQuery 执行 EXPLAIN 失败：type=%s err=%v sql=%q", dbType, err, sqlSnippet(query))
 		return connection.QueryResult{Success: false, Message: err.Error()}
@@ -248,13 +257,20 @@ func skipMySQLQuotedText(query string, start int, quote byte) int {
 //  1. 若 dbInst 实现 ExplainExecer（driver-agent 在 PR2 接入），优先用驱动原生实现
 //  2. 否则走 app 层 fallback：buildExplainQuery 构造 EXPLAIN 语句，通过 QueryMulti 执行
 func (a *App) executeExplain(dbInst db.Database, config connection.ConnectionConfig, dbType, query string) (connection.ExplainResult, error) {
+	return a.executeExplainContext(context.Background(), dbInst, config, dbType, query)
+}
+
+func (a *App) executeExplainContext(parent context.Context, dbInst db.Database, config connection.ConnectionConfig, dbType, query string) (connection.ExplainResult, error) {
 	text := a.appText
-	ctx, cancel := context.WithCancel(context.Background())
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithCancel(parent)
 	defer cancel()
 
 	if timeout := getDiagnoseTimeout(config); timeout > 0 {
 		var cancelFn context.CancelFunc
-		ctx, cancelFn = utils.ContextWithTimeout(timeout)
+		ctx, cancelFn = context.WithTimeout(parent, timeout)
 		defer cancelFn()
 	}
 
@@ -411,12 +427,23 @@ func runPinnedExplainCleanup(session db.StatementExecer, dbType string, queries 
 
 // runExplainCleanup 执行清理语句（如 Oracle DELETE FROM plan_table），失败仅记日志不阻塞主流程。
 // 在 defer 中调用，确保主 EXPLAIN 失败时也能尝试清理。
+
 func runExplainCleanup(dbInst db.Database, cleanupQueries []string) {
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	for _, q := range cleanupQueries {
 		if strings.TrimSpace(q) == "" {
 			continue
 		}
-		if _, err := dbInst.Exec(q); err != nil {
+		var err error
+		if execer, ok := dbInst.(interface {
+			ExecContext(context.Context, string) (int64, error)
+		}); ok {
+			_, err = execer.ExecContext(cleanupCtx, q)
+		} else {
+			_, err = dbInst.Exec(q)
+		}
+		if err != nil {
 			logger.Warnf("EXPLAIN 清理失败（可忽略）：sql=%q err=%v", sqlSnippet(q), err)
 		}
 	}
@@ -449,8 +476,14 @@ func executeExplainStatementsWithText(ctx context.Context, dbInst db.Database, d
 		return collectExplainRawWithText(results, preferFormat, text)
 	}
 	if multi, ok := dbInst.(db.MultiResultQuerier); ok {
+		if err := ctx.Err(); err != nil {
+			return "", preferFormat, err
+		}
 		results, err := multi.QueryMulti(fullSQL)
 		if err != nil {
+			return "", preferFormat, err
+		}
+		if err := ctx.Err(); err != nil {
 			return "", preferFormat, err
 		}
 		return collectExplainRawWithText(results, preferFormat, text)
@@ -470,7 +503,13 @@ func executeExplainStatementsWithText(ctx context.Context, dbInst db.Database, d
 	}); ok {
 		data, columns, err = queryWithContext.QueryContext(ctx, wrappedSQL)
 	} else {
+		if err := ctx.Err(); err != nil {
+			return "", preferFormat, err
+		}
 		data, columns, err = dbInst.Query(wrappedSQL)
+		if err == nil {
+			err = ctx.Err()
+		}
 	}
 	if err != nil {
 		return "", preferFormat, err

--- a/internal/app/methods_explain_test.go
+++ b/internal/app/methods_explain_test.go
@@ -422,6 +422,76 @@ func TestExecuteExplainStatementsSingleResultFallbackHonorsContext(t *testing.T)
 	}
 }
 
+type legacyContextBoundaryExplainDatabase struct {
+	db.Database
+	queryCalls int
+	onQuery    func()
+}
+
+func (database *legacyContextBoundaryExplainDatabase) Query(string) ([]map[string]interface{}, []string, error) {
+	database.queryCalls++
+	if database.onQuery != nil {
+		database.onQuery()
+	}
+	return []map[string]interface{}{{"detail": "legacy"}}, []string{"detail"}, nil
+}
+
+type legacyContextBoundaryMultiExplainDatabase struct {
+	legacyContextBoundaryExplainDatabase
+	multiCalls int
+	onMulti    func()
+}
+
+func (database *legacyContextBoundaryMultiExplainDatabase) QueryMulti(string) ([]connection.ResultSetData, error) {
+	database.multiCalls++
+	if database.onMulti != nil {
+		database.onMulti()
+	}
+	return []connection.ResultSetData{{Rows: []map[string]interface{}{{"detail": "legacy"}}, Columns: []string{"detail"}}}, nil
+}
+
+func TestExecuteExplainStatementsLegacyFallbackChecksContextBoundaries(t *testing.T) {
+	t.Run("single result does not dispatch after cancellation", func(t *testing.T) {
+		database := &legacyContextBoundaryExplainDatabase{}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, _, err := executeExplainStatementsWithText(
+			ctx, database, "sqlite", "EXPLAIN QUERY PLAN SELECT 1", nil,
+			connection.ExplainFormatTable, defaultExplainBackendText,
+		)
+		if !errors.Is(err, context.Canceled) || database.queryCalls != 0 {
+			t.Fatalf("result error=%v queryCalls=%d, want pre-dispatch cancellation", err, database.queryCalls)
+		}
+	})
+
+	t.Run("single result reports cancellation observed after dispatch", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		database := &legacyContextBoundaryExplainDatabase{onQuery: cancel}
+
+		_, _, err := executeExplainStatementsWithText(
+			ctx, database, "sqlite", "EXPLAIN QUERY PLAN SELECT 1", nil,
+			connection.ExplainFormatTable, defaultExplainBackendText,
+		)
+		if !errors.Is(err, context.Canceled) || database.queryCalls != 1 {
+			t.Fatalf("result error=%v queryCalls=%d, want post-dispatch cancellation", err, database.queryCalls)
+		}
+	})
+
+	t.Run("multi result reports cancellation observed after dispatch", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		database := &legacyContextBoundaryMultiExplainDatabase{onMulti: cancel}
+
+		_, _, err := executeExplainStatementsWithText(
+			ctx, database, "mysql", "EXPLAIN FORMAT=JSON SELECT 1", nil,
+			connection.ExplainFormatJSON, defaultExplainBackendText,
+		)
+		if !errors.Is(err, context.Canceled) || database.multiCalls != 1 || database.queryCalls != 0 {
+			t.Fatalf("result error=%v multiCalls=%d queryCalls=%d, want post-dispatch cancellation", err, database.multiCalls, database.queryCalls)
+		}
+	})
+}
+
 func TestBuildExplainQuery_UnsupportedDialectReturnsError(t *testing.T) {
 	_, _, _, _, err := buildExplainQuery("mongodb", "db.t.find()")
 	if err == nil {

--- a/internal/app/methods_file.go
+++ b/internal/app/methods_file.go
@@ -3141,6 +3141,22 @@ func (a *App) ImportDatabaseSQLWithOptions(config connection.ConnectionConfig, d
 }
 
 func (a *App) importDatabaseSQLWithGTIDMode(config connection.ConnectionConfig, dbName string, filePath string, jobID string, continueOnError bool, mode mysqlGTIDImportMode) (result connection.QueryResult) {
+	return a.importDatabaseSQLWithGTIDModeContext(context.Background(), config, dbName, filePath, jobID, continueOnError, mode)
+}
+
+func (a *App) importDatabaseSQLContext(ctx context.Context, config connection.ConnectionConfig, dbName string, filePath string, jobID string, continueOnError bool, mysqlGTIDMode string) connection.QueryResult {
+	mode := mysqlGTIDImportModeReject
+	if strings.TrimSpace(mysqlGTIDMode) != "" {
+		var err error
+		mode, err = normalizeMySQLGTIDImportMode(mysqlGTIDMode)
+		if err != nil {
+			return connection.QueryResult{Success: false, Message: a.appText("file.backend.error.mysql_gtid_mode_invalid", nil)}
+		}
+	}
+	return a.importDatabaseSQLWithGTIDModeContext(ctx, config, dbName, filePath, jobID, continueOnError, mode)
+}
+
+func (a *App) importDatabaseSQLWithGTIDModeContext(ctx context.Context, config connection.ConnectionConfig, dbName string, filePath string, jobID string, continueOnError bool, mode mysqlGTIDImportMode) (result connection.QueryResult) {
 	if err := a.validateDatabaseSQLImportAccess(config); err != nil {
 		return connection.QueryResult{Success: false, Message: err.Error()}
 	}
@@ -3156,7 +3172,7 @@ func (a *App) importDatabaseSQLWithGTIDMode(config connection.ConnectionConfig, 
 		mode = ""
 	}
 	return a.executeSQLFileWithStatementLimitPolicyContextWithPolicy(
-		context.Background(),
+		ctx,
 		config,
 		dbName,
 		filePath,
@@ -3173,6 +3189,10 @@ func (a *App) importDatabaseSQLWithGTIDMode(config connection.ConnectionConfig, 
 }
 
 func (a *App) ExecuteSQLFile(config connection.ConnectionConfig, dbName string, filePath string, jobID string) connection.QueryResult {
+	return a.executeSQLFileContext(context.Background(), config, dbName, filePath, jobID)
+}
+
+func (a *App) executeSQLFileContext(ctx context.Context, config connection.ConnectionConfig, dbName string, filePath string, jobID string) connection.QueryResult {
 	// The generic SQL-file runner retains its established compatibility
 	// behavior. Database restore calls ImportDatabaseSQL and chooses the policy
 	// explicitly, defaulting to fail-fast in the UI.
@@ -3184,7 +3204,7 @@ func (a *App) ExecuteSQLFile(config connection.ConnectionConfig, dbName string, 
 	); err != nil {
 		return connection.QueryResult{Success: false, Message: err.Error()}
 	}
-	return a.executeSQLFile(config, dbName, filePath, jobID, true)
+	return a.executeSQLFileWithStatementLimitPolicyContext(ctx, config, dbName, filePath, jobID, true, DefaultSQLImportMaxStatementBytes, false, "sql_file")
 }
 
 func (a *App) executeSQLFile(config connection.ConnectionConfig, dbName string, filePath string, jobID string, continueOnError bool) (result connection.QueryResult) {
@@ -4033,12 +4053,22 @@ func (a *App) SelectDatabaseFile(currentPath string, driverType string) connecti
 
 // PreviewImportFile 解析导入文件，返回字段列表、总行数、前 5 行预览数据
 func (a *App) PreviewImportFile(filePath string) connection.QueryResult {
-	return a.PreviewImportFileWithOptions(filePath, ImportFileOptions{})
+	return a.previewImportFileContext(context.Background(), filePath, ImportFileOptions{})
 }
 
 // PreviewImportFileWithOptions previews a file with the same parser settings
 // that will be used by ImportDataWithProgressOptions.
 func (a *App) PreviewImportFileWithOptions(filePath string, options ImportFileOptions) (queryResult connection.QueryResult) {
+	return a.previewImportFileContext(context.Background(), filePath, options)
+}
+
+func (a *App) previewImportFileContext(ctx context.Context, filePath string, options ImportFileOptions) (queryResult connection.QueryResult) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
 	if strings.TrimSpace(filePath) == "" {
 		return connection.QueryResult{Success: false, Message: a.appText("file.backend.error.import_file_empty", nil)}
 	}
@@ -4059,7 +4089,7 @@ func (a *App) PreviewImportFileWithOptions(filePath string, options ImportFileOp
 		return connection.QueryResult{Success: false, Message: err.Error()}
 	}
 
-	preview, err := buildImportPreviewWithOptions(filePath, defaultImportPreviewLimit, options)
+	preview, err := buildImportPreviewWithOptionsContext(ctx, filePath, defaultImportPreviewLimit, options)
 	if err != nil {
 		return connection.QueryResult{Success: false, Message: err.Error()}
 	}
@@ -4543,6 +4573,10 @@ func (a *App) stoppedImportResult(resultData importExecutionResult, detail strin
 // ImportDataWithProgressOptions executes a streamed import with optional source-header
 // to database-column mappings. ImportDataWithProgress remains the compatibility entrypoint.
 func (a *App) ImportDataWithProgressOptions(config connection.ConnectionConfig, dbName, tableName, filePath string, options ImportFileOptions) (result connection.QueryResult) {
+	return a.importDataWithProgressContext(context.Background(), config, dbName, tableName, filePath, options)
+}
+
+func (a *App) importDataWithProgressContext(parent context.Context, config connection.ConnectionConfig, dbName, tableName, filePath string, options ImportFileOptions) (result connection.QueryResult) {
 	resolvedPath, err := a.resolveWebUploadReference(filePath, webUploadPurposeDataImport)
 	if err != nil {
 		return connection.QueryResult{Success: false, Message: err.Error()}
@@ -4551,7 +4585,7 @@ func (a *App) ImportDataWithProgressOptions(config connection.ConnectionConfig, 
 	if a.webRuntime {
 		defer func() { result = sanitizeWebManagedResult(result, filePath) }()
 	}
-	return a.importDataWithProgressOptions(config, dbName, tableName, filePath, options, nil)
+	return a.importDataWithProgressOptionsContext(parent, config, dbName, tableName, filePath, options, nil)
 }
 
 func (a *App) importDataWithProgressOptions(
@@ -4560,6 +4594,19 @@ func (a *App) importDataWithProgressOptions(
 	options ImportFileOptions,
 	recovery *tableImportRecoveryPlan,
 ) (result connection.QueryResult) {
+	return a.importDataWithProgressOptionsContext(context.Background(), config, dbName, tableName, filePath, options, recovery)
+}
+
+func (a *App) importDataWithProgressOptionsContext(
+	parent context.Context,
+	config connection.ConnectionConfig,
+	dbName, tableName, filePath string,
+	options ImportFileOptions,
+	recovery *tableImportRecoveryPlan,
+) (result connection.QueryResult) {
+	if parent == nil {
+		parent = context.Background()
+	}
 	if strings.TrimSpace(filePath) == "" {
 		return connection.QueryResult{Success: false, Message: a.appText("file.backend.error.import_file_empty", nil)}
 	}
@@ -4601,9 +4648,7 @@ func (a *App) importDataWithProgressOptions(
 			return connection.QueryResult{Success: false, Message: importJobRecoveryErrorMessage(a, err)}
 		}
 	}
-	metadataSchemaName, metadataTableName := normalizeMetadataSchemaAndTable(config, dbName, tableName)
-
-	importCtx, importCancel := context.WithCancel(context.Background())
+	importCtx, importCancel := context.WithCancel(parent)
 	defer importCancel()
 	jobID := strings.TrimSpace(options.JobID)
 	if recovery != nil && jobID == "" {
@@ -4688,7 +4733,7 @@ func (a *App) importDataWithProgressOptions(
 		return a.cancelledImportResult(importExecutionResult{})
 	}
 	runConfig := normalizeRunConfig(config, dbName)
-	dbInst, err := a.getDatabase(runConfig)
+	dbInst, err := a.getDatabaseSynchronouslyWithContext(importCtx, runConfig, false)
 	if err != nil {
 		if errors.Is(importCtx.Err(), context.Canceled) {
 			return a.cancelledImportResult(importExecutionResult{})
@@ -4710,7 +4755,7 @@ func (a *App) importDataWithProgressOptions(
 		}
 	}
 
-	targetColumns, colErr := getColumnsWithMetadataFallback(dbInst, config, metadataSchemaName, metadataTableName, a.appText)
+	targetColumns, colErr := a.importTargetColumnsContext(importCtx, dbInst, config, dbName, tableName)
 	if errors.Is(importCtx.Err(), context.Canceled) {
 		return a.cancelledImportResult(importExecutionResult{})
 	}
@@ -4776,7 +4821,7 @@ func (a *App) importDataWithProgressOptions(
 		}
 		return managedArtifact.finish(resultData)
 	}
-	if err := streamImportFileWithOptions(filePath, consumer, options); err != nil {
+	if err := streamImportFileWithOptionsContext(importCtx, filePath, consumer, options); err != nil {
 		resultData := batchConsumer.Result()
 		if jobPersistErr != nil {
 			if artifactErr := finishArtifact(&resultData); artifactErr != nil {
@@ -4868,6 +4913,34 @@ func (a *App) importDataWithProgressOptions(
 
 	maybeReleaseFileTransferMemory("import-finished", int64(resultData.Total), filePath)
 	return connection.QueryResult{Success: true, Data: resultPayload, Message: summary}
+}
+
+func (a *App) importTargetColumnsContext(
+	ctx context.Context,
+	dbInst db.Database,
+	config connection.ConnectionConfig,
+	dbName, tableName string,
+) ([]connection.ColumnDefinition, error) {
+	// A second connection to :memory: is a different SQLite or DuckDB database.
+	// Prefer a same-instance Context API for file-local engines so cancellation
+	// does not regress their in-memory import path. Other databases retain the
+	// isolated metadata session, which avoids binding request Context to a shared
+	// cached driver instance.
+	dbType := resolveDDLDBType(config)
+	if dbType == "sqlite" || dbType == "duckdb" {
+		if getter, ok := dbInst.(db.ColumnDefinitionContexter); ok {
+			schemaName, pureTableName := normalizeMetadataSchemaAndTable(config, dbName, tableName)
+			return getter.GetColumnsContext(ctx, schemaName, pureTableName)
+		}
+	}
+	metadataResult := a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult {
+		return session.DBGetColumns(config, dbName, tableName)
+	})
+	if !metadataResult.Success {
+		return nil, errors.New(metadataResult.Message)
+	}
+	targetColumns, _ := metadataResult.Data.([]connection.ColumnDefinition)
+	return targetColumns, nil
 }
 
 func (a *App) ApplyChanges(config connection.ConnectionConfig, dbName, tableName string, changes connection.ChangeSet) (result connection.QueryResult) {

--- a/internal/app/methods_file_import_test.go
+++ b/internal/app/methods_file_import_test.go
@@ -209,6 +209,20 @@ type issue1025CapturingImportDB struct {
 	batchChanges []connection.ChangeSet
 }
 
+type sameSessionImportMetadataDB struct {
+	issue1025CapturingImportDB
+	contextValue any
+	contextCalls int
+}
+
+func (database *sameSessionImportMetadataDB) GetColumnsContext(ctx context.Context, _, _ string) ([]connection.ColumnDefinition, error) {
+	database.contextCalls++
+	database.contextValue = ctx.Value(importMetadataContextKey{})
+	return append([]connection.ColumnDefinition(nil), database.columns...), ctx.Err()
+}
+
+type importMetadataContextKey struct{}
+
 func (database *issue1025CapturingImportDB) ApplyChanges(_ string, changes connection.ChangeSet) error {
 	database.batchChanges = append(database.batchChanges, changes)
 	return nil
@@ -284,6 +298,70 @@ func TestIssue1025BlankNullableXLSXCellsBecomeSQLNull(t *testing.T) {
 	}
 	if row["required_count"] != "" {
 		t.Fatalf("required blank cell = %#v, want empty string for database validation", row["required_count"])
+	}
+}
+
+func TestSQLiteMemoryImportReadsColumnsFromSameContextAwareInstance(t *testing.T) {
+	installFakeOptionalDriverRuntime(t)
+	database := &sameSessionImportMetadataDB{issue1025CapturingImportDB: issue1025CapturingImportDB{
+		fakeMetadataRetryDB: fakeMetadataRetryDB{
+			columns: []connection.ColumnDefinition{{Name: "id", Type: "integer", Nullable: "NO"}},
+		},
+	}}
+	installImportTestDatabase(t, database)
+	path := filepath.Join(t.TempDir(), "users.csv")
+	if err := os.WriteFile(path, []byte("id\n1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	application := newManagedImportTestApp(t)
+	ctx := context.WithValue(context.Background(), importMetadataContextKey{}, "request-1098")
+
+	result := application.importDataWithProgressContext(
+		ctx,
+		connection.ConnectionConfig{Type: "sqlite", Host: ":memory:"},
+		"",
+		"users",
+		path,
+		ImportFileOptions{ColumnMappings: map[string]string{"id": "id"}},
+	)
+	if !result.Success {
+		t.Fatalf("in-memory import failed: %#v", result)
+	}
+	if database.contextCalls != 1 || database.contextValue != "request-1098" {
+		t.Fatalf("same-session metadata context calls=%d value=%v", database.contextCalls, database.contextValue)
+	}
+	if database.connectCalls != 1 {
+		t.Fatalf("database connect calls = %d, want one shared in-memory instance", database.connectCalls)
+	}
+	if len(database.batchChanges) != 1 || len(database.batchChanges[0].Inserts) != 1 {
+		t.Fatalf("applied changes = %#v, want one row", database.batchChanges)
+	}
+}
+
+func TestDuckDBMemoryImportReadsColumnsFromSameContextAwareInstance(t *testing.T) {
+	database := &sameSessionImportMetadataDB{issue1025CapturingImportDB: issue1025CapturingImportDB{
+		fakeMetadataRetryDB: fakeMetadataRetryDB{
+			columns: []connection.ColumnDefinition{{Name: "id", Type: "integer", Nullable: "NO"}},
+		},
+	}}
+	application := NewAppWithSecretStore(newFakeAppSecretStore())
+	ctx := context.WithValue(context.Background(), importMetadataContextKey{}, "request-1098")
+
+	columns, err := application.importTargetColumnsContext(
+		ctx,
+		database,
+		connection.ConnectionConfig{Type: "duckdb", Host: ":memory:"},
+		"main",
+		"users",
+	)
+	if err != nil {
+		t.Fatalf("read in-memory DuckDB columns: %v", err)
+	}
+	if len(columns) != 1 || columns[0].Name != "id" {
+		t.Fatalf("columns = %#v, want id", columns)
+	}
+	if database.contextCalls != 1 || database.contextValue != "request-1098" {
+		t.Fatalf("same-session metadata context calls=%d value=%v", database.contextCalls, database.contextValue)
 	}
 }
 

--- a/internal/app/methods_sync.go
+++ b/internal/app/methods_sync.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -89,6 +90,13 @@ func (a *App) DataSyncCapability(sourceConfig connection.ConnectionConfig, targe
 
 // DataSync executes a data synchronization task
 func (a *App) DataSync(config sync.SyncConfig) (result sync.SyncResult) {
+	return a.dataSyncContext(context.Background(), config)
+}
+
+func (a *App) dataSyncContext(ctx context.Context, config sync.SyncConfig) (result sync.SyncResult) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	auditStartedAt := time.Now()
 	defer func() {
 		runConfig := normalizeRunConfig(config.TargetConfig, config.TargetDatabase)
@@ -158,7 +166,7 @@ func (a *App) DataSync(config sync.SyncConfig) (result sync.SyncResult) {
 	}
 
 	engine := sync.NewSyncEngine(reporter)
-	res := engine.RunSync(resolvedConfig)
+	res := engine.RunSyncContext(ctx, resolvedConfig)
 
 	uievents.Emit(a.ctx, sync.EventSyncDone, map[string]any{
 		"jobId":  jobID,
@@ -170,6 +178,13 @@ func (a *App) DataSync(config sync.SyncConfig) (result sync.SyncResult) {
 
 // DataSyncAnalyze analyzes differences between source and target for the given tables (dry-run).
 func (a *App) DataSyncAnalyze(config sync.SyncConfig) connection.QueryResult {
+	return a.dataSyncAnalyzeContext(context.Background(), config)
+}
+
+func (a *App) dataSyncAnalyzeContext(ctx context.Context, config sync.SyncConfig) connection.QueryResult {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	jobID := strings.TrimSpace(config.JobID)
 	if jobID == "" {
 		jobID = fmt.Sprintf("analyze-%d", time.Now().UnixNano())
@@ -203,7 +218,7 @@ func (a *App) DataSyncAnalyze(config sync.SyncConfig) connection.QueryResult {
 	}
 
 	engine := sync.NewSyncEngine(reporter)
-	res := engine.Analyze(resolvedConfig)
+	res := engine.AnalyzeContext(ctx, resolvedConfig)
 
 	uievents.Emit(a.ctx, sync.EventSyncDone, map[string]any{
 		"jobId":  jobID,
@@ -219,6 +234,13 @@ func (a *App) DataSyncAnalyze(config sync.SyncConfig) connection.QueryResult {
 
 // DataSyncPreview returns a limited preview of diff rows for one table.
 func (a *App) DataSyncPreview(config sync.SyncConfig, tableName string, limit int) connection.QueryResult {
+	return a.dataSyncPreviewContext(context.Background(), config, tableName, limit)
+}
+
+func (a *App) dataSyncPreviewContext(ctx context.Context, config sync.SyncConfig, tableName string, limit int) connection.QueryResult {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	jobID := strings.TrimSpace(config.JobID)
 	if jobID == "" {
 		jobID = fmt.Sprintf("preview-%d", time.Now().UnixNano())
@@ -231,7 +253,7 @@ func (a *App) DataSyncPreview(config sync.SyncConfig, tableName string, limit in
 	}
 
 	engine := sync.NewSyncEngine(sync.Reporter{})
-	preview, err := engine.Preview(resolvedConfig, tableName, limit)
+	preview, err := engine.PreviewContext(ctx, resolvedConfig, tableName, limit)
 	if err != nil {
 		return connection.QueryResult{Success: false, Message: err.Error()}
 	}

--- a/internal/app/web_rpc_context.go
+++ b/internal/app/web_rpc_context.go
@@ -1,0 +1,294 @@
+package app
+
+import (
+	"context"
+	"strings"
+
+	"GoNavi-Wails/internal/connection"
+	"GoNavi-Wails/internal/logger"
+	syncengine "GoNavi-Wails/internal/sync"
+	"GoNavi-Wails/internal/syncjob"
+)
+
+var requiredIssue1098WebRPCContextMethods = []string{
+	"DBQuery", "DBQueryWithCancel", "DBQueryMulti", "DBQueryAudited", "DBQueryAI", "DBQueryIsolated", "MySQLQuery",
+	"DBGetDatabases", "DBGetTables", "DBGetViews", "DBGetObjects", "DBGetAllColumns", "DBGetColumns", "DBGetIndexes",
+	"DBGetForeignKeys", "DBGetDatabaseForeignKeys", "DBGetTriggers", "DBShowCreateTable", "DBTableExists",
+	"MySQLGetDatabases", "MySQLGetTables", "MySQLShowCreateTable", "MongoDiscoverMembers", "DBRefreshTableStats", "DiagnoseQuery",
+	"DataSyncDatabaseList", "DataSyncObjectList", "DataSyncFieldList", "DataSyncCapabilityResolve", "DataSyncCDCProbe", "DataSyncJobPreflight",
+	"DataSyncJobList", "DataSyncJobGet", "DataSyncRunGet", "DataSyncRunList", "DataSyncRunPage", "DataSyncRunEventList",
+	"DataSyncErrorRowList", "DataSyncErrorRowGet", "DataSyncCheckpointGet", "DataSync", "DataSyncAnalyze", "DataSyncPreview",
+	"PreviewImportFile", "PreviewImportFileWithOptions", "ImportDataWithProgress", "ImportDataWithProgressOptions",
+	"ImportDatabaseSQL", "ImportDatabaseSQLWithOptions", "ExecuteSQLFile", "ResumeImportJob", "RetryImportJobFailedRows",
+}
+
+// RequiredIssue1098WebRPCContextMethods returns the exact App method set whose
+// Web RPC lifetime is request-scoped. Callers receive a copy so the contract
+// cannot be mutated after server construction.
+func RequiredIssue1098WebRPCContextMethods() []string {
+	return append([]string(nil), requiredIssue1098WebRPCContextMethods...)
+}
+
+// WebRPCContextHandlers keeps context injection outside App's exported Wails
+// method set. Every handler has the original public signature prefixed by a
+// context.Context; the Web server validates the complete map at construction.
+func WebRPCContextHandlers(a *App) map[string]any {
+	return map[string]any{
+		"DBQuery": func(ctx context.Context, config connection.ConnectionConfig, dbName, query string) connection.QueryResult {
+			return a.dbQueryContext(ctx, config, dbName, query)
+		},
+		"DBQueryWithCancel": func(ctx context.Context, config connection.ConnectionConfig, dbName, query, queryID string) connection.QueryResult {
+			return a.dbQueryWithCancelContext(ctx, config, dbName, query, queryID)
+		},
+		"DBQueryMulti": func(ctx context.Context, config connection.ConnectionConfig, dbName, query, queryID string) connection.QueryResult {
+			return a.dbQueryMultiContext(ctx, config, dbName, query, queryID)
+		},
+		"DBQueryAudited": func(ctx context.Context, config connection.ConnectionConfig, dbName, query, source string) connection.QueryResult {
+			return a.dbQueryAuditedContext(ctx, config, dbName, query, source)
+		},
+		"DBQueryAI": func(ctx context.Context, config connection.ConnectionConfig, dbName, query string) connection.QueryResult {
+			return a.dbQueryAIContext(ctx, config, dbName, query)
+		},
+		"DBQueryIsolated": func(ctx context.Context, config connection.ConnectionConfig, dbName, query string) connection.QueryResult {
+			return a.dbQueryIsolatedContext(ctx, config, dbName, query)
+		},
+		"MySQLQuery": func(ctx context.Context, config connection.ConnectionConfig, dbName, query string) connection.QueryResult {
+			config.Type = "mysql"
+			return a.dbQueryContext(ctx, config, dbName, query)
+		},
+
+		"DBGetDatabases": func(ctx context.Context, config connection.ConnectionConfig) connection.QueryResult {
+			return a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetDatabases(config) })
+		},
+		"DBGetTables": func(ctx context.Context, config connection.ConnectionConfig, dbName string) connection.QueryResult {
+			return a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetTables(config, dbName) })
+		},
+		"DBGetViews": func(ctx context.Context, config connection.ConnectionConfig, dbName string) connection.QueryResult {
+			return a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetViews(config, dbName) })
+		},
+		"DBGetObjects": func(ctx context.Context, config connection.ConnectionConfig, dbName string) connection.QueryResult {
+			return a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetObjects(config, dbName) })
+		},
+		"DBGetAllColumns": func(ctx context.Context, config connection.ConnectionConfig, dbName string) connection.QueryResult {
+			return a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetAllColumns(config, dbName) })
+		},
+		"DBGetColumns": func(ctx context.Context, config connection.ConnectionConfig, dbName, tableName string) connection.QueryResult {
+			return a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetColumns(config, dbName, tableName) })
+		},
+		"DBGetIndexes": func(ctx context.Context, config connection.ConnectionConfig, dbName, tableName string) connection.QueryResult {
+			return a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetIndexes(config, dbName, tableName) })
+		},
+		"DBGetForeignKeys": func(ctx context.Context, config connection.ConnectionConfig, dbName, tableName string) connection.QueryResult {
+			return a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetForeignKeys(config, dbName, tableName) })
+		},
+		"DBGetDatabaseForeignKeys": func(ctx context.Context, config connection.ConnectionConfig, dbName string) connection.QueryResult {
+			return a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetDatabaseForeignKeys(config, dbName) })
+		},
+		"DBGetTriggers": func(ctx context.Context, config connection.ConnectionConfig, dbName, tableName string) connection.QueryResult {
+			return a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetTriggers(config, dbName, tableName) })
+		},
+		"DBShowCreateTable": func(ctx context.Context, config connection.ConnectionConfig, dbName, tableName string) connection.QueryResult {
+			return a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBShowCreateTable(config, dbName, tableName) })
+		},
+		"DBTableExists": func(ctx context.Context, config connection.ConnectionConfig, dbName, tableName string) connection.QueryResult {
+			return a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBTableExists(config, dbName, tableName) })
+		},
+		"MySQLGetDatabases": func(ctx context.Context, config connection.ConnectionConfig) connection.QueryResult {
+			config.Type = "mysql"
+			return a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetDatabases(config) })
+		},
+		"MySQLGetTables": func(ctx context.Context, config connection.ConnectionConfig, dbName string) connection.QueryResult {
+			config.Type = "mysql"
+			return a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBGetTables(config, dbName) })
+		},
+		"MySQLShowCreateTable": func(ctx context.Context, config connection.ConnectionConfig, dbName, tableName string) connection.QueryResult {
+			config.Type = "mysql"
+			return a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult { return session.DBShowCreateTable(config, dbName, tableName) })
+		},
+		"MongoDiscoverMembers": func(ctx context.Context, config connection.ConnectionConfig) connection.QueryResult {
+			return a.mongoDiscoverMembersContext(ctx, config)
+		},
+		"DBRefreshTableStats": func(ctx context.Context, config connection.ConnectionConfig, dbName string, rawTables []string) connection.QueryResult {
+			return a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult {
+				return session.DBRefreshTableStats(config, dbName, rawTables)
+			})
+		},
+		"DiagnoseQuery": func(ctx context.Context, config connection.ConnectionConfig, dbName, query string) connection.QueryResult {
+			return a.diagnoseQueryContext(ctx, config, dbName, query)
+		},
+
+		"DataSyncDatabaseList": func(ctx context.Context, connectionID string) connection.QueryResult {
+			return a.dataSyncDatabaseListContext(ctx, connectionID)
+		},
+		"DataSyncObjectList": func(ctx context.Context, connectionID, database, schema string) connection.QueryResult {
+			return a.dataSyncObjectListContext(ctx, connectionID, database, schema)
+		},
+		"DataSyncFieldList": func(ctx context.Context, connectionID, database, schema, objectName string) connection.QueryResult {
+			return a.dataSyncFieldListContext(ctx, connectionID, database, schema, objectName)
+		},
+		"DataSyncCapabilityResolve": func(ctx context.Context, sourceConnectionID, sourceDatabase, sourceSchema, targetConnectionID, targetDatabase, targetSchema string) connection.QueryResult {
+			return a.dataSyncCapabilityResolveContext(ctx, sourceConnectionID, sourceDatabase, sourceSchema, targetConnectionID, targetDatabase, targetSchema)
+		},
+		"DataSyncCDCProbe": func(ctx context.Context, connectionID, database, schema, mode string) connection.QueryResult {
+			return a.dataSyncCDCProbeContext(ctx, connectionID, database, schema, mode)
+		},
+		"DataSyncJobPreflight": func(ctx context.Context, definition syncjob.JobDefinition) connection.QueryResult {
+			return a.dataSyncJobPreflightContext(ctx, definition)
+		},
+		"DataSyncJobList": func(ctx context.Context) connection.QueryResult { return a.dataSyncJobListContext(ctx) },
+		"DataSyncJobGet": func(ctx context.Context, jobID string) connection.QueryResult {
+			return a.dataSyncJobGetContext(ctx, jobID)
+		},
+		"DataSyncRunGet": func(ctx context.Context, runID string) connection.QueryResult {
+			return a.dataSyncRunGetContext(ctx, runID)
+		},
+		"DataSyncRunList": func(ctx context.Context, jobID string, limit int) connection.QueryResult {
+			return a.dataSyncRunListContext(ctx, jobID, limit)
+		},
+		"DataSyncRunPage": func(ctx context.Context, jobID string, beforeCreatedAt int64, beforeID string, limit int) connection.QueryResult {
+			return a.dataSyncRunPageContext(ctx, jobID, beforeCreatedAt, beforeID, limit)
+		},
+		"DataSyncRunEventList": func(ctx context.Context, runID string, afterSequence int64, limit int) connection.QueryResult {
+			return a.dataSyncRunEventListContext(ctx, runID, afterSequence, limit)
+		},
+		"DataSyncErrorRowList": func(ctx context.Context, runID, status string, limit int) connection.QueryResult {
+			return a.dataSyncErrorRowListContext(ctx, runID, status, limit)
+		},
+		"DataSyncErrorRowGet": func(ctx context.Context, errorRowID string) connection.QueryResult {
+			return a.dataSyncErrorRowGetContext(ctx, errorRowID)
+		},
+		"DataSyncCheckpointGet": func(ctx context.Context, jobID string) connection.QueryResult {
+			return a.dataSyncCheckpointGetContext(ctx, jobID)
+		},
+		"DataSync": func(ctx context.Context, config syncengine.SyncConfig) syncengine.SyncResult {
+			return a.dataSyncContext(ctx, config)
+		},
+		"DataSyncAnalyze": func(ctx context.Context, config syncengine.SyncConfig) connection.QueryResult {
+			return a.dataSyncAnalyzeContext(ctx, config)
+		},
+		"DataSyncPreview": func(ctx context.Context, config syncengine.SyncConfig, tableName string, limit int) connection.QueryResult {
+			return a.dataSyncPreviewContext(ctx, config, tableName, limit)
+		},
+
+		"PreviewImportFile": func(ctx context.Context, filePath string) connection.QueryResult {
+			return a.previewImportFileContext(ctx, filePath, ImportFileOptions{})
+		},
+		"PreviewImportFileWithOptions": func(ctx context.Context, filePath string, options ImportFileOptions) connection.QueryResult {
+			return a.previewImportFileContext(ctx, filePath, options)
+		},
+		"ImportDataWithProgress": func(ctx context.Context, config connection.ConnectionConfig, dbName, tableName, filePath string) connection.QueryResult {
+			return a.importDataWithProgressContext(ctx, config, dbName, tableName, filePath, ImportFileOptions{})
+		},
+		"ImportDataWithProgressOptions": func(ctx context.Context, config connection.ConnectionConfig, dbName, tableName, filePath string, options ImportFileOptions) connection.QueryResult {
+			return a.importDataWithProgressContext(ctx, config, dbName, tableName, filePath, options)
+		},
+		"ImportDatabaseSQL": func(ctx context.Context, config connection.ConnectionConfig, dbName, filePath, jobID string, continueOnError bool) connection.QueryResult {
+			return a.importDatabaseSQLContext(ctx, config, dbName, filePath, jobID, continueOnError, "")
+		},
+		"ImportDatabaseSQLWithOptions": func(ctx context.Context, config connection.ConnectionConfig, dbName, filePath, jobID string, continueOnError bool, mysqlGTIDMode string) connection.QueryResult {
+			return a.importDatabaseSQLContext(ctx, config, dbName, filePath, jobID, continueOnError, mysqlGTIDMode)
+		},
+		"ExecuteSQLFile": func(ctx context.Context, config connection.ConnectionConfig, dbName, filePath, jobID string) connection.QueryResult {
+			return a.executeSQLFileContext(ctx, config, dbName, filePath, jobID)
+		},
+		"ResumeImportJob": func(ctx context.Context, jobID string) connection.QueryResult {
+			return a.resumeImportJobContext(ctx, jobID)
+		},
+		"RetryImportJobFailedRows": func(ctx context.Context, jobID string) connection.QueryResult {
+			return a.retryImportJobFailedRowsContext(ctx, jobID)
+		},
+	}
+}
+
+func (a *App) dbQueryContext(ctx context.Context, config connection.ConnectionConfig, dbName, query string) connection.QueryResult {
+	return a.dbQueryWithCancel(config, dbName, query, "", dbQueryAuditOptions{
+		auditAll: a.webRuntime, auditWrites: true, source: "application_api", executionContext: ctx, synchronousConnectionWait: true,
+	})
+}
+
+func (a *App) dbQueryWithCancelContext(ctx context.Context, config connection.ConnectionConfig, dbName, query, queryID string) connection.QueryResult {
+	explicitQuery := strings.TrimSpace(queryID) != ""
+	source := "application_api"
+	if explicitQuery {
+		source = "query_editor"
+	}
+	return a.dbQueryWithCancel(config, dbName, query, queryID, dbQueryAuditOptions{
+		trackHistory: explicitQuery, auditAll: explicitQuery || a.webRuntime, auditWrites: true, source: source,
+		executionContext: ctx, synchronousConnectionWait: true,
+	})
+}
+
+func (a *App) dbQueryMultiContext(ctx context.Context, config connection.ConnectionConfig, dbName, query, queryID string) connection.QueryResult {
+	explicitQuery := strings.TrimSpace(queryID) != ""
+	source := "query_editor"
+	if !explicitQuery {
+		source = "application_api"
+	}
+	return a.dbQueryMulti(config, dbName, query, queryID, dbQueryMultiAuditOptions{
+		auditAll: explicitQuery || a.webRuntime, auditWrites: true, source: source,
+		executionContext: ctx, synchronousConnectionWait: true,
+	})
+}
+
+func (a *App) dbQueryAuditedContext(ctx context.Context, config connection.ConnectionConfig, dbName, query, source string) connection.QueryResult {
+	return a.dbQueryWithCancel(config, dbName, query, generateQueryID(), dbQueryAuditOptions{
+		auditAll: true, auditWrites: true, source: normalizeSQLAuditUserActionSource(source), executionContext: ctx, synchronousConnectionWait: true,
+	})
+}
+
+func (a *App) dbQueryAIContext(ctx context.Context, config connection.ConnectionConfig, dbName, query string) connection.QueryResult {
+	return a.dbQueryWithCancel(config, dbName, query, "", dbQueryAuditOptions{
+		auditAll: true, auditWrites: true, source: "ai_action", executionContext: ctx, synchronousConnectionWait: true,
+	})
+}
+
+func (a *App) mongoDiscoverMembersContext(ctx context.Context, config connection.ConnectionConfig) connection.QueryResult {
+	config.Type = "mongodb"
+	return a.runWebMetadataWithContext(ctx, func(session *App) connection.QueryResult {
+		dbInst, err := session.getDatabaseSynchronouslyWithContext(ctx, config, false)
+		if err != nil {
+			logger.Error(err, "MongoDiscoverMembers 获取连接失败：%s", formatConnSummary(config))
+			return connection.QueryResult{Success: false, Message: err.Error()}
+		}
+		session.bindMetadataDatabase(dbInst)
+		if pinger, ok := dbInst.(interface{ PingContext(context.Context) error }); ok {
+			if err := pinger.PingContext(ctx); err != nil {
+				return connection.QueryResult{Success: false, Message: err.Error()}
+			}
+		} else if pinger, ok := dbInst.(interface{ Ping() error }); ok {
+			if err := pinger.Ping(); err != nil {
+				return connection.QueryResult{Success: false, Message: err.Error()}
+			}
+		}
+		if err := ctx.Err(); err != nil {
+			return connection.QueryResult{Success: false, Message: err.Error()}
+		}
+		discoverable, ok := dbInst.(interface {
+			DiscoverMembersContext(context.Context) (string, []connection.MongoMemberInfo, error)
+		})
+		if !ok {
+			legacy, legacyOK := dbInst.(interface {
+				DiscoverMembers() (string, []connection.MongoMemberInfo, error)
+			})
+			if !legacyOK {
+				return connection.QueryResult{Success: false, Message: a.appText("db.backend.error.mongo_member_discovery_unsupported", nil)}
+			}
+			replicaSet, members, err := legacy.DiscoverMembers()
+			return buildMongoDiscoveryResult(a, config, replicaSet, members, err)
+		}
+		replicaSet, members, err := discoverable.DiscoverMembersContext(ctx)
+		return buildMongoDiscoveryResult(a, config, replicaSet, members, err)
+	})
+}
+
+func buildMongoDiscoveryResult(a *App, config connection.ConnectionConfig, replicaSet string, members []connection.MongoMemberInfo, err error) connection.QueryResult {
+	if err != nil {
+		logger.Error(err, "MongoDiscoverMembers 执行失败：%s", formatConnSummary(config))
+		return connection.QueryResult{Success: false, Message: err.Error()}
+	}
+	return connection.QueryResult{
+		Success: true,
+		Message: a.appText("db.backend.message.mongo_members_discovered", map[string]any{"count": len(members)}),
+		Data:    map[string]any{"replicaSet": replicaSet, "members": members},
+	}
+}

--- a/internal/db/database.go
+++ b/internal/db/database.go
@@ -328,6 +328,13 @@ type QueryContexter interface {
 	QueryContext(ctx context.Context, query string) ([]map[string]interface{}, []string, error)
 }
 
+// ColumnDefinitionContexter is an optional same-session metadata extension.
+// It is used when opening a second database instance would change connection-
+// scoped semantics, such as an in-memory SQLite or DuckDB database.
+type ColumnDefinitionContexter interface {
+	GetColumnsContext(ctx context.Context, dbName, tableName string) ([]connection.ColumnDefinition, error)
+}
+
 // ExecContexter is the optional cancellation-capable write contract.
 // Callers must not assume Database.Exec can be interrupted without it.
 type ExecContexter interface {

--- a/internal/db/mongodb_impl.go
+++ b/internal/db/mongodb_impl.go
@@ -500,6 +500,10 @@ func (m *MongoDB) Close() error {
 }
 
 func (m *MongoDB) Ping() error {
+	return m.PingContext(context.Background())
+}
+
+func (m *MongoDB) PingContext(parent context.Context) error {
 	if m.client == nil {
 		return fmt.Errorf("连接未打开")
 	}
@@ -507,7 +511,10 @@ func (m *MongoDB) Ping() error {
 	if timeout <= 0 {
 		timeout = 5 * time.Second
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, timeout)
 	defer cancel()
 	return m.client.Ping(ctx, readpref.Primary())
 }
@@ -704,6 +711,10 @@ func buildMembersFromHello(raw bson.M) []connection.MongoMemberInfo {
 }
 
 func (m *MongoDB) DiscoverMembers() (string, []connection.MongoMemberInfo, error) {
+	return m.DiscoverMembersContext(context.Background())
+}
+
+func (m *MongoDB) DiscoverMembersContext(parent context.Context) (string, []connection.MongoMemberInfo, error) {
 	if m.client == nil {
 		return "", nil, fmt.Errorf("连接未打开")
 	}
@@ -712,7 +723,10 @@ func (m *MongoDB) DiscoverMembers() (string, []connection.MongoMemberInfo, error
 	if timeout <= 0 {
 		timeout = 10 * time.Second
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, timeout)
 	defer cancel()
 
 	adminDB := m.client.Database("admin")

--- a/internal/db/mongodb_impl_v1.go
+++ b/internal/db/mongodb_impl_v1.go
@@ -491,6 +491,10 @@ func (m *MongoDBV1) Close() error {
 }
 
 func (m *MongoDBV1) Ping() error {
+	return m.PingContext(context.Background())
+}
+
+func (m *MongoDBV1) PingContext(parent context.Context) error {
 	if m.client == nil {
 		return fmt.Errorf("连接未打开")
 	}
@@ -498,7 +502,10 @@ func (m *MongoDBV1) Ping() error {
 	if timeout <= 0 {
 		timeout = 5 * time.Second
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, timeout)
 	defer cancel()
 	return m.client.Ping(ctx, readpref.Primary())
 }
@@ -695,6 +702,10 @@ func buildMembersFromHello(raw bson.M) []connection.MongoMemberInfo {
 }
 
 func (m *MongoDBV1) DiscoverMembers() (string, []connection.MongoMemberInfo, error) {
+	return m.DiscoverMembersContext(context.Background())
+}
+
+func (m *MongoDBV1) DiscoverMembersContext(parent context.Context) (string, []connection.MongoMemberInfo, error) {
 	if m.client == nil {
 		return "", nil, fmt.Errorf("连接未打开")
 	}
@@ -703,7 +714,10 @@ func (m *MongoDBV1) DiscoverMembers() (string, []connection.MongoMemberInfo, err
 	if timeout <= 0 {
 		timeout = 10 * time.Second
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, timeout)
 	defer cancel()
 
 	adminDB := m.client.Database("admin")

--- a/internal/db/optional_driver_agent_impl.go
+++ b/internal/db/optional_driver_agent_impl.go
@@ -1358,12 +1358,19 @@ func (d *OptionalDriverAgentDB) GetCreateStatement(dbName, tableName string) (st
 }
 
 func (d *OptionalDriverAgentDB) GetColumns(dbName, tableName string) ([]connection.ColumnDefinition, error) {
+	return d.GetColumnsContext(metadataContextFor(d), dbName, tableName)
+}
+
+func (d *OptionalDriverAgentDB) GetColumnsContext(ctx context.Context, dbName, tableName string) ([]connection.ColumnDefinition, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	client, err := d.requireClient()
 	if err != nil {
 		return nil, err
 	}
 	var columns []connection.ColumnDefinition
-	if err := client.callWithContext(metadataContextFor(d), optionalAgentRequest{
+	if err := client.callWithContext(ctx, optionalAgentRequest{
 		Method:    optionalAgentMethodGetColumns,
 		DBName:    dbName,
 		TableName: tableName,

--- a/internal/db/sqlite_impl.go
+++ b/internal/db/sqlite_impl.go
@@ -312,13 +312,24 @@ func (s *SQLiteDB) GetCreateStatement(dbName, tableName string) (string, error) 
 }
 
 func (s *SQLiteDB) GetColumns(dbName, tableName string) ([]connection.ColumnDefinition, error) {
+	return s.getColumnsContext(metadataContextFor(s), dbName, tableName)
+}
+
+func (s *SQLiteDB) GetColumnsContext(ctx context.Context, dbName, tableName string) ([]connection.ColumnDefinition, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return s.getColumnsContext(ctx, dbName, tableName)
+}
+
+func (s *SQLiteDB) getColumnsContext(ctx context.Context, dbName, tableName string) ([]connection.ColumnDefinition, error) {
 	table := strings.TrimSpace(tableName)
 	if table == "" {
 		return nil, localizedDatabaseRuntimeError("db.backend.error.table_name_required", nil)
 	}
 
 	// cid, name, type, notnull, dflt_value, pk
-	data, _, err := s.Query(fmt.Sprintf("PRAGMA table_info('%s')", escapeSQLiteStringLiteral(table)))
+	data, _, err := s.QueryContext(ctx, fmt.Sprintf("PRAGMA table_info('%s')", escapeSQLiteStringLiteral(table)))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/redis/redis_impl.go
+++ b/internal/redis/redis_impl.go
@@ -895,7 +895,7 @@ func (r *RedisClientImpl) GetKeyType(key string) (string, error) {
 	if r.client == nil {
 		return "", fmt.Errorf("Redis 客户端未连接")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(r), 5*time.Second)
 	defer cancel()
 	return r.client.Type(ctx, r.toPhysicalKey(key)).Result()
 }
@@ -905,7 +905,7 @@ func (r *RedisClientImpl) GetTTL(key string) (int64, error) {
 	if r.client == nil {
 		return 0, fmt.Errorf("Redis 客户端未连接")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(r), 5*time.Second)
 	defer cancel()
 
 	ttl, err := r.client.TTL(ctx, r.toPhysicalKey(key)).Result()
@@ -993,7 +993,7 @@ func (r *RedisClientImpl) GetValue(key string) (*RedisValue, error) {
 		TTL:  ttl,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(metadataContextFor(r), 30*time.Second)
 	defer cancel()
 
 	switch keyType {

--- a/internal/redis/redis_impl_test.go
+++ b/internal/redis/redis_impl_test.go
@@ -122,6 +122,22 @@ func redisBulkString(value string) string {
 	return fmt.Sprintf("$%d\r\n%s\r\n", len(value), value)
 }
 
+func TestGetValueObservesBoundMetadataContext(t *testing.T) {
+	rawClient := goredis.NewClient(&goredis.Options{Addr: "127.0.0.1:0", Protocol: 2})
+	client := &RedisClientImpl{client: rawClient, singleClient: rawClient}
+	t.Cleanup(func() { _ = client.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	BindMetadataContext(client, ctx)
+	t.Cleanup(func() { ClearMetadataContext(client) })
+
+	_, err := client.GetValue("session:1")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetValue() error = %v, want context.Canceled", err)
+	}
+}
+
 func TestScanKeysKeepsEntireRedisScanBatch(t *testing.T) {
 	addr := startRedisProtocolTestServer(t, func(args []string) string {
 		switch strings.ToUpper(strings.TrimSpace(args[0])) {

--- a/internal/sync/analyze.go
+++ b/internal/sync/analyze.go
@@ -1,7 +1,10 @@
 package sync
 
 import (
+	"GoNavi-Wails/internal/db"
 	"GoNavi-Wails/internal/logger"
+	"context"
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -41,9 +44,25 @@ type SyncAnalyzeResult struct {
 }
 
 func (s *SyncEngine) Analyze(config SyncConfig) SyncAnalyzeResult {
+	runner := &SyncEngine{reporter: s.reporter, ctx: context.Background()}
+	return runner.analyze(config)
+}
+
+func (s *SyncEngine) AnalyzeContext(ctx context.Context, config SyncConfig) SyncAnalyzeResult {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	runner := &SyncEngine{reporter: s.reporter, ctx: markSyncDriverContext(ctx)}
+	return runner.analyze(config)
+}
+
+func (s *SyncEngine) analyze(config SyncConfig) SyncAnalyzeResult {
 	config = normalizeSyncConnectionDatabases(config)
 	config = normalizeMappedSyncTables(config)
 	result := SyncAnalyzeResult{Success: true, Tables: []TableDiffSummary{}}
+	if err := s.contextError(); err != nil {
+		return SyncAnalyzeResult{Success: false, Message: err.Error(), Tables: []TableDiffSummary{}}
+	}
 	if err := validateSyncMappings(config); err != nil {
 		result.Success = false
 		result.Message = err.Error()
@@ -105,18 +124,59 @@ func (s *SyncEngine) Analyze(config SyncConfig) SyncAnalyzeResult {
 	}
 
 	if err := sourceDB.Connect(config.SourceConfig); err != nil {
+		if contextErr := s.contextError(); contextErr != nil {
+			return SyncAnalyzeResult{Success: false, Message: contextErr.Error(), Tables: []TableDiffSummary{}}
+		}
 		logger.Error(err, "源数据库连接失败：%s", formatConnSummaryForSync(config.SourceConfig))
 		return SyncAnalyzeResult{Success: false, Message: localizedSyncBackendDetailText("data_sync.backend.error.connect_source_failed", err)}
 	}
+	if err := s.contextError(); err != nil {
+		_ = sourceDB.Close()
+		return SyncAnalyzeResult{Success: false, Message: err.Error(), Tables: []TableDiffSummary{}}
+	}
 	defer sourceDB.Close()
+	db.BindMetadataContext(sourceDB, s.context())
+	defer db.ClearMetadataContext(sourceDB)
 
 	if err := targetDB.Connect(config.TargetConfig); err != nil {
+		if contextErr := s.contextError(); contextErr != nil {
+			return SyncAnalyzeResult{Success: false, Message: contextErr.Error(), Tables: []TableDiffSummary{}}
+		}
 		logger.Error(err, "目标数据库连接失败：%s", formatConnSummaryForSync(config.TargetConfig))
 		return SyncAnalyzeResult{Success: false, Message: localizedSyncBackendDetailText("data_sync.backend.error.connect_target_failed", err)}
 	}
+	if err := s.contextError(); err != nil {
+		_ = targetDB.Close()
+		return SyncAnalyzeResult{Success: false, Message: err.Error(), Tables: []TableDiffSummary{}}
+	}
 	defer targetDB.Close()
+	db.BindMetadataContext(targetDB, s.context())
+	defer db.ClearMetadataContext(targetDB)
+
+	cancelled := false
+	recordCancellation := func(err error) bool {
+		contextErr := s.contextError()
+		if contextErr == nil {
+			switch {
+			case errors.Is(err, context.Canceled):
+				contextErr = context.Canceled
+			case errors.Is(err, context.DeadlineExceeded):
+				contextErr = context.DeadlineExceeded
+			default:
+				return false
+			}
+		}
+		cancelled = true
+		result.Success = false
+		result.Message = contextErr.Error()
+		return true
+	}
 
 	for i, tableName := range config.Tables {
+		if err := s.contextError(); err != nil {
+			recordCancellation(err)
+			break
+		}
 		func() {
 			s.progress(config.JobID, i, totalTables, tableName, localizedSyncBackendText("data_sync.progress.stage.analyzing_table", map[string]any{
 				"current": i + 1,
@@ -136,6 +196,7 @@ func (s *SyncEngine) Analyze(config SyncConfig) SyncAnalyzeResult {
 
 			plan, cols, targetCols, err := buildSchemaMigrationPlan(config, tableName, sourceDB, targetDB)
 			if err != nil {
+				recordCancellation(err)
 				summary.Message = err.Error()
 				result.Tables = append(result.Tables, summary)
 				return
@@ -225,15 +286,17 @@ func (s *SyncEngine) Analyze(config SyncConfig) SyncAnalyzeResult {
 
 			sourceType := resolveMigrationDBType(config.SourceConfig)
 			targetType := resolveMigrationDBType(config.TargetConfig)
-			sourceCount, counted, err := countTableRowsForSync(sourceDB, sourceType, plan.SourceQueryTable)
+			sourceCount, counted, err := countTableRowsForSyncContext(s.context(), sourceDB, sourceType, plan.SourceQueryTable)
 			if err != nil {
+				recordCancellation(err)
 				summary.Message = localizedSyncBackendDetailText("data_sync.backend.error.read_source_table_failed", err)
 				result.Tables = append(result.Tables, summary)
 				return
 			}
 			if !counted {
-				sourceRows, _, err := sourceDB.Query(fmt.Sprintf("SELECT * FROM %s", quoteQualifiedIdentByType(sourceType, plan.SourceQueryTable)))
+				sourceRows, _, err := querySyncDatabaseContext(s.context(), sourceDB, fmt.Sprintf("SELECT * FROM %s", quoteQualifiedIdentByType(sourceType, plan.SourceQueryTable)))
 				if err != nil {
+					recordCancellation(err)
 					summary.Message = localizedSyncBackendDetailText("data_sync.backend.error.read_source_table_failed", err)
 					result.Tables = append(result.Tables, summary)
 					return
@@ -277,10 +340,11 @@ func (s *SyncEngine) Analyze(config SyncConfig) SyncAnalyzeResult {
 			counts := pagedDiffCounts{}
 			var scanErr error
 			if !hasExplicitSyncMappings(config) && len(pkCols) == 1 {
-				handled, counts, scanErr = scanTableDiffInPages(sourceDB, targetDB, sourceType, targetType, plan, cols, targetCols, sourcePKCol, targetColSet, true, nil)
+				handled, counts, scanErr = scanTableDiffInPagesContext(s.context(), sourceDB, targetDB, sourceType, targetType, plan, cols, targetCols, sourcePKCol, targetColSet, true, nil)
 			}
 			if handled {
 				if scanErr != nil {
+					recordCancellation(scanErr)
 					summary.Message = scanErr.Error()
 					result.Tables = append(result.Tables, summary)
 					return
@@ -307,8 +371,9 @@ func (s *SyncEngine) Analyze(config SyncConfig) SyncAnalyzeResult {
 				return
 			}
 
-			sourceRows, _, err := sourceDB.Query(fmt.Sprintf("SELECT * FROM %s", quoteQualifiedIdentByType(sourceType, plan.SourceQueryTable)))
+			sourceRows, _, err := querySyncDatabaseContext(s.context(), sourceDB, fmt.Sprintf("SELECT * FROM %s", quoteQualifiedIdentByType(sourceType, plan.SourceQueryTable)))
 			if err != nil {
+				recordCancellation(err)
 				summary.Message = localizedSyncBackendDetailText("data_sync.backend.error.read_source_table_failed", err)
 				result.Tables = append(result.Tables, summary)
 				return
@@ -321,8 +386,9 @@ func (s *SyncEngine) Analyze(config SyncConfig) SyncAnalyzeResult {
 					return
 				}
 			}
-			targetRows, _, err := targetDB.Query(fmt.Sprintf("SELECT * FROM %s", quoteQualifiedIdentByType(targetType, plan.TargetQueryTable)))
+			targetRows, _, err := querySyncDatabaseContext(s.context(), targetDB, fmt.Sprintf("SELECT * FROM %s", quoteQualifiedIdentByType(targetType, plan.TargetQueryTable)))
 			if err != nil {
+				recordCancellation(err)
 				summary.Message = localizedSyncBackendDetailText("data_sync.backend.error.read_target_table_failed", err)
 				result.Tables = append(result.Tables, summary)
 				return
@@ -337,8 +403,14 @@ func (s *SyncEngine) Analyze(config SyncConfig) SyncAnalyzeResult {
 			}
 			result.Tables = append(result.Tables, summary)
 		}()
+		if cancelled {
+			break
+		}
 	}
 
+	if cancelled || recordCancellation(nil) {
+		return result
+	}
 	s.progress(config.JobID, totalTables, totalTables, "", analysisCompletedStage)
 	result.Message = localizedSyncBackendText("data_sync.backend.result.analyzed_tables", map[string]any{
 		"count": len(result.Tables),

--- a/internal/sync/diff_paging.go
+++ b/internal/sync/diff_paging.go
@@ -474,8 +474,12 @@ func buildKeysetPagedTableQuery(dbType, queryTable string, cols []connection.Col
 }
 
 func countTableRowsForSync(database db.Database, dbType, queryTable string) (int, bool, error) {
+	return countTableRowsForSyncContext(context.Background(), database, dbType, queryTable)
+}
+
+func countTableRowsForSyncContext(ctx context.Context, database db.Database, dbType, queryTable string) (int, bool, error) {
 	query := fmt.Sprintf("SELECT COUNT(*) AS __gonavi_count__ FROM %s", quoteQualifiedIdentByType(dbType, queryTable))
-	rows, _, err := database.Query(query)
+	rows, _, err := querySyncDatabaseContext(ctx, database, query)
 	if err != nil {
 		return 0, true, err
 	}

--- a/internal/sync/migration_redis.go
+++ b/internal/sync/migration_redis.go
@@ -4,6 +4,7 @@ import (
 	"GoNavi-Wails/internal/connection"
 	"GoNavi-Wails/internal/db"
 	redispkg "GoNavi-Wails/internal/redis"
+	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -29,6 +30,15 @@ type redisMigrationClient interface {
 
 var newSyncDatabase = db.NewDatabase
 var newRedisSourceClient = func() redisMigrationClient { return redispkg.NewRedisClient() }
+
+func bindRedisMigrationContext(client redisMigrationClient, ctx context.Context) func() {
+	redisClient, ok := client.(redispkg.RedisClient)
+	if !ok || ctx == nil {
+		return func() {}
+	}
+	redispkg.BindMetadataContext(redisClient, ctx)
+	return func() { redispkg.ClearMetadataContext(redisClient) }
+}
 
 func isRedisToMongoKeyspacePair(config SyncConfig) bool {
 	return resolveMigrationDBType(config.SourceConfig) == "redis" && resolveMigrationDBType(config.TargetConfig) == "mongodb"
@@ -105,6 +115,16 @@ func buildRedisToMongoPlan(config SyncConfig, keyName string, targetDB db.Databa
 }
 
 func listRedisMigrationKeys(client redisMigrationClient, selected []string) ([]string, error) {
+	return listRedisMigrationKeysContext(context.Background(), client, selected)
+}
+
+func listRedisMigrationKeysContext(ctx context.Context, client redisMigrationClient, selected []string) ([]string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if len(selected) > 0 {
 		return dedupeStrings(selected), nil
 	}
@@ -112,12 +132,18 @@ func listRedisMigrationKeys(client redisMigrationClient, selected []string) ([]s
 	keys := make([]string, 0, 64)
 	seen := map[string]struct{}{}
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		result, err := client.ScanKeys("*", cursor, 1000)
 		if err != nil {
 			return nil, err
 		}
 		if result != nil {
 			for _, item := range result.Keys {
+				if err := ctx.Err(); err != nil {
+					return nil, err
+				}
 				key := strings.TrimSpace(item.Key)
 				if key == "" {
 					continue
@@ -227,6 +253,10 @@ func buildRedisMongoExistingDocsQuery(collection string, ids []string) (string, 
 }
 
 func loadExistingRedisMongoDocs(targetDB db.Database, collection string, ids []string) (map[string]map[string]interface{}, error) {
+	return loadExistingRedisMongoDocsContext(context.Background(), targetDB, collection, ids)
+}
+
+func loadExistingRedisMongoDocsContext(ctx context.Context, targetDB db.Database, collection string, ids []string) (map[string]map[string]interface{}, error) {
 	result := make(map[string]map[string]interface{}, len(ids))
 	if len(ids) == 0 {
 		return result, nil
@@ -235,11 +265,14 @@ func loadExistingRedisMongoDocs(targetDB db.Database, collection string, ids []s
 	if err != nil {
 		return nil, err
 	}
-	rows, _, err := targetDB.Query(query)
+	rows, _, err := querySyncDatabaseContext(ctx, targetDB, query)
 	if err != nil {
 		return nil, err
 	}
 	for _, row := range rows {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		id := strings.TrimSpace(fmt.Sprintf("%v", row["_id"]))
 		if id == "" || id == "<nil>" {
 			continue
@@ -250,10 +283,17 @@ func loadExistingRedisMongoDocs(targetDB db.Database, collection string, ids []s
 }
 
 func buildRedisMongoChanges(config SyncConfig, keys []string, client redisMigrationClient, targetDB db.Database, collection string) (connection.ChangeSet, []map[string]interface{}, error) {
+	return buildRedisMongoChangesContext(context.Background(), config, keys, client, targetDB, collection)
+}
+
+func buildRedisMongoChangesContext(ctx context.Context, config SyncConfig, keys []string, client redisMigrationClient, targetDB db.Database, collection string) (connection.ChangeSet, []map[string]interface{}, error) {
 	changeSet := connection.ChangeSet{Inserts: []map[string]interface{}{}, Updates: []connection.UpdateRow{}, Deletes: []map[string]interface{}{}}
 	documents := make([]map[string]interface{}, 0, len(keys))
 	dbIndex := resolveRedisDBIndex(config.SourceConfig)
 	for _, key := range keys {
+		if err := ctx.Err(); err != nil {
+			return changeSet, nil, err
+		}
 		value, err := client.GetValue(key)
 		if err != nil {
 			return changeSet, nil, fmt.Errorf("读取 Redis Key 失败: key=%s err=%w", key, err)
@@ -264,12 +304,15 @@ func buildRedisMongoChanges(config SyncConfig, keys []string, client redisMigrat
 	for _, doc := range documents {
 		ids = append(ids, fmt.Sprintf("%v", doc["_id"]))
 	}
-	existing, err := loadExistingRedisMongoDocs(targetDB, collection, ids)
+	existing, err := loadExistingRedisMongoDocsContext(ctx, targetDB, collection, ids)
 	if err != nil {
 		return changeSet, nil, err
 	}
 	mode := normalizeSyncMode(config.Mode)
 	for _, doc := range documents {
+		if err := ctx.Err(); err != nil {
+			return changeSet, nil, err
+		}
 		id := fmt.Sprintf("%v", doc["_id"])
 		existingDoc, ok := existing[id]
 		if !ok {
@@ -414,27 +457,54 @@ func (s *SyncEngine) analyzeRedisToMongo(config SyncConfig) SyncAnalyzeResult {
 	// falling back to the task's compareMode and hiding them under a schema-only
 	// view that this analyzer never populates.
 	result := SyncAnalyzeResult{Success: true, Content: "data", Tables: []TableDiffSummary{}}
+	cancelledResult := func() SyncAnalyzeResult {
+		result.Success = false
+		result.Message = s.contextError().Error()
+		return result
+	}
 	sourceClient := newRedisSourceClient()
 	sourceConfig := withResolvedRedisDB(config.SourceConfig)
 	if err := sourceClient.Connect(sourceConfig); err != nil {
+		if s.contextError() != nil {
+			return cancelledResult()
+		}
 		return SyncAnalyzeResult{Success: false, Message: "源 Redis 连接失败: " + err.Error()}
 	}
 	defer sourceClient.Close()
+	if s.contextError() != nil {
+		return cancelledResult()
+	}
+	clearRedisContext := bindRedisMigrationContext(sourceClient, s.context())
+	defer clearRedisContext()
 	targetDB, err := newSyncDatabase(config.TargetConfig.Type)
 	if err != nil {
 		return SyncAnalyzeResult{Success: false, Message: "初始化目标数据库驱动失败: " + err.Error()}
 	}
 	if err := targetDB.Connect(config.TargetConfig); err != nil {
+		if s.contextError() != nil {
+			return cancelledResult()
+		}
 		return SyncAnalyzeResult{Success: false, Message: "目标数据库连接失败: " + err.Error()}
 	}
 	defer targetDB.Close()
-	keys, err := listRedisMigrationKeys(sourceClient, config.Tables)
+	if s.contextError() != nil {
+		return cancelledResult()
+	}
+	db.BindMetadataContext(targetDB, s.context())
+	defer db.ClearMetadataContext(targetDB)
+	keys, err := listRedisMigrationKeysContext(s.context(), sourceClient, config.Tables)
 	if err != nil {
+		if s.contextError() != nil {
+			return cancelledResult()
+		}
 		return SyncAnalyzeResult{Success: false, Message: "扫描 Redis Key 失败: " + err.Error()}
 	}
 	collection := deriveRedisMongoCollectionName(config)
-	changeSet, documents, err := buildRedisMongoChanges(config, keys, sourceClient, targetDB, collection)
+	changeSet, documents, err := buildRedisMongoChangesContext(s.context(), config, keys, sourceClient, targetDB, collection)
 	if err != nil {
+		if s.contextError() != nil {
+			return cancelledResult()
+		}
 		return SyncAnalyzeResult{Success: false, Message: "分析 Redis 迁移变更失败: " + err.Error()}
 	}
 	insertSet := make(map[string]struct{}, len(changeSet.Inserts))
@@ -446,6 +516,9 @@ func (s *SyncEngine) analyzeRedisToMongo(config SyncConfig) SyncAnalyzeResult {
 		updateSet[fmt.Sprintf("%v", row.Keys["_id"])] = struct{}{}
 	}
 	for _, doc := range documents {
+		if s.contextError() != nil {
+			return cancelledResult()
+		}
 		key := fmt.Sprintf("%v", doc["key"])
 		id := fmt.Sprintf("%v", doc["_id"])
 		summary := TableDiffSummary{
@@ -479,19 +552,35 @@ func (s *SyncEngine) previewRedisToMongo(config SyncConfig, keyName string, limi
 	sourceClient := newRedisSourceClient()
 	sourceConfig := withResolvedRedisDB(config.SourceConfig)
 	if err := sourceClient.Connect(sourceConfig); err != nil {
+		if contextErr := s.contextError(); contextErr != nil {
+			return TableDiffPreview{}, contextErr
+		}
 		return TableDiffPreview{}, fmt.Errorf("源 Redis 连接失败: %w", err)
 	}
 	defer sourceClient.Close()
+	if err := s.contextError(); err != nil {
+		return TableDiffPreview{}, err
+	}
+	clearRedisContext := bindRedisMigrationContext(sourceClient, s.context())
+	defer clearRedisContext()
 	targetDB, err := newSyncDatabase(config.TargetConfig.Type)
 	if err != nil {
 		return TableDiffPreview{}, fmt.Errorf("初始化目标数据库驱动失败: %w", err)
 	}
 	if err := targetDB.Connect(config.TargetConfig); err != nil {
+		if contextErr := s.contextError(); contextErr != nil {
+			return TableDiffPreview{}, contextErr
+		}
 		return TableDiffPreview{}, fmt.Errorf("目标数据库连接失败: %w", err)
 	}
 	defer targetDB.Close()
+	if err := s.contextError(); err != nil {
+		return TableDiffPreview{}, err
+	}
+	db.BindMetadataContext(targetDB, s.context())
+	defer db.ClearMetadataContext(targetDB)
 	collection := deriveRedisMongoCollectionName(config)
-	changeSet, documents, err := buildRedisMongoChanges(config, []string{keyName}, sourceClient, targetDB, collection)
+	changeSet, documents, err := buildRedisMongoChangesContext(s.context(), config, []string{keyName}, sourceClient, targetDB, collection)
 	if err != nil {
 		return TableDiffPreview{}, err
 	}
@@ -501,7 +590,7 @@ func (s *SyncEngine) previewRedisToMongo(config SyncConfig, keyName string, limi
 	}
 	doc := documents[0]
 	id := fmt.Sprintf("%v", doc["_id"])
-	existingDocs, err := loadExistingRedisMongoDocs(targetDB, collection, []string{id})
+	existingDocs, err := loadExistingRedisMongoDocsContext(s.context(), targetDB, collection, []string{id})
 	if err != nil {
 		return TableDiffPreview{}, err
 	}
@@ -558,10 +647,20 @@ func deriveDefaultMongoRedisCollection(config SyncConfig) string {
 }
 
 func listMongoRedisCollections(sourceDB db.Database, config SyncConfig) ([]string, error) {
+	return listMongoRedisCollectionsContext(context.Background(), sourceDB, config)
+}
+
+func listMongoRedisCollectionsContext(ctx context.Context, sourceDB db.Database, config SyncConfig) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if len(config.Tables) > 0 {
 		return dedupeStrings(config.Tables), nil
 	}
 	tables, err := sourceDB.GetTables(strings.TrimSpace(selectedSyncSourceDatabase(config)))
+	if contextErr := ctx.Err(); contextErr != nil {
+		return nil, contextErr
+	}
 	if err == nil && len(tables) > 0 {
 		return dedupeStrings(tables), nil
 	}
@@ -584,11 +683,15 @@ func buildMongoRedisFindQuery(collection string, limit int) (string, error) {
 }
 
 func loadMongoRedisDocuments(sourceDB db.Database, collection string, limit int) ([]map[string]interface{}, error) {
+	return loadMongoRedisDocumentsContext(context.Background(), sourceDB, collection, limit)
+}
+
+func loadMongoRedisDocumentsContext(ctx context.Context, sourceDB db.Database, collection string, limit int) ([]map[string]interface{}, error) {
 	query, err := buildMongoRedisFindQuery(collection, limit)
 	if err != nil {
 		return nil, err
 	}
-	rows, _, err := sourceDB.Query(query)
+	rows, _, err := querySyncDatabaseContext(ctx, sourceDB, query)
 	if err != nil {
 		return nil, err
 	}
@@ -683,18 +786,25 @@ func parseMongoRedisDocument(row map[string]interface{}) (mongoRedisKeyDocument,
 }
 
 func buildMongoToRedisDiffs(sourceDB db.Database, targetClient redisMigrationClient, collection string, mode string) ([]mongoRedisKeyDiff, error) {
-	rows, err := loadMongoRedisDocuments(sourceDB, collection, 0)
+	return buildMongoToRedisDiffsContext(context.Background(), sourceDB, targetClient, collection, mode)
+}
+
+func buildMongoToRedisDiffsContext(ctx context.Context, sourceDB db.Database, targetClient redisMigrationClient, collection string, mode string) ([]mongoRedisKeyDiff, error) {
+	rows, err := loadMongoRedisDocumentsContext(ctx, sourceDB, collection, 0)
 	if err != nil {
 		return nil, err
 	}
 	diffs := make([]mongoRedisKeyDiff, 0, len(rows))
 	effectiveMode := normalizeSyncMode(mode)
 	for _, row := range rows {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		doc, err := parseMongoRedisDocument(row)
 		if err != nil {
 			return nil, err
 		}
-		current, exists, err := loadExistingRedisMigrationValue(targetClient, doc.Key)
+		current, exists, err := loadExistingRedisMigrationValueContext(ctx, targetClient, doc.Key)
 		if err != nil {
 			return nil, fmt.Errorf("读取目标 Redis Key 失败: key=%s err=%w", doc.Key, err)
 		}
@@ -726,6 +836,13 @@ func buildMongoToRedisDiffs(sourceDB db.Database, targetClient redisMigrationCli
 }
 
 func loadExistingRedisMigrationValue(client redisMigrationClient, key string) (*redispkg.RedisValue, bool, error) {
+	return loadExistingRedisMigrationValueContext(context.Background(), client, key)
+}
+
+func loadExistingRedisMigrationValueContext(ctx context.Context, client redisMigrationClient, key string) (*redispkg.RedisValue, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
 	keyType, err := client.GetKeyType(key)
 	if err != nil {
 		return nil, false, err
@@ -733,6 +850,9 @@ func loadExistingRedisMigrationValue(client redisMigrationClient, key string) (*
 	keyType = strings.ToLower(strings.TrimSpace(keyType))
 	if keyType == "" || keyType == "none" {
 		return nil, false, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
 	}
 	value, err := client.GetValue(key)
 	if err != nil {
@@ -1201,17 +1321,33 @@ func (s *SyncEngine) analyzeMongoToRedis(config SyncConfig) SyncAnalyzeResult {
 	// See analyzeRedisToMongo: keyspace migration is data-only, so pin the
 	// echoed content rather than letting the UI fall back to compareMode.
 	result := SyncAnalyzeResult{Success: true, Content: "data", Tables: []TableDiffSummary{}}
+	cancelledResult := func() SyncAnalyzeResult {
+		result.Success = false
+		result.Message = s.contextError().Error()
+		return result
+	}
 	sourceDB, err := newSyncDatabase(config.SourceConfig.Type)
 	if err != nil {
 		return SyncAnalyzeResult{Success: false, Message: "初始化源数据库驱动失败: " + err.Error()}
 	}
 	if err := sourceDB.Connect(config.SourceConfig); err != nil {
+		if s.contextError() != nil {
+			return cancelledResult()
+		}
 		return SyncAnalyzeResult{Success: false, Message: "源 MongoDB 连接失败: " + err.Error()}
 	}
 	defer sourceDB.Close()
+	if s.contextError() != nil {
+		return cancelledResult()
+	}
+	db.BindMetadataContext(sourceDB, s.context())
+	defer db.ClearMetadataContext(sourceDB)
 
-	collections, err := listMongoRedisCollections(sourceDB, config)
+	collections, err := listMongoRedisCollectionsContext(s.context(), sourceDB, config)
 	if err != nil {
+		if s.contextError() != nil {
+			return cancelledResult()
+		}
 		return SyncAnalyzeResult{Success: false, Message: "获取 MongoDB 集合列表失败: " + err.Error()}
 	}
 
@@ -1225,11 +1361,22 @@ func (s *SyncEngine) analyzeMongoToRedis(config SyncConfig) SyncAnalyzeResult {
 	targetClient := newRedisSourceClient()
 	targetConfig := withResolvedRedisDB(config.TargetConfig)
 	if err := targetClient.Connect(targetConfig); err != nil {
+		if s.contextError() != nil {
+			return cancelledResult()
+		}
 		return SyncAnalyzeResult{Success: false, Message: "目标 Redis 连接失败: " + err.Error()}
 	}
 	defer targetClient.Close()
+	if s.contextError() != nil {
+		return cancelledResult()
+	}
+	clearRedisContext := bindRedisMigrationContext(targetClient, s.context())
+	defer clearRedisContext()
 
 	for _, collection := range collections {
+		if s.contextError() != nil {
+			return cancelledResult()
+		}
 		summary := TableDiffSummary{
 			Table:             collection,
 			PKColumn:          "key",
@@ -1244,8 +1391,11 @@ func (s *SyncEngine) analyzeMongoToRedis(config SyncConfig) SyncAnalyzeResult {
 		if modeWarning != "" {
 			summary.Warnings = append(summary.Warnings, modeWarning)
 		}
-		diffs, err := buildMongoToRedisDiffs(sourceDB, targetClient, collection, effectiveMode)
+		diffs, err := buildMongoToRedisDiffsContext(s.context(), sourceDB, targetClient, collection, effectiveMode)
 		if err != nil {
+			if s.contextError() != nil {
+				return cancelledResult()
+			}
 			summary.CanSync = false
 			summary.Message = err.Error()
 			result.Tables = append(result.Tables, summary)
@@ -1282,28 +1432,47 @@ func (s *SyncEngine) previewMongoToRedis(config SyncConfig, collection string, l
 		return TableDiffPreview{}, fmt.Errorf("初始化源数据库驱动失败: %w", err)
 	}
 	if err := sourceDB.Connect(config.SourceConfig); err != nil {
+		if contextErr := s.contextError(); contextErr != nil {
+			return TableDiffPreview{}, contextErr
+		}
 		return TableDiffPreview{}, fmt.Errorf("源 MongoDB 连接失败: %w", err)
 	}
 	defer sourceDB.Close()
+	if err := s.contextError(); err != nil {
+		return TableDiffPreview{}, err
+	}
+	db.BindMetadataContext(sourceDB, s.context())
+	defer db.ClearMetadataContext(sourceDB)
 
 	targetClient := newRedisSourceClient()
 	targetConfig := withResolvedRedisDB(config.TargetConfig)
 	if err := targetClient.Connect(targetConfig); err != nil {
+		if contextErr := s.contextError(); contextErr != nil {
+			return TableDiffPreview{}, contextErr
+		}
 		return TableDiffPreview{}, fmt.Errorf("目标 Redis 连接失败: %w", err)
 	}
 	defer targetClient.Close()
+	if err := s.contextError(); err != nil {
+		return TableDiffPreview{}, err
+	}
+	clearRedisContext := bindRedisMigrationContext(targetClient, s.context())
+	defer clearRedisContext()
 
 	effectiveMode := normalizeSyncMode(config.Mode)
 	if effectiveMode == "full_overwrite" {
 		effectiveMode = "insert_update"
 	}
 
-	diffs, err := buildMongoToRedisDiffs(sourceDB, targetClient, collection, effectiveMode)
+	diffs, err := buildMongoToRedisDiffsContext(s.context(), sourceDB, targetClient, collection, effectiveMode)
 	if err != nil {
 		return TableDiffPreview{}, err
 	}
 	preview := TableDiffPreview{Table: collection, PKColumn: "key", Inserts: []PreviewRow{}, Updates: []PreviewUpdateRow{}, Deletes: []PreviewRow{}}
 	for _, diff := range diffs {
+		if err := s.contextError(); err != nil {
+			return TableDiffPreview{}, err
+		}
 		switch diff.Action {
 		case "insert":
 			preview.TotalInserts++

--- a/internal/sync/preview.go
+++ b/internal/sync/preview.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"GoNavi-Wails/internal/connection"
 	"GoNavi-Wails/internal/db"
+	"context"
 	"fmt"
 	"strings"
 )
@@ -41,8 +42,24 @@ type TableDiffPreview struct {
 }
 
 func (s *SyncEngine) Preview(config SyncConfig, tableName string, limit int) (TableDiffPreview, error) {
+	runner := &SyncEngine{reporter: s.reporter, ctx: context.Background()}
+	return runner.preview(config, tableName, limit)
+}
+
+func (s *SyncEngine) PreviewContext(ctx context.Context, config SyncConfig, tableName string, limit int) (TableDiffPreview, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	runner := &SyncEngine{reporter: s.reporter, ctx: markSyncDriverContext(ctx)}
+	return runner.preview(config, tableName, limit)
+}
+
+func (s *SyncEngine) preview(config SyncConfig, tableName string, limit int) (TableDiffPreview, error) {
 	config = normalizeSyncConnectionDatabases(config)
 	config = normalizeMappedSyncTables(config)
+	if err := s.contextError(); err != nil {
+		return TableDiffPreview{}, err
+	}
 	if limit <= 0 {
 		limit = 200
 	}
@@ -77,12 +94,24 @@ func (s *SyncEngine) Preview(config SyncConfig, tableName string, limit int) (Ta
 	if err := sourceDB.Connect(config.SourceConfig); err != nil {
 		return TableDiffPreview{}, syncWrapDetailError("data_sync.backend.error.connect_source_failed", err)
 	}
+	if err := s.contextError(); err != nil {
+		_ = sourceDB.Close()
+		return TableDiffPreview{}, err
+	}
 	defer sourceDB.Close()
+	db.BindMetadataContext(sourceDB, s.context())
+	defer db.ClearMetadataContext(sourceDB)
 
 	if err := targetDB.Connect(config.TargetConfig); err != nil {
 		return TableDiffPreview{}, syncWrapDetailError("data_sync.backend.error.connect_target_failed", err)
 	}
+	if err := s.contextError(); err != nil {
+		_ = targetDB.Close()
+		return TableDiffPreview{}, err
+	}
 	defer targetDB.Close()
+	db.BindMetadataContext(targetDB, s.context())
+	defer db.ClearMetadataContext(targetDB)
 
 	plan, cols, targetCols, err := buildSchemaMigrationPlan(config, tableName, sourceDB, targetDB)
 	if err != nil {
@@ -192,7 +221,7 @@ func (s *SyncEngine) Preview(config SyncConfig, tableName string, limit int) (Ta
 
 	handled := false
 	if !hasExplicitSyncMappings(config) && len(pkCols) == 1 {
-		handled, _, err = scanTableDiffInPages(sourceDB, targetDB, sourceType, targetType, plan, cols, nil, sourcePKCol, targetColSet, true, func(page pagedDiffPage) error {
+		handled, _, err = scanTableDiffInPagesContext(s.context(), sourceDB, targetDB, sourceType, targetType, plan, cols, nil, sourcePKCol, targetColSet, true, func(page pagedDiffPage) error {
 			out.TotalInserts += len(page.Inserts)
 			out.TotalUpdates += len(page.Updates)
 			out.TotalDeletes += len(page.Deletes)
@@ -242,7 +271,7 @@ func (s *SyncEngine) Preview(config SyncConfig, tableName string, limit int) (Ta
 		return out, nil
 	}
 
-	sourceRows, _, err := sourceDB.Query(fmt.Sprintf("SELECT * FROM %s", quoteQualifiedIdentByType(sourceType, plan.SourceQueryTable)))
+	sourceRows, _, err := querySyncDatabaseContext(s.context(), sourceDB, fmt.Sprintf("SELECT * FROM %s", quoteQualifiedIdentByType(sourceType, plan.SourceQueryTable)))
 	if err != nil {
 		return TableDiffPreview{}, fmt.Errorf("读取源表失败: %w", err)
 	}
@@ -255,7 +284,7 @@ func (s *SyncEngine) Preview(config SyncConfig, tableName string, limit int) (Ta
 
 	targetRows := make([]map[string]interface{}, 0)
 	if plan.TargetTableExists {
-		targetRows, _, err = targetDB.Query(fmt.Sprintf("SELECT * FROM %s", quoteQualifiedIdentByType(targetType, plan.TargetQueryTable)))
+		targetRows, _, err = querySyncDatabaseContext(s.context(), targetDB, fmt.Sprintf("SELECT * FROM %s", quoteQualifiedIdentByType(targetType, plan.TargetQueryTable)))
 		if err != nil {
 			return TableDiffPreview{}, fmt.Errorf("读取目标表失败: %w", err)
 		}
@@ -312,7 +341,7 @@ func (s *SyncEngine) Preview(config SyncConfig, tableName string, limit int) (Ta
 // therefore must not require or manufacture a stable key.
 func (s *SyncEngine) previewInsertOnlyTable(config SyncConfig, tableName string, limit int, sourceDB db.Database, plan SchemaMigrationPlan, cols, targetCols []connection.ColumnDefinition, projection *CompiledProjection, schemaStatements, selectionKeyCols []string) (TableDiffPreview, error) {
 	sourceType := resolveMigrationDBType(config.SourceConfig)
-	sourceCount, counted, err := countTableRowsForSync(sourceDB, sourceType, plan.SourceQueryTable)
+	sourceCount, counted, err := countTableRowsForSyncContext(s.context(), sourceDB, sourceType, plan.SourceQueryTable)
 	if err != nil {
 		return TableDiffPreview{}, fmt.Errorf("读取源表数量失败: %w", err)
 	}
@@ -320,7 +349,7 @@ func (s *SyncEngine) previewInsertOnlyTable(config SyncConfig, tableName string,
 	if strings.TrimSpace(query) == "" {
 		return TableDiffPreview{}, fmt.Errorf("当前数据源不支持分页预览")
 	}
-	sourceRows, _, err := sourceDB.Query(query)
+	sourceRows, _, err := querySyncDatabaseContext(s.context(), sourceDB, query)
 	if err != nil {
 		return TableDiffPreview{}, fmt.Errorf("读取源表失败: %w", err)
 	}

--- a/internal/sync/source_query_paging.go
+++ b/internal/sync/source_query_paging.go
@@ -333,12 +333,16 @@ func buildSourceQueryPKInSelectSQL(dbType, sourceQuery string, cols []connection
 }
 
 func countSourceQueryRowsForSync(database db.Database, dbType, sourceQuery string) (int, bool, error) {
+	return countSourceQueryRowsForSyncContext(context.Background(), database, dbType, sourceQuery)
+}
+
+func countSourceQueryRowsForSyncContext(ctx context.Context, database db.Database, dbType, sourceQuery string) (int, bool, error) {
 	subquery, ok := normalizeSourceQueryForPaging(sourceQuery)
 	if !ok {
 		return 0, false, nil
 	}
 	query := fmt.Sprintf("SELECT COUNT(*) AS __gonavi_count__ FROM (%s) AS __gonavi_source_query__", subquery)
-	rows, _, err := database.Query(query)
+	rows, _, err := querySyncDatabaseContext(ctx, database, query)
 	if err != nil {
 		return 0, true, err
 	}

--- a/internal/sync/source_query_sync.go
+++ b/internal/sync/source_query_sync.go
@@ -109,6 +109,12 @@ func loadSourceQuerySyncContext(config SyncConfig, sourceDB db.Database, targetD
 }
 
 func loadSourceQuerySyncContextWithContext(runCtx context.Context, config SyncConfig, sourceDB db.Database, targetDB db.Database, needSourceRows bool, needTargetRows bool, requirePK bool) (sourceQuerySyncContext, error) {
+	if runCtx == nil {
+		runCtx = context.Background()
+	}
+	if err := runCtx.Err(); err != nil {
+		return sourceQuerySyncContext{}, err
+	}
 	tableName, err := validateSourceQuerySyncConfig(config)
 	if err != nil {
 		return sourceQuerySyncContext{}, err
@@ -118,6 +124,9 @@ func loadSourceQuerySyncContextWithContext(runCtx context.Context, config SyncCo
 	targetCols, err := targetDB.GetColumns(targetSchema, targetTable)
 	if err != nil {
 		return sourceQuerySyncContext{}, syncWrapDetailError("data_sync.backend.error.load_target_columns_failed", err)
+	}
+	if err := runCtx.Err(); err != nil {
+		return sourceQuerySyncContext{}, err
 	}
 	if len(targetCols) == 0 {
 		return sourceQuerySyncContext{}, syncTextError("data_sync.backend.error.target_table_columns_missing", map[string]any{
@@ -302,6 +311,19 @@ func (s *SyncEngine) analyzeSourceQuery(config SyncConfig) SyncAnalyzeResult {
 	// echo it explicitly instead of leaving the field empty and letting the UI
 	// fall back to the task's compareMode.
 	result := SyncAnalyzeResult{Success: true, Content: "data", Tables: []TableDiffSummary{}}
+	cancelledResult := func(summary *TableDiffSummary) SyncAnalyzeResult {
+		err := s.contextError()
+		if err == nil {
+			return result
+		}
+		result.Success = false
+		result.Message = err.Error()
+		if summary != nil {
+			summary.Message = err.Error()
+			result.Tables = append(result.Tables, *summary)
+		}
+		return result
+	}
 	tableName, err := validateSourceQuerySyncConfig(config)
 	if err != nil {
 		return SyncAnalyzeResult{Success: false, Message: err.Error()}
@@ -326,14 +348,32 @@ func (s *SyncEngine) analyzeSourceQuery(config SyncConfig) SyncAnalyzeResult {
 	}
 
 	if err := sourceDB.Connect(config.SourceConfig); err != nil {
+		if s.contextError() != nil {
+			return cancelledResult(nil)
+		}
 		return SyncAnalyzeResult{Success: false, Message: localizedSyncBackendDetailText("data_sync.backend.error.connect_source_failed", err)}
 	}
+	if s.contextError() != nil {
+		_ = sourceDB.Close()
+		return cancelledResult(nil)
+	}
 	defer sourceDB.Close()
+	db.BindMetadataContext(sourceDB, s.context())
+	defer db.ClearMetadataContext(sourceDB)
 
 	if err := targetDB.Connect(config.TargetConfig); err != nil {
+		if s.contextError() != nil {
+			return cancelledResult(nil)
+		}
 		return SyncAnalyzeResult{Success: false, Message: localizedSyncBackendDetailText("data_sync.backend.error.connect_target_failed", err)}
 	}
+	if s.contextError() != nil {
+		_ = targetDB.Close()
+		return cancelledResult(nil)
+	}
 	defer targetDB.Close()
+	db.BindMetadataContext(targetDB, s.context())
+	defer db.ClearMetadataContext(targetDB)
 
 	summary := TableDiffSummary{
 		Table:   tableName,
@@ -341,8 +381,11 @@ func (s *SyncEngine) analyzeSourceQuery(config SyncConfig) SyncAnalyzeResult {
 	}
 	tableMode := normalizeSyncMode(config.Mode)
 	requiresComparisonKey := tableMode == "insert_update"
-	ctx, err := loadSourceQuerySyncContext(config, sourceDB, targetDB, false, false, requiresComparisonKey)
+	ctx, err := loadSourceQuerySyncContextWithContext(s.context(), config, sourceDB, targetDB, false, false, requiresComparisonKey)
 	if err != nil {
+		if s.contextError() != nil {
+			return cancelledResult(&summary)
+		}
 		summary.Message = err.Error()
 		result.Tables = append(result.Tables, summary)
 		result.Message = analyzedTargetTablesMessage
@@ -351,8 +394,11 @@ func (s *SyncEngine) analyzeSourceQuery(config SyncConfig) SyncAnalyzeResult {
 	}
 	if !requiresComparisonKey {
 		sourceType := resolveMigrationDBType(config.SourceConfig)
-		sourceCount, counted, err := countSourceQueryRowsForSync(sourceDB, sourceType, config.SourceQuery)
+		sourceCount, counted, err := countSourceQueryRowsForSyncContext(s.context(), sourceDB, sourceType, config.SourceQuery)
 		if err != nil {
+			if s.contextError() != nil {
+				return cancelledResult(&summary)
+			}
 			summary.Message = localizedSyncBackendDetailText("data_sync.backend.error.execute_source_query_failed", err)
 			result.Tables = append(result.Tables, summary)
 			result.Message = analyzedTargetTablesMessage
@@ -385,10 +431,13 @@ func (s *SyncEngine) analyzeSourceQuery(config SyncConfig) SyncAnalyzeResult {
 	counts := pagedDiffCounts{}
 	var scanErr error
 	if !hasExplicitSyncMappings(config) && len(ctx.PKColumns) == 1 {
-		handled, counts, scanErr = scanSourceQueryDiffInPages(sourceDB, targetDB, sourceType, ctx.TargetType, strings.TrimSpace(config.SourceQuery), ctx.TargetQueryTable, ctx.TargetCols, ctx.PKColumn, true, nil)
+		handled, counts, scanErr = scanSourceQueryDiffInPagesContext(s.context(), sourceDB, targetDB, sourceType, ctx.TargetType, strings.TrimSpace(config.SourceQuery), ctx.TargetQueryTable, ctx.TargetCols, ctx.PKColumn, true, nil)
 	}
 	if handled {
 		if scanErr != nil {
+			if s.contextError() != nil {
+				return cancelledResult(&summary)
+			}
 			summary.Message = scanErr.Error()
 			result.Tables = append(result.Tables, summary)
 			result.Message = analyzedTargetTablesMessage
@@ -409,8 +458,11 @@ func (s *SyncEngine) analyzeSourceQuery(config SyncConfig) SyncAnalyzeResult {
 		return result
 	}
 
-	ctx, err = loadSourceQuerySyncContext(config, sourceDB, targetDB, true, true, true)
+	ctx, err = loadSourceQuerySyncContextWithContext(s.context(), config, sourceDB, targetDB, true, true, true)
 	if err != nil {
+		if s.contextError() != nil {
+			return cancelledResult(&summary)
+		}
 		summary.Message = err.Error()
 		result.Tables = append(result.Tables, summary)
 		result.Message = analyzedTargetTablesMessage
@@ -419,6 +471,9 @@ func (s *SyncEngine) analyzeSourceQuery(config SyncConfig) SyncAnalyzeResult {
 	}
 
 	inserts, updates, deletes, same := diffRowsByKeyColumns(ctx.PKColumns, ctx.SourceRows, ctx.TargetRows)
+	if s.contextError() != nil {
+		return cancelledResult(&summary)
+	}
 	summary.CanSync = true
 	summary.PKColumn = ctx.PKColumn
 	summary.Inserts = len(inserts)
@@ -444,25 +499,43 @@ func (s *SyncEngine) previewSourceQuery(config SyncConfig, limit int) (TableDiff
 	}
 
 	if err := sourceDB.Connect(config.SourceConfig); err != nil {
+		if contextErr := s.contextError(); contextErr != nil {
+			return TableDiffPreview{}, contextErr
+		}
 		return TableDiffPreview{}, syncWrapDetailError("data_sync.backend.error.connect_source_failed", err)
 	}
+	if err := s.contextError(); err != nil {
+		_ = sourceDB.Close()
+		return TableDiffPreview{}, err
+	}
 	defer sourceDB.Close()
+	db.BindMetadataContext(sourceDB, s.context())
+	defer db.ClearMetadataContext(sourceDB)
 
 	if err := targetDB.Connect(config.TargetConfig); err != nil {
+		if contextErr := s.contextError(); contextErr != nil {
+			return TableDiffPreview{}, contextErr
+		}
 		return TableDiffPreview{}, syncWrapDetailError("data_sync.backend.error.connect_target_failed", err)
 	}
+	if err := s.contextError(); err != nil {
+		_ = targetDB.Close()
+		return TableDiffPreview{}, err
+	}
 	defer targetDB.Close()
+	db.BindMetadataContext(targetDB, s.context())
+	defer db.ClearMetadataContext(targetDB)
 
 	tableMode := normalizeSyncMode(config.Mode)
 	requiresComparisonKey := tableMode == "insert_update"
-	ctx, err := loadSourceQuerySyncContext(config, sourceDB, targetDB, false, false, requiresComparisonKey)
+	ctx, err := loadSourceQuerySyncContextWithContext(s.context(), config, sourceDB, targetDB, false, false, requiresComparisonKey)
 	if err != nil {
 		return TableDiffPreview{}, err
 	}
 
 	previewSummary := localizedSyncBackendText("data_sync.plan.source_query_preview", nil)
 	if !requiresComparisonKey {
-		ctx, err = loadSourceQuerySyncContext(config, sourceDB, targetDB, true, false, false)
+		ctx, err = loadSourceQuerySyncContextWithContext(s.context(), config, sourceDB, targetDB, true, false, false)
 		if err != nil {
 			return TableDiffPreview{}, err
 		}
@@ -493,6 +566,9 @@ func (s *SyncEngine) previewSourceQuery(config SyncConfig, limit int) (TableDiff
 			}
 		}
 		for _, row := range ctx.SourceRows {
+			if err := s.contextError(); err != nil {
+				return TableDiffPreview{}, err
+			}
 			if len(out.Inserts) >= limit {
 				break
 			}
@@ -529,7 +605,7 @@ func (s *SyncEngine) previewSourceQuery(config SyncConfig, limit int) (TableDiff
 	handled := false
 	var scanErr error
 	if !hasExplicitSyncMappings(config) && len(ctx.PKColumns) == 1 {
-		handled, _, scanErr = scanSourceQueryDiffInPages(sourceDB, targetDB, sourceType, ctx.TargetType, strings.TrimSpace(config.SourceQuery), ctx.TargetQueryTable, ctx.TargetCols, ctx.PKColumn, true, func(page pagedDiffPage) error {
+		handled, _, scanErr = scanSourceQueryDiffInPagesContext(s.context(), sourceDB, targetDB, sourceType, ctx.TargetType, strings.TrimSpace(config.SourceQuery), ctx.TargetQueryTable, ctx.TargetCols, ctx.PKColumn, true, func(page pagedDiffPage) error {
 			out.TotalInserts += len(page.Inserts)
 			out.TotalUpdates += len(page.Updates)
 			out.TotalDeletes += len(page.Deletes)
@@ -576,12 +652,15 @@ func (s *SyncEngine) previewSourceQuery(config SyncConfig, limit int) (TableDiff
 		return out, nil
 	}
 
-	ctx, err = loadSourceQuerySyncContext(config, sourceDB, targetDB, true, true, true)
+	ctx, err = loadSourceQuerySyncContextWithContext(s.context(), config, sourceDB, targetDB, true, true, true)
 	if err != nil {
 		return TableDiffPreview{}, err
 	}
 
 	inserts, updates, deletes, _ := diffRowsByKeyColumns(ctx.PKColumns, ctx.SourceRows, ctx.TargetRows)
+	if err := s.contextError(); err != nil {
+		return TableDiffPreview{}, err
+	}
 	out = TableDiffPreview{
 		Table:                 ctx.TableName,
 		PKColumn:              ctx.PKColumn,

--- a/internal/sync/sync_engine.go
+++ b/internal/sync/sync_engine.go
@@ -205,6 +205,8 @@ func (s *SyncEngine) runSync(config SyncConfig) SyncResult {
 	if err := s.contextError(); err != nil {
 		return s.fail(config.JobID, totalTables, result, err.Error())
 	}
+	db.BindMetadataContext(sourceDB, s.context())
+	defer db.ClearMetadataContext(sourceDB)
 
 	// Connect Target
 	s.appendLog(config.JobID, &result, "info", fmt.Sprintf("正在连接目标数据库: %s...", config.TargetConfig.Host))
@@ -217,6 +219,11 @@ func (s *SyncEngine) runSync(config SyncConfig) SyncResult {
 		return s.fail(config.JobID, totalTables, result, localizedSyncBackendDetailText("data_sync.backend.error.connect_target_failed", err))
 	}
 	defer targetDB.Close()
+	if err := s.contextError(); err != nil {
+		return s.fail(config.JobID, totalTables, result, err.Error())
+	}
+	db.BindMetadataContext(targetDB, s.context())
+	defer db.ClearMetadataContext(targetDB)
 
 	tableFailures := make([]string, 0)
 	for i, tableName := range config.Tables {

--- a/internal/sync/sync_mapping_integration_test.go
+++ b/internal/sync/sync_mapping_integration_test.go
@@ -3,8 +3,10 @@ package sync
 import (
 	"GoNavi-Wails/internal/connection"
 	"GoNavi-Wails/internal/db"
+	redispkg "GoNavi-Wails/internal/redis"
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"sync"
@@ -418,6 +420,282 @@ func TestRunSyncContextCancelsContextAwareQuery(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("RunSyncContext() did not return after cancellation")
+	}
+}
+
+func TestAnalyzeContextCancelsContextAwareQuery(t *testing.T) {
+	source := &contextAwareSyncDatabase{
+		queryStarted: make(chan struct{}),
+		columns:      []connection.ColumnDefinition{{Name: "id", Type: "NUMBER", Key: "PK"}},
+	}
+	target := &contextTargetSyncDatabase{
+		columns: []connection.ColumnDefinition{{Name: "id", Type: "BIGINT", Key: "PK"}},
+	}
+	originalFactory := newSyncDatabase
+	t.Cleanup(func() { newSyncDatabase = originalFactory })
+	newSyncDatabase = func(databaseType string) (db.Database, error) {
+		if databaseType == "oracle" {
+			return source, nil
+		}
+		return target, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan SyncAnalyzeResult, 1)
+	go func() {
+		resultCh <- NewSyncEngine(Reporter{}).AnalyzeContext(ctx, SyncConfig{
+			SourceConfig:        connection.ConnectionConfig{Type: "oracle"},
+			TargetConfig:        connection.ConnectionConfig{Type: "sqlserver"},
+			SourceDatabase:      "APP",
+			TargetDatabase:      "warehouse",
+			TargetSchema:        "dbo",
+			Tables:              []string{"users"},
+			Content:             "data",
+			Mode:                "insert_only",
+			TargetTableStrategy: "existing_only",
+		})
+	}()
+
+	select {
+	case <-source.queryStarted:
+		cancel()
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for context-aware analyze query")
+	}
+
+	select {
+	case result := <-resultCh:
+		if result.Success || result.Message != context.Canceled.Error() {
+			t.Fatalf("AnalyzeContext() result = %+v, want context-cancelled failure", result)
+		}
+		if len(result.Tables) != 1 || !strings.Contains(result.Tables[0].Message, context.Canceled.Error()) {
+			t.Fatalf("AnalyzeContext() tables = %+v, want cancelled table summary", result.Tables)
+		}
+		if source.legacyCalls != 0 {
+			t.Fatalf("legacy Query calls = %d, want 0", source.legacyCalls)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("AnalyzeContext() did not return after cancellation")
+	}
+}
+
+func TestPreviewContextCancelsContextAwareQuery(t *testing.T) {
+	source := &contextAwareSyncDatabase{
+		queryStarted: make(chan struct{}),
+		columns:      []connection.ColumnDefinition{{Name: "id", Type: "NUMBER", Key: "PK"}},
+	}
+	target := &contextTargetSyncDatabase{
+		columns: []connection.ColumnDefinition{{Name: "id", Type: "BIGINT", Key: "PK"}},
+	}
+	originalFactory := newSyncDatabase
+	t.Cleanup(func() { newSyncDatabase = originalFactory })
+	newSyncDatabase = func(databaseType string) (db.Database, error) {
+		if databaseType == "oracle" {
+			return source, nil
+		}
+		return target, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := NewSyncEngine(Reporter{}).PreviewContext(ctx, SyncConfig{
+			SourceConfig:        connection.ConnectionConfig{Type: "oracle"},
+			TargetConfig:        connection.ConnectionConfig{Type: "sqlserver"},
+			SourceDatabase:      "APP",
+			TargetDatabase:      "warehouse",
+			TargetSchema:        "dbo",
+			Tables:              []string{"users"},
+			Content:             "data",
+			Mode:                "insert_only",
+			TargetTableStrategy: "existing_only",
+		}, "users", 25)
+		errCh <- err
+	}()
+
+	select {
+	case <-source.queryStarted:
+		cancel()
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for context-aware preview query")
+	}
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("PreviewContext() error = %v, want context.Canceled", err)
+		}
+		if source.legacyCalls != 0 {
+			t.Fatalf("legacy Query calls = %d, want 0", source.legacyCalls)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("PreviewContext() did not return after cancellation")
+	}
+}
+
+func TestSourceQueryAnalyzeAndPreviewObserveRequestContext(t *testing.T) {
+	operations := []struct {
+		name string
+		run  func(context.Context, SyncConfig) error
+	}{
+		{
+			name: "analyze",
+			run: func(ctx context.Context, config SyncConfig) error {
+				result := NewSyncEngine(Reporter{}).AnalyzeContext(ctx, config)
+				if result.Success || result.Message != context.Canceled.Error() {
+					return fmt.Errorf("AnalyzeContext() = %+v, want cancelled failure", result)
+				}
+				return context.Canceled
+			},
+		},
+		{
+			name: "preview",
+			run: func(ctx context.Context, config SyncConfig) error {
+				_, err := NewSyncEngine(Reporter{}).PreviewContext(ctx, config, "users", 25)
+				return err
+			},
+		},
+	}
+
+	for _, operation := range operations {
+		t.Run(operation.name, func(t *testing.T) {
+			source := &contextAwareSyncDatabase{
+				queryStarted: make(chan struct{}),
+				columns:      []connection.ColumnDefinition{{Name: "id", Type: "NUMBER", Key: "PK"}},
+			}
+			target := &contextTargetSyncDatabase{
+				columns: []connection.ColumnDefinition{{Name: "id", Type: "BIGINT", Key: "PK"}},
+			}
+			originalFactory := newSyncDatabase
+			t.Cleanup(func() { newSyncDatabase = originalFactory })
+			newSyncDatabase = func(databaseType string) (db.Database, error) {
+				if databaseType == "oracle" {
+					return source, nil
+				}
+				return target, nil
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			errCh := make(chan error, 1)
+			go func() {
+				errCh <- operation.run(ctx, SyncConfig{
+					SourceConfig:   connection.ConnectionConfig{Type: "oracle"},
+					TargetConfig:   connection.ConnectionConfig{Type: "sqlserver"},
+					SourceDatabase: "APP",
+					TargetDatabase: "warehouse",
+					TargetSchema:   "dbo",
+					Tables:         []string{"users"},
+					SourceQuery:    "SELECT id FROM active_users",
+					Content:        "data",
+					Mode:           "insert_only",
+				})
+			}()
+
+			select {
+			case <-source.queryStarted:
+				cancel()
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for source-query execution")
+			}
+
+			select {
+			case err := <-errCh:
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("%s error = %v, want context.Canceled", operation.name, err)
+				}
+				if source.legacyCalls != 0 {
+					t.Fatalf("legacy Query calls = %d, want 0", source.legacyCalls)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatalf("%s did not return after cancellation", operation.name)
+			}
+		})
+	}
+}
+
+func TestRedisMongoAnalyzeAndPreviewObserveRequestContext(t *testing.T) {
+	operations := []struct {
+		name           string
+		config         SyncConfig
+		blockingDBType string
+		run            func(context.Context, SyncConfig) error
+	}{
+		{
+			name: "redis_to_mongo_analyze",
+			config: SyncConfig{
+				SourceConfig: connection.ConnectionConfig{Type: "redis"},
+				TargetConfig: connection.ConnectionConfig{Type: "mongodb", Database: "app"},
+				Tables:       []string{"session:1"},
+				Content:      "data",
+				Mode:         "insert_update",
+			},
+			blockingDBType: "mongodb",
+			run: func(ctx context.Context, config SyncConfig) error {
+				result := NewSyncEngine(Reporter{}).AnalyzeContext(ctx, config)
+				if result.Success || result.Message != context.Canceled.Error() {
+					return fmt.Errorf("AnalyzeContext() = %+v, want cancelled failure", result)
+				}
+				return context.Canceled
+			},
+		},
+		{
+			name: "mongo_to_redis_preview",
+			config: SyncConfig{
+				SourceConfig: connection.ConnectionConfig{Type: "mongodb", Database: "app"},
+				TargetConfig: connection.ConnectionConfig{Type: "redis"},
+				Tables:       []string{"redis_db_0_keys"},
+				Content:      "data",
+				Mode:         "insert_update",
+			},
+			blockingDBType: "mongodb",
+			run: func(ctx context.Context, config SyncConfig) error {
+				_, err := NewSyncEngine(Reporter{}).PreviewContext(ctx, config, "redis_db_0_keys", 25)
+				return err
+			},
+		},
+	}
+
+	for _, operation := range operations {
+		t.Run(operation.name, func(t *testing.T) {
+			blockingDB := &contextAwareSyncDatabase{queryStarted: make(chan struct{})}
+			redisClient := &fakeRedisMigrationClient{values: map[string]*redispkg.RedisValue{
+				"session:1": {Type: "string", TTL: -1, Value: "token"},
+			}}
+			originalFactory := newSyncDatabase
+			originalRedisFactory := newRedisSourceClient
+			t.Cleanup(func() {
+				newSyncDatabase = originalFactory
+				newRedisSourceClient = originalRedisFactory
+			})
+			newSyncDatabase = func(databaseType string) (db.Database, error) {
+				if databaseType != operation.blockingDBType {
+					return nil, fmt.Errorf("unexpected database type %s", databaseType)
+				}
+				return blockingDB, nil
+			}
+			newRedisSourceClient = func() redisMigrationClient { return redisClient }
+
+			ctx, cancel := context.WithCancel(context.Background())
+			errCh := make(chan error, 1)
+			go func() { errCh <- operation.run(ctx, operation.config) }()
+			select {
+			case <-blockingDB.queryStarted:
+				cancel()
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for Redis/Mongo query")
+			}
+			select {
+			case err := <-errCh:
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("%s error = %v, want context.Canceled", operation.name, err)
+				}
+				if blockingDB.legacyCalls != 0 {
+					t.Fatalf("legacy Query calls = %d, want 0", blockingDB.legacyCalls)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatalf("%s did not return after cancellation", operation.name)
+			}
+		})
 	}
 }
 

--- a/internal/webserver/runtime_bridge.go
+++ b/internal/webserver/runtime_bridge.go
@@ -96,21 +96,49 @@ func runtimeBridgeScript() string {
     }
   };
 
-  var invoke = async function (namespace, receiver, method, args) {
-    var response = await fetch(apiBase + '/api/invoke', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      credentials: 'same-origin',
-      body: JSON.stringify({
-        namespace: namespace,
-        receiver: receiver,
-        method: method,
-        args: Array.isArray(args) ? args : []
-      })
-    });
-    var payload = await response.json().catch(function () { return {}; });
+  var buildAbortError = function (dispatchState) {
+    var error = new Error('Web RPC request was aborted');
+    error.name = 'AbortError';
+    error.code = 'WEB_RPC_ABORTED';
+    error.dispatchState = dispatchState;
+    return error;
+  };
+
+  var invokeWithOptions = async function (namespace, receiver, method, args, options) {
+    options = options || {};
+    var signal = options.signal;
+    if (signal && signal.aborted) {
+      throw buildAbortError('not_started');
+    }
+    var response;
+    var payload;
+    try {
+      response = await fetch(apiBase + '/api/invoke', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        credentials: 'same-origin',
+        signal: signal,
+        body: JSON.stringify({
+          namespace: namespace,
+          receiver: receiver,
+          method: method,
+          args: Array.isArray(args) ? args : []
+        })
+      });
+      payload = await response.json().catch(function (error) {
+        if ((signal && signal.aborted) || (error && error.name === 'AbortError')) {
+          throw error;
+        }
+        return {};
+      });
+    } catch (error) {
+      if ((signal && signal.aborted) || (error && error.name === 'AbortError')) {
+        throw buildAbortError('possibly_dispatched');
+      }
+      throw error;
+    }
     if (!response.ok || payload.error) {
       throw new Error(payload.error || ('invoke failed with status ' + response.status));
     }
@@ -127,6 +155,10 @@ func runtimeBridgeScript() string {
       }
     }
     return payload.result;
+  };
+
+  var invoke = function (namespace, receiver, method, args) {
+    return invokeWithOptions(namespace, receiver, method, args, {});
   };
 
   var buildServiceProxy = function (namespace, receiver) {
@@ -216,6 +248,10 @@ func runtimeBridgeScript() string {
       fileDialog: false,
       clipboard: typeof navigator !== 'undefined' && !!navigator.clipboard
     }
+  };
+  window.__GONAVI_WEB_RPC__ = {
+    invoke: invoke,
+    invokeWithOptions: invokeWithOptions
   };
   window.go = {
     ...existingGo,

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -354,11 +354,12 @@ func (h *eventHub) unsubscribe(subscriber *eventSubscriber) {
 
 type methodInvoker struct {
 	targets             map[string]reflect.Value
+	contextHandlers     map[string]map[string]reflect.Value
 	allowDesktopMethods bool
 }
 
-func newMethodInvoker(app *appcore.App, ai *aiservice.Service) *methodInvoker {
-	return &methodInvoker{
+func newMethodInvoker(app *appcore.App, ai *aiservice.Service) (*methodInvoker, error) {
+	invoker := &methodInvoker{
 		targets: map[string]reflect.Value{
 			"app.app":           reflect.ValueOf(app),
 			"app":               reflect.ValueOf(app),
@@ -366,9 +367,98 @@ func newMethodInvoker(app *appcore.App, ai *aiservice.Service) *methodInvoker {
 			"aiservice":         reflect.ValueOf(ai),
 		},
 	}
+	appHandlers, err := validateContextHandlers(
+		reflect.ValueOf(app),
+		appcore.RequiredIssue1098WebRPCContextMethods(),
+		appcore.WebRPCContextHandlers(app),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("validate App Web RPC context handlers: %w", err)
+	}
+	invoker.contextHandlers = map[string]map[string]reflect.Value{"app": appHandlers}
+	return invoker, nil
 }
 
-func (i *methodInvoker) Invoke(req invokeRequest) (any, error) {
+func validateContextHandlers(target reflect.Value, required []string, handlers map[string]any) (map[string]reflect.Value, error) {
+	if !target.IsValid() || (target.Kind() == reflect.Pointer && target.IsNil()) {
+		return nil, fmt.Errorf("context handler target is unavailable")
+	}
+	requiredSet := make(map[string]struct{}, len(required))
+	for _, methodName := range required {
+		methodName = strings.TrimSpace(methodName)
+		if methodName == "" {
+			return nil, fmt.Errorf("required context method name is empty")
+		}
+		if _, exists := requiredSet[methodName]; exists {
+			return nil, fmt.Errorf("required context method %s is duplicated", methodName)
+		}
+		requiredSet[methodName] = struct{}{}
+	}
+	if len(handlers) != len(requiredSet) {
+		return nil, fmt.Errorf("context handler count mismatch: want %d got %d", len(requiredSet), len(handlers))
+	}
+
+	contextType := reflect.TypeOf((*context.Context)(nil)).Elem()
+	validated := make(map[string]reflect.Value, len(handlers))
+	for methodName, rawHandler := range handlers {
+		if _, required := requiredSet[methodName]; !required {
+			return nil, fmt.Errorf("context handler %s is not in the required method set", methodName)
+		}
+		publicMethod := target.MethodByName(methodName)
+		if !publicMethod.IsValid() {
+			return nil, fmt.Errorf("public method %s does not exist", methodName)
+		}
+		publicType := publicMethod.Type()
+		if publicType.IsVariadic() {
+			return nil, fmt.Errorf("public method %s must not be variadic", methodName)
+		}
+
+		handler := reflect.ValueOf(rawHandler)
+		if !handler.IsValid() || handler.Kind() != reflect.Func || handler.IsNil() {
+			return nil, fmt.Errorf("context handler %s must be a non-nil function", methodName)
+		}
+		handlerType := handler.Type()
+		if handlerType.IsVariadic() {
+			return nil, fmt.Errorf("context handler %s must not be variadic", methodName)
+		}
+		if handlerType.NumIn() != publicType.NumIn()+1 || handlerType.In(0) != contextType {
+			return nil, fmt.Errorf("context handler %s has an invalid parameter list", methodName)
+		}
+		for index := 0; index < publicType.NumIn(); index++ {
+			if handlerType.In(index+1) != publicType.In(index) {
+				return nil, fmt.Errorf("context handler %s parameter %d type mismatch", methodName, index)
+			}
+		}
+		if handlerType.NumOut() != publicType.NumOut() {
+			return nil, fmt.Errorf("context handler %s return count mismatch", methodName)
+		}
+		for index := 0; index < publicType.NumOut(); index++ {
+			if handlerType.Out(index) != publicType.Out(index) {
+				return nil, fmt.Errorf("context handler %s return %d type mismatch", methodName, index)
+			}
+		}
+		validated[methodName] = handler
+	}
+	for methodName := range requiredSet {
+		if _, exists := validated[methodName]; !exists {
+			return nil, fmt.Errorf("required context handler %s is missing", methodName)
+		}
+	}
+	return validated, nil
+}
+
+func canonicalInvokeTarget(key string) string {
+	switch key {
+	case "app", "app.app":
+		return "app"
+	case "aiservice", "aiservice.service":
+		return "aiservice"
+	default:
+		return key
+	}
+}
+
+func (i *methodInvoker) Invoke(ctx context.Context, req invokeRequest) (any, error) {
 	if i == nil {
 		return nil, fmt.Errorf("web invoker is not initialized")
 	}
@@ -411,6 +501,24 @@ func (i *methodInvoker) Invoke(req invokeRequest) (any, error) {
 			return nil, fmt.Errorf("decode argument %d for %s failed: %w", index, methodName, err)
 		}
 		callArgs = append(callArgs, argValue)
+	}
+
+	canonicalTarget := canonicalInvokeTarget(key)
+	handler := reflect.Value{}
+	if handlers := i.contextHandlers[canonicalTarget]; handlers != nil {
+		handler = handlers[methodName]
+	}
+	if handler.IsValid() {
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		contextCallArgs := make([]reflect.Value, 0, len(callArgs)+1)
+		contextCallArgs = append(contextCallArgs, reflect.ValueOf(ctx))
+		contextCallArgs = append(contextCallArgs, callArgs...)
+		return unpackResults(handler.Call(contextCallArgs))
 	}
 
 	results := method.Call(callArgs)
@@ -515,17 +623,18 @@ func NewSharedRuntime(assetFS fs.FS, app *appcore.App, ai *aiservice.Service, op
 	}
 
 	events := newEventHub()
+	invoker, err := newMethodInvoker(app, ai)
+	if err != nil {
+		return nil, err
+	}
+	invoker.allowDesktopMethods = true
 	shared := &SharedRuntime{
 		server: &Server{
-			assets: frontendFS,
-			app:    app,
-			ai:     ai,
-			events: events,
-			invoker: func() *methodInvoker {
-				invoker := newMethodInvoker(app, ai)
-				invoker.allowDesktopMethods = true
-				return invoker
-			}(),
+			assets:        frontendFS,
+			app:           app,
+			ai:            ai,
+			events:        events,
+			invoker:       invoker,
 			auditHeavySem: make(chan struct{}, 1),
 		},
 		runtimeBridgePath:   bridgePath,
@@ -665,6 +774,10 @@ func New(ctx context.Context, assetFS fs.FS, options Options) (*Server, error) {
 	appcore.InitializeLifecycle(app, lifecycleCtx)
 	ai := aiservice.NewService()
 	aiservice.InitializeLifecycle(ai, lifecycleCtx)
+	invoker, err := newMethodInvoker(app, ai)
+	if err != nil {
+		return nil, err
+	}
 	auth, err := newWebAuthManagerFromEnvironment("")
 	if err != nil {
 		return nil, fmt.Errorf("initialize web auth failed: %w", err)
@@ -677,7 +790,7 @@ func New(ctx context.Context, assetFS fs.FS, options Options) (*Server, error) {
 		ai:            ai,
 		auth:          auth,
 		events:        events,
-		invoker:       newMethodInvoker(app, ai),
+		invoker:       invoker,
 		auditHeavySem: make(chan struct{}, 1),
 	}, nil
 }
@@ -865,6 +978,9 @@ func (s *Server) handleInvoke(w http.ResponseWriter, r *http.Request) {
 		if webTrace != nil {
 			completeWebInvokeTrace(webTrace, response)
 		}
+		if r.Context().Err() != nil {
+			return
+		}
 		if requestID != "" {
 			w.Header().Set("X-GoNavi-Request-ID", requestID)
 		}
@@ -879,7 +995,7 @@ func (s *Server) handleInvoke(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	result, err := s.invoker.Invoke(request)
+	result, err := s.invoker.Invoke(r.Context(), request)
 	if err != nil {
 		writeResponse(http.StatusBadRequest, invokeResponse{Error: err.Error()})
 		return

--- a/internal/webserver/server_test.go
+++ b/internal/webserver/server_test.go
@@ -3,6 +3,7 @@ package webserver
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -24,6 +25,15 @@ type webserverTestReceiver struct{}
 
 type countingWebserverTestReceiver struct {
 	calls atomic.Int32
+}
+
+type contextWebserverTestReceiver struct {
+	publicCalls atomic.Int32
+}
+
+func (r *contextWebserverTestReceiver) Echo(value string) string {
+	r.publicCalls.Add(1)
+	return "public:" + value
 }
 
 func (r *countingWebserverTestReceiver) Echo(value string) string {
@@ -70,7 +80,7 @@ func TestMethodInvokerInvokeDecodesArgumentsAndReturnsResult(t *testing.T) {
 
 	rawLeft, _ := json.Marshal(2)
 	rawRight, _ := json.Marshal(5)
-	result, err := invoker.Invoke(invokeRequest{
+	result, err := invoker.Invoke(context.Background(), invokeRequest{
 		Namespace: "test",
 		Receiver:  "receiver",
 		Method:    "Sum",
@@ -92,7 +102,7 @@ func TestMethodInvokerInvokeSupportsStructuredReturnValues(t *testing.T) {
 	}
 
 	rawValue, _ := json.Marshal("hello")
-	result, err := invoker.Invoke(invokeRequest{
+	result, err := invoker.Invoke(context.Background(), invokeRequest{
 		Namespace: "test",
 		Receiver:  "receiver",
 		Method:    "Echo",
@@ -107,6 +117,183 @@ func TestMethodInvokerInvokeSupportsStructuredReturnValues(t *testing.T) {
 	}
 	if payload["value"] != "hello" {
 		t.Fatalf("expected echoed value hello, got %#v", payload["value"])
+	}
+}
+
+func TestMethodInvokerUsesContextHandlerForBothAppAliases(t *testing.T) {
+	receiver := &contextWebserverTestReceiver{}
+	handlerCalls := atomic.Int32{}
+	invoker := &methodInvoker{
+		targets: map[string]reflect.Value{
+			"app":     reflect.ValueOf(receiver),
+			"app.app": reflect.ValueOf(receiver),
+		},
+		contextHandlers: map[string]map[string]reflect.Value{
+			"app": {
+				"Echo": reflect.ValueOf(func(ctx context.Context, value string) string {
+					handlerCalls.Add(1)
+					if ctx.Value("request") != "1098" {
+						t.Fatalf("handler received the wrong request context")
+					}
+					return "context:" + value
+				}),
+			},
+		},
+	}
+	rawValue, _ := json.Marshal("hello")
+	ctx := context.WithValue(context.Background(), "request", "1098")
+
+	for _, request := range []invokeRequest{
+		{Namespace: "app", Method: "Echo", Args: []json.RawMessage{rawValue}},
+		{Namespace: "app", Receiver: "app", Method: "Echo", Args: []json.RawMessage{rawValue}},
+	} {
+		result, err := invoker.Invoke(ctx, request)
+		if err != nil {
+			t.Fatalf("Invoke(%s.%s) error = %v", request.Namespace, request.Receiver, err)
+		}
+		if result != "context:hello" {
+			t.Fatalf("Invoke(%s.%s) result = %#v", request.Namespace, request.Receiver, result)
+		}
+	}
+	if handlerCalls.Load() != 2 || receiver.publicCalls.Load() != 0 {
+		t.Fatalf("handler calls = %d, public calls = %d", handlerCalls.Load(), receiver.publicCalls.Load())
+	}
+}
+
+func TestMethodInvokerCancellationOnlyPrechecksRegisteredMethods(t *testing.T) {
+	receiver := &contextWebserverTestReceiver{}
+	handlerCalls := atomic.Int32{}
+	invoker := &methodInvoker{
+		targets: map[string]reflect.Value{"app": reflect.ValueOf(receiver)},
+		contextHandlers: map[string]map[string]reflect.Value{
+			"app": {
+				"Echo": reflect.ValueOf(func(context.Context, string) string {
+					handlerCalls.Add(1)
+					return "context"
+				}),
+			},
+		},
+	}
+	rawValue, _ := json.Marshal("hello")
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := invoker.Invoke(cancelled, invokeRequest{
+		Namespace: "app", Method: "Echo", Args: []json.RawMessage{rawValue},
+	}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("registered method error = %v, want context.Canceled", err)
+	}
+	if handlerCalls.Load() != 0 || receiver.publicCalls.Load() != 0 {
+		t.Fatalf("cancelled registered call reached business code")
+	}
+
+	invoker.contextHandlers = nil
+	result, err := invoker.Invoke(cancelled, invokeRequest{
+		Namespace: "app", Method: "Echo", Args: []json.RawMessage{rawValue},
+	})
+	if err != nil || result != "public:hello" || receiver.publicCalls.Load() != 1 {
+		t.Fatalf("unregistered cancelled call = (%#v, %v), public calls = %d", result, err, receiver.publicCalls.Load())
+	}
+}
+
+func TestValidateContextHandlersRejectsSignatureMismatch(t *testing.T) {
+	_, err := validateContextHandlers(
+		reflect.ValueOf(webserverTestReceiver{}),
+		[]string{"Sum"},
+		map[string]any{
+			"Sum": func(context.Context, int, string) int { return 0 },
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "parameter 1 type mismatch") {
+		t.Fatalf("validateContextHandlers error = %v, want parameter mismatch", err)
+	}
+}
+
+func TestIssue1098RequiredContextHandlerSetIsExact(t *testing.T) {
+	application := appcore.NewWebApp()
+	invoker, err := newMethodInvoker(application, aiservice.NewService())
+	if err != nil {
+		t.Fatalf("newMethodInvoker returned error: %v", err)
+	}
+	handlers := invoker.contextHandlers["app"]
+	required := appcore.RequiredIssue1098WebRPCContextMethods()
+	if len(handlers) != len(required) {
+		t.Fatalf("handler count = %d, required count = %d", len(handlers), len(required))
+	}
+	for _, methodName := range required {
+		if !handlers[methodName].IsValid() {
+			t.Fatalf("required handler %s is missing", methodName)
+		}
+	}
+}
+
+func TestHTTPClientCancellationReachesContextHandler(t *testing.T) {
+	receiver := &contextWebserverTestReceiver{}
+	entered := make(chan struct{})
+	observed := make(chan struct{})
+	invoker := &methodInvoker{
+		targets: map[string]reflect.Value{"app": reflect.ValueOf(receiver)},
+		contextHandlers: map[string]map[string]reflect.Value{
+			"app": {
+				"Echo": reflect.ValueOf(func(ctx context.Context, value string) string {
+					close(entered)
+					<-ctx.Done()
+					close(observed)
+					return value
+				}),
+			},
+		},
+	}
+	server := httptest.NewServer(http.HandlerFunc((&Server{invoker: invoker}).handleInvoke))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL, strings.NewReader(
+		`{"namespace":"app","method":"Echo","args":["hello"]}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	result := make(chan error, 1)
+	go func() {
+		response, requestErr := server.Client().Do(request)
+		if response != nil {
+			_ = response.Body.Close()
+		}
+		result <- requestErr
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("context handler was not entered")
+	}
+	cancel()
+	select {
+	case <-observed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("HTTP cancellation did not reach the context handler")
+	}
+	select {
+	case requestErr := <-result:
+		if requestErr == nil {
+			t.Fatal("client request unexpectedly completed without cancellation")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancelled HTTP request did not return")
+	}
+}
+
+func TestRuntimeBridgeExposesStableAbortContract(t *testing.T) {
+	script := runtimeBridgeScript()
+	for _, expected := range []string{
+		"window.__GONAVI_WEB_RPC__", "invokeWithOptions", "WEB_RPC_ABORTED",
+		"not_started", "possibly_dispatched", "signal: signal",
+	} {
+		if !strings.Contains(script, expected) {
+			t.Fatalf("runtime bridge is missing %q", expected)
+		}
 	}
 }
 
@@ -172,7 +359,7 @@ func TestMethodInvokerRejectsDesktopOnlyAppMethodsBeforeReflection(t *testing.T)
 		"SelectSavedQueryDirectory", "ApplySavedQueryDirectory", "OpenSavedQueryDirectory", "RevealSavedQueryInFolder", "SetApplicationBrandIcon",
 		"RefreshWebViewBounds", "RevealSavedConnectionPrimaryPassword",
 	} {
-		_, err := invoker.Invoke(invokeRequest{Namespace: "app", Receiver: "app", Method: method})
+		_, err := invoker.Invoke(context.Background(), invokeRequest{Namespace: "app", Receiver: "app", Method: method})
 		if err == nil || !strings.Contains(err.Error(), "unavailable in web runtime") {
 			t.Fatalf("desktop-only method %s error = %v, want web runtime rejection", method, err)
 		}
@@ -186,7 +373,7 @@ func TestSharedMethodInvokerAllowsDesktopMethods(t *testing.T) {
 		},
 		allowDesktopMethods: true,
 	}
-	result, err := invoker.Invoke(invokeRequest{Namespace: "app", Receiver: "app", Method: "OpenSQLFile"})
+	result, err := invoker.Invoke(context.Background(), invokeRequest{Namespace: "app", Receiver: "app", Method: "OpenSQLFile"})
 	if err != nil {
 		t.Fatalf("shared desktop method was rejected: %v", err)
 	}
@@ -203,7 +390,7 @@ func TestSharedMethodInvokerAllowsSavedPasswordReveal(t *testing.T) {
 		allowDesktopMethods: true,
 	}
 	rawID, _ := json.Marshal("conn-1")
-	result, err := invoker.Invoke(invokeRequest{
+	result, err := invoker.Invoke(context.Background(), invokeRequest{
 		Namespace: "app",
 		Receiver:  "app",
 		Method:    "RevealSavedConnectionPrimaryPassword",


### PR DESCRIPTION
- 将 AbortSignal 与 HTTP Context 贯穿数据库、同步和导入请求
- 保留 DataSync Run、审批与托管事务的独立生命周期
- 补充特殊数据源、预检、导入和前端生命周期取消回归