### PR TITLE
🐛 fix(webserver): 限制分离窗口可靠事件队列

### DIFF
--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -30,7 +30,12 @@ const (
 	internalRoutePrefix       = "/__gonavi"
 	detachedWindowIDHeader    = "X-GoNavi-Detached-Window-ID"
 	eventSubscriberQueueLimit = 128
-	eventStreamDataChunkBytes = 256 << 10
+	// Reliable events are allowed bounded headroom over the broadcast queue so
+	// a critical targeted event can still be delivered after broadcasts fill
+	// the soft limit. A subscriber that remains slower than this hard limit is
+	// closed and must reconnect instead of retaining an unbounded queue.
+	eventSubscriberReliableQueueLimit = eventSubscriberQueueLimit * 2
+	eventStreamDataChunkBytes         = 256 << 10
 )
 
 var errorType = reflect.TypeOf((*error)(nil)).Elem()
@@ -147,10 +152,27 @@ func (s *eventSubscriber) enqueue(msg eventMessage, reliable bool) {
 		}
 		return
 	}
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+	queueLen := len(s.queue) - s.head
+	if reliable && queueLen >= eventSubscriberReliableQueueLimit {
+		// Reliable delivery cannot silently drop the event, but retaining it
+		// forever would make a stalled detached window an unbounded memory
+		// sink. Close this stream and release its pending payloads; the child
+		// runtime will reconnect and obtain fresh state.
+		s.closed = true
+		s.queue = nil
+		s.head = 0
+		close(s.done)
+		s.mu.Unlock()
+		return
+	}
 	// AI stream deltas are loss-sensitive. Once one delta is queued, later
 	// deltas for that session coalesce into it; the first delta and terminal
 	// events may therefore exceed the soft broadcast limit by a small amount.
-	if s.closed || (!reliable && !strings.HasPrefix(msg.Name, "ai:stream:") && len(s.queue)-s.head >= eventSubscriberQueueLimit) {
+	if !reliable && !strings.HasPrefix(msg.Name, "ai:stream:") && queueLen >= eventSubscriberQueueLimit {
 		s.mu.Unlock()
 		return
 	}
@@ -293,6 +315,8 @@ func (s *eventSubscriber) close() {
 		return
 	}
 	s.closed = true
+	s.queue = nil
+	s.head = 0
 	close(s.done)
 	s.mu.Unlock()
 }

--- a/internal/webserver/server_test.go
+++ b/internal/webserver/server_test.go
@@ -514,6 +514,56 @@ func TestEventHubEmitToSurvivesFullBroadcastQueue(t *testing.T) {
 	}
 }
 
+func TestEventHubReliableQueueDisconnectsSlowDetachedWindowAtHardLimit(t *testing.T) {
+	hub := newEventHub()
+	subscriber := hub.subscribe("window-1")
+	t.Cleanup(func() { hub.unsubscribe(subscriber) })
+
+	for index := 0; index < eventSubscriberReliableQueueLimit; index++ {
+		hub.EmitTo("window-1", "gonavi:command", index)
+	}
+
+	subscriber.mu.Lock()
+	queueLen := len(subscriber.queue) - subscriber.head
+	closedBeforeOverflow := subscriber.closed
+	subscriber.mu.Unlock()
+	if queueLen != eventSubscriberReliableQueueLimit {
+		t.Fatalf("reliable queue length before overflow = %d, want %d", queueLen, eventSubscriberReliableQueueLimit)
+	}
+	if closedBeforeOverflow {
+		t.Fatal("reliable queue closed before reaching its hard limit")
+	}
+
+	hub.EmitTo("window-1", "gonavi:close", "close")
+	select {
+	case <-subscriber.done:
+	default:
+		t.Fatal("slow reliable subscriber was not disconnected after queue overflow")
+	}
+
+	subscriber.mu.Lock()
+	queueLen = len(subscriber.queue) - subscriber.head
+	closedAfterOverflow := subscriber.closed
+	subscriber.mu.Unlock()
+	if queueLen != 0 {
+		t.Fatalf("reliable queue retained %d messages after disconnect", queueLen)
+	}
+	if !closedAfterOverflow {
+		t.Fatal("subscriber was not marked closed after reliable queue overflow")
+	}
+
+	// A fresh SSE subscription for the same child ID still receives targeted
+	// lifecycle events after the stalled stream has been removed.
+	hub.unsubscribe(subscriber)
+	reconnected := hub.subscribe("window-1")
+	t.Cleanup(func() { hub.unsubscribe(reconnected) })
+	hub.EmitTo("window-1", "gonavi:close", "close")
+	message, ok := reconnected.dequeue()
+	if !ok || message.Name != "gonavi:close" {
+		t.Fatalf("reconnected subscriber message = %#v, %v", message, ok)
+	}
+}
+
 func TestEventHubAIStreamCoalescesWithoutLosingChunksOrTerminalEvents(t *testing.T) {
 	hub := newEventHub()
 	target := hub.subscribe("window-1")
@@ -709,6 +759,89 @@ func TestHandleEventsRegistersDetachedWindowHeader(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("event stream did not stop after cancellation")
 	}
+}
+
+func TestHandleEventsDisconnectsBlockedDetachedConsumerAfterReliableOverflow(t *testing.T) {
+	events := newEventHub()
+	server := &Server{events: events}
+	requestContext, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	request := httptest.NewRequest(http.MethodGet, internalRoutePrefix+"/events", nil).WithContext(requestContext)
+	request.Header.Set(detachedWindowIDHeader, "window-42")
+	writer := newBlockingEventStreamTestWriter()
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(writer.release) }) }
+	t.Cleanup(release)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		server.handleEvents(writer, request)
+	}()
+
+	select {
+	case <-writer.flushed:
+	case <-time.After(time.Second):
+		t.Fatal("event stream did not connect")
+	}
+	events.EmitTo("window-42", "gonavi:blocked", "first")
+	select {
+	case <-writer.started:
+	case <-time.After(time.Second):
+		t.Fatal("event stream did not block on the first targeted event")
+	}
+
+	events.mu.RLock()
+	var subscriber *eventSubscriber
+	for candidate := range events.subscribers {
+		if candidate.targetID == "window-42" {
+			subscriber = candidate
+			break
+		}
+	}
+	events.mu.RUnlock()
+	if subscriber == nil {
+		t.Fatal("detached subscriber was not registered")
+	}
+
+	for index := 0; index < eventSubscriberReliableQueueLimit; index++ {
+		events.EmitTo("window-42", "gonavi:command", index)
+	}
+	events.EmitTo("window-42", "gonavi:overflow", "close")
+	select {
+	case <-subscriber.done:
+	case <-time.After(time.Second):
+		t.Fatal("blocked detached consumer was not disconnected after reliable overflow")
+	}
+
+	release()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("event stream handler did not exit after the blocked write was released")
+	}
+}
+
+type blockingEventStreamTestWriter struct {
+	*eventStreamTestWriter
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func newBlockingEventStreamTestWriter() *blockingEventStreamTestWriter {
+	return &blockingEventStreamTestWriter{
+		eventStreamTestWriter: newEventStreamTestWriter(),
+		started:               make(chan struct{}),
+		release:               make(chan struct{}),
+	}
+}
+
+func (w *blockingEventStreamTestWriter) Write(payload []byte) (int, error) {
+	if strings.Contains(string(payload), `"name":"gonavi:blocked"`) {
+		w.once.Do(func() { close(w.started) })
+		<-w.release
+	}
+	return w.eventStreamTestWriter.Write(payload)
 }
 
 type eventStreamTestWriter struct {


### PR DESCRIPTION
## 背景与问题

Issue #1099 中，分离窗口的 `EmitTo` 固定使用可靠事件队列，但原队列仅限制非可靠事件。慢速或挂起的 SSE 客户端会导致定向可靠事件持续增长，存在无界内存占用风险。

## 变更内容

- 为可靠事件队列增加 256 条硬上限，并保留有限空间承载关键定向事件。
- 队列溢出时关闭对应 SSE 订阅、清空待发送消息并触发重连，避免静默丢弃可靠事件或持续占用内存。
- 保留现有广播限流、事件合并、关闭和重连语义。
- 增加可靠队列上限、阻塞 SSE 消费、溢出断连和重连回归测试。

## 影响与风险

仅影响分离窗口 SSE 事件订阅。极端慢消费端达到硬上限后会断连，客户端通过重连和状态同步恢复；正常消费、窗口关闭和 AI 终止事件路径不变。

## 验证方式

- `go test ./internal/webserver ./internal/httpserver ./internal/nativewindow -count=1 -timeout=10m`
- `git diff --check`
- 子 agent 对验收标准、并发安全和调用方回归进行了只读审查，未发现 P0/P1/P2 问题。

Closes #1099