### PR TITLE
🐛 fix(query-editor): 修复 DML 目标表误追加别名

### DIFF
--- a/frontend/src/components/QueryEditor.external-sql-save.test.tsx
+++ b/frontend/src/components/QueryEditor.external-sql-save.test.tsx
@@ -4091,6 +4091,32 @@ describe('QueryEditor external SQL save', () => {
     expect(insertResult.suggestions.find((item: any) => item.label === 'system_user')?.insertText)
       .toBe('system_user');
 
+    for (const sql of [
+      'UPDATE system',
+      'DELETE FROM system',
+      'INSERT INTO system',
+      'REPLACE INTO system',
+      'MERGE INTO system',
+    ]) {
+      editorState.value = sql;
+      editorState.latestOnChange?.(editorState.value);
+      const dmlResult = await sqlProvider.provideCompletionItems(
+        editorState.editor.getModel(),
+        { lineNumber: 1, column: editorState.value.length + 1 },
+      );
+      expect(dmlResult.suggestions.find((item: any) => item.label === 'system_user')?.insertText)
+        .toBe('system_user');
+    }
+
+    editorState.value = 'INSERT INTO audit_log SELECT * FROM system';
+    editorState.latestOnChange?.(editorState.value);
+    const insertSelectResult = await sqlProvider.provideCompletionItems(
+      editorState.editor.getModel(),
+      { lineNumber: 1, column: editorState.value.length + 1 },
+    );
+    expect(insertSelectResult.suggestions.find((item: any) => item.label === 'system_user')?.insertText)
+      .toBe('system_user AS su');
+
     await act(async () => {
       renderer.unmount();
     });

--- a/frontend/src/components/queryEditor/QueryEditorAiAssist.test.ts
+++ b/frontend/src/components/queryEditor/QueryEditorAiAssist.test.ts
@@ -6,6 +6,7 @@ import {
     buildQueryEditorInlineCompletionContext,
     buildQueryEditorTextToElasticsearchMessages,
     buildQueryEditorTextToSqlMessages,
+    isQueryEditorInlineTableAliasPending,
     requestQueryEditorTextToElasticsearch,
     requestQueryEditorInlineCompletion,
     resolveInlineSqlGhostPreviewText,
@@ -850,6 +851,57 @@ describe('QueryEditorAiAssist', () => {
             },
         })).resolves.toBe('su');
         expect(service.AISubmitAgentInput).not.toHaveBeenCalled();
+    });
+
+    it('does not suggest aliases after DML targets but keeps INSERT SELECT aliases', async () => {
+        const service = readyService('SELECT * FROM system_user su;');
+        const request = {
+            service,
+            aiContext: {
+                connectionName: 'Local MySQL',
+                sourceType: 'mysql',
+                currentDb: 'shop',
+                tables: [{ dbName: 'shop', tableName: 'system_user' }],
+                columns: [],
+            },
+        };
+        const makeSnapshot = (prefix: string) => ({
+            prefix,
+            suffix: '',
+            currentLineBeforeCursor: prefix,
+            currentLineAfterCursor: '',
+        });
+
+        for (const prefix of [
+            'UPDATE system_user ',
+            'DELETE FROM system_user ',
+            'INSERT INTO system_user ',
+            'REPLACE INTO system_user ',
+            'MERGE INTO system_user ',
+        ]) {
+            const snapshot = makeSnapshot(prefix);
+            expect(isQueryEditorInlineTableAliasPending(snapshot)).toBe(false);
+            const insertText = await requestQueryEditorInlineCompletion({
+                ...request,
+                editorSnapshot: snapshot,
+            });
+            expect(insertText).not.toBe('AS su');
+            expect(insertText).not.toBe('su');
+        }
+
+        const insertSelectSnapshot = makeSnapshot('INSERT INTO audit_log SELECT * FROM system_user ');
+        expect(isQueryEditorInlineTableAliasPending(insertSelectSnapshot)).toBe(true);
+        await expect(requestQueryEditorInlineCompletion({
+            ...request,
+            editorSnapshot: insertSelectSnapshot,
+        })).resolves.toBe('AS su');
+
+        const functionSelectSnapshot = makeSnapshot("SELECT REPLACE(name, 'x', 'y') FROM system_user ");
+        expect(isQueryEditorInlineTableAliasPending(functionSelectSnapshot)).toBe(true);
+        await expect(requestQueryEditorInlineCompletion({
+            ...request,
+            editorSnapshot: functionSelectSnapshot,
+        })).resolves.toBe('AS su');
     });
 
     it('uses the resolved OceanBase Oracle dialect for table aliases', async () => {

--- a/frontend/src/components/queryEditor/QueryEditorHelpers.test.ts
+++ b/frontend/src/components/queryEditor/QueryEditorHelpers.test.ts
@@ -360,9 +360,30 @@ describe('QueryEditorHelpers qualified navigation (MySQL db.table + PG schema.ta
         expect(buildQueryEditorTableSourceAlias('system_user', 'SELECT * FROM system_user su JOIN service_user su2')).toBe('su3');
     });
 
-    it('only permits table aliases for non-insert table sources', () => {
-        expect(isQueryEditorTableAliasCompletionContext('SELECT * FROM system_user ')).toBe(true);
-        expect(isQueryEditorTableAliasCompletionContext('INSERT INTO system_user ')).toBe(false);
+    it('only permits table aliases for SELECT table sources', () => {
+        for (const sql of [
+            'UPDATE system_user ',
+            'DELETE FROM system_user ',
+            'INSERT INTO system_user ',
+            'REPLACE INTO system_user ',
+            'MERGE INTO system_user ',
+        ]) {
+            expect(isQueryEditorTableSourceCompletionContext(sql)).toBe(true);
+            expect(isQueryEditorTableAliasCompletionContext(sql)).toBe(false);
+        }
+
+        for (const sql of [
+            'SELECT * FROM system_user ',
+            "SELECT REPLACE(name, 'x', 'y') FROM system_user ",
+            'SELECT INSERT(name, 1, 0, \'x\') FROM system_user ',
+            'SELECT * FROM system_user su JOIN service_user ',
+            'SELECT * FROM system_user su, service_user ',
+            'INSERT INTO audit_log SELECT * FROM system_user ',
+            'INSERT INTO audit_log SELECT * FROM (SELECT * FROM system_user ',
+        ]) {
+            expect(isQueryEditorTableSourceCompletionContext(sql)).toBe(true);
+            expect(isQueryEditorTableAliasCompletionContext(sql)).toBe(true);
+        }
     });
 
     it('keeps a dotted Dameng owner intact when metadata already identifies it', () => {

--- a/frontend/src/components/queryEditor/QueryEditorHelpers.ts
+++ b/frontend/src/components/queryEditor/QueryEditorHelpers.ts
@@ -2120,11 +2120,16 @@ type QueryEditorSqlReferenceToken = {
     quoted: boolean;
 };
 
+type QueryEditorSqlStatementKind = 'select' | 'insert' | 'update' | 'delete' | 'replace' | 'merge';
+type QueryEditorSqlTableSourceKind = 'from' | 'join' | 'comma' | 'update' | 'into';
+
 type QueryEditorSqlReferenceDepthState = {
     fromListActive: boolean;
     queryStatementActive: boolean;
     sourceContextActive: boolean;
-    expectsSource?: 'from' | 'join' | 'comma' | 'update' | 'into';
+    statementKind?: QueryEditorSqlStatementKind;
+    sourceContextKind?: QueryEditorSqlTableSourceKind;
+    expectsSource?: QueryEditorSqlTableSourceKind;
 };
 
 const QUERY_EDITOR_SQL_REFERENCE_PUNCTUATION = new Set(['(', ')', '.', ',', ';']);
@@ -2170,6 +2175,7 @@ const isQueryEditorSqlIdentifierToken = (token: QueryEditorSqlReferenceToken | u
 const analyzeQueryEditorTableReferences = (source: string): {
     references: QueryEditorTableReference[];
     expectsTableSource: boolean;
+    allowsTableAlias: boolean;
 } => {
     const tokens = tokenizeQueryEditorSqlReferences(String(source || ''));
     const references: QueryEditorTableReference[] = [];
@@ -2186,6 +2192,8 @@ const analyzeQueryEditorTableReferences = (source: string): {
                 fromListActive: false,
                 queryStatementActive: false,
                 sourceContextActive: false,
+                statementKind: undefined,
+                sourceContextKind: undefined,
             };
         }
         return states[depth];
@@ -2205,6 +2213,8 @@ const analyzeQueryEditorTableReferences = (source: string): {
                 fromListActive: false,
                 queryStatementActive: false,
                 sourceContextActive: false,
+                statementKind: undefined,
+                sourceContextKind: undefined,
             };
             continue;
         }
@@ -2217,6 +2227,8 @@ const analyzeQueryEditorTableReferences = (source: string): {
             state.fromListActive = false;
             state.queryStatementActive = false;
             state.sourceContextActive = false;
+            state.statementKind = undefined;
+            state.sourceContextKind = undefined;
             state.expectsSource = undefined;
             continue;
         }
@@ -2224,6 +2236,7 @@ const analyzeQueryEditorTableReferences = (source: string): {
             if (state.fromListActive) {
                 state.expectsSource = 'comma';
                 state.sourceContextActive = true;
+                state.sourceContextKind = 'comma';
             }
             continue;
         }
@@ -2260,6 +2273,7 @@ const analyzeQueryEditorTableReferences = (source: string): {
                 && (sourceKind === 'from' || sourceKind === 'join' || sourceKind === 'comma')
             ) {
                 state.sourceContextActive = false;
+                state.sourceContextKind = undefined;
                 index = pathEnd;
                 continue;
             }
@@ -2303,47 +2317,82 @@ const analyzeQueryEditorTableReferences = (source: string): {
                 ...(alias ? { alias } : {}),
             });
             state.sourceContextActive = !alias;
+            state.sourceContextKind = sourceKind;
             index = consumedEnd;
             continue;
         }
 
-        if (keyword === 'select' || keyword === 'delete') {
+        if (keyword === 'select') {
             state.queryStatementActive = true;
+            // INSERT/REPLACE ... SELECT 会切换到内部查询；已识别的其它语句
+            // 类型不能被表达式或函数名中的同名标识符覆盖。
+            if (!state.statementKind || state.statementKind === 'insert' || state.statementKind === 'replace') {
+                state.statementKind = 'select';
+            }
             state.sourceContextActive = false;
+            state.sourceContextKind = undefined;
+            continue;
+        }
+        if (keyword === 'delete' || keyword === 'insert' || keyword === 'replace' || keyword === 'merge') {
+            if (!state.statementKind) {
+                state.queryStatementActive = true;
+                state.statementKind = keyword as QueryEditorSqlStatementKind;
+                state.sourceContextActive = false;
+                state.sourceContextKind = undefined;
+            }
+            continue;
+        }
+        if (keyword === 'update') {
+            if (!state.statementKind) {
+                state.queryStatementActive = true;
+                state.statementKind = 'update';
+                state.expectsSource = 'update';
+                state.sourceContextActive = true;
+                state.sourceContextKind = 'update';
+            }
             continue;
         }
         if (keyword === 'from' && state.queryStatementActive) {
             state.fromListActive = true;
             state.expectsSource = 'from';
             state.sourceContextActive = true;
+            state.sourceContextKind = 'from';
             continue;
         }
         if (keyword === 'join' || keyword === 'straight_join' || keyword === 'apply') {
             state.fromListActive = true;
             state.expectsSource = 'join';
             state.sourceContextActive = true;
+            state.sourceContextKind = 'join';
             continue;
         }
-        if (keyword === 'update' || keyword === 'into') {
+        if (keyword === 'into') {
             state.queryStatementActive = true;
             state.expectsSource = keyword;
             state.sourceContextActive = true;
+            state.sourceContextKind = keyword;
             continue;
         }
         if (QUERY_EDITOR_SQL_FROM_LIST_END_WORDS.has(keyword)) {
             state.fromListActive = false;
             state.sourceContextActive = false;
+            state.sourceContextKind = undefined;
             state.expectsSource = undefined;
             continue;
         }
         if (QUERY_EDITOR_SQL_TABLE_ALIAS_RESERVED_WORDS.has(keyword)) {
             state.sourceContextActive = false;
+            state.sourceContextKind = undefined;
         }
     }
 
+    const state = getState();
     return {
         references,
-        expectsTableSource: getState().sourceContextActive,
+        expectsTableSource: state.sourceContextActive,
+        allowsTableAlias: state.sourceContextActive
+            && state.statementKind === 'select'
+            && (state.sourceContextKind === 'from' || state.sourceContextKind === 'join' || state.sourceContextKind === 'comma'),
     };
 };
 
@@ -2355,13 +2404,9 @@ export const isQueryEditorTableSourceCompletionContext = (source: string): boole
     analyzeQueryEditorTableReferences(source).expectsTableSource
 );
 
-export const isQueryEditorTableAliasCompletionContext = (source: string): boolean => {
-    if (!isQueryEditorTableSourceCompletionContext(source)) {
-        return false;
-    }
-    return !/\b(?:INSERT|REPLACE)\s+INTO\s+(?:[`"\[]?[A-Za-z_][\w$]*[`"\]]?\s*\.\s*){0,2}[`"\[]?[A-Za-z_][\w$]*[`"\]]?\s*$/i
-        .test(source);
-};
+export const isQueryEditorTableAliasCompletionContext = (source: string): boolean => (
+    analyzeQueryEditorTableReferences(source).allowsTableAlias
+);
 
 export type QueryEditorAliasMap = Record<
     string,


### PR DESCRIPTION
## 问题背景

SQL 表源分析器会将自动表别名应用到 UPDATE、DELETE、INSERT、REPLACE、MERGE 的目标表，导致结构化补全和 AI 手输补全生成错误 SQL。

## 修复内容

- 扫描状态记录当前 SQL 语句类型和表源类型。
- 仅允许 SELECT 的 FROM、JOIN、逗号表源自动追加别名。
- 禁止 DML 顶层目标表及其它 DML 表源自动追加别名。
- 保留 INSERT/REPLACE ... SELECT 内部查询、嵌套子查询及 MySQL/Oracle 方言别名行为。
- 增加 Helpers、AI 内联补全和结构化候选回归测试。

## 验证方式

- 相关 Vitest 测试：451 个全部通过。
- `npm run build`：成功。
- `git diff --check`：通过。
- 子 agent 只读审查：未发现 P1/P2 问题，并补充覆盖函数名与语句类型冲突场景。

## 影响与风险

- 不新增对外 API，不改变 `autoAddTableAlias` 开关和现有调用入口。
- 仅调整表别名上下文判定；未自动处理 MERGE `USING`、部分方言修饰词等非本 Issue 范围语法。

## 关联 Issue

Closes #1145
