### PR TITLE
🐛 fix(query-editor): 执行当前语句时忽略前置注释

### DIFF
--- a/frontend/src/components/QueryEditor.results-and-drop.test.tsx
+++ b/frontend/src/components/QueryEditor.results-and-drop.test.tsx
@@ -2079,6 +2079,47 @@ describe('QueryEditor external SQL save', () => {
     }));
   });
 
+  it('executes only the statement body when the cursor is on a semicolon after leading comments', async () => {
+    const sql = [
+      '-- 1856887305879470081',
+      '-- 3257969823961465780',
+      '-- 3257963896428446491',
+      "SELECT * FROM contract WHERE contract_code = 'YEC202608039';",
+    ].join('\n');
+    backendApp.DBQueryMulti.mockResolvedValueOnce({
+      success: true,
+      data: [{
+        columns: ['id', 'contract_code'],
+        rows: [{ id: 1, contract_code: 'YEC202608039' }],
+      }],
+    });
+    backendApp.DBGetColumns.mockResolvedValueOnce({
+      success: true,
+      data: [{ name: 'id', key: 'PRI' }, { name: 'contract_code', key: '' }],
+    });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<QueryEditor tab={createTab({ dbName: 'main', query: sql })} />);
+    });
+    editorState.position = { lineNumber: 4, column: sql.split('\n')[3].length + 1 };
+
+    await act(async () => {
+      const runButton = findButton(renderer!, '运行');
+      runButton.props.onMouseDown?.();
+      await runButton.props.onClick();
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(backendApp.DBQueryMulti.mock.calls[0]?.[2]).toBe(
+      "SELECT * FROM contract WHERE contract_code = 'YEC202608039' LIMIT 5000",
+    );
+    renderer!.unmount();
+  });
+
   it('keeps cursor statement execution available in v2 UI', async () => {
     storeState.appearance.uiVersion = 'v2';
     backendApp.DBQueryMulti.mockResolvedValueOnce({
@@ -5148,6 +5189,50 @@ describe('QueryEditor external SQL save', () => {
     });
     expect(dataGridState.latestProps?.readOnly).toBe(false);
     expect(dataGridState.latestProps?.columnPinScope).toBeUndefined();
+    renderer!.unmount();
+  });
+
+  it.each([
+    ['leading line comments', '-- 1856887305879470081\n-- 3257969823961465780\nSELECT * FROM contract WHERE contract_code = \'YEC202608039\';'],
+    ['leading block comments', '/* export batch: 3257963896428446491 */\nSELECT * FROM contract WHERE contract_code = \'YEC202608039\';'],
+    ['leading hash comments', '# exported query\nSELECT * FROM contract WHERE contract_code = \'YEC202608039\';'],
+    ['comments containing SQL join keywords', '/* JOIN notes from the previous export */\nSELECT * FROM contract WHERE contract_code = \'YEC202608039\';'],
+    ['a comment between FROM and the table', 'SELECT * FROM /* primary contract source */ contract WHERE contract_code = \'YEC202608039\';'],
+  ])('keeps a single-table result editable with %s', async (_label, sql) => {
+    backendApp.DBQueryMulti.mockResolvedValueOnce({
+      success: true,
+      data: [{
+        columns: ['id', 'contract_code'],
+        rows: [{ id: 1, contract_code: 'YEC202608039' }],
+      }],
+    });
+    backendApp.DBGetColumns.mockResolvedValueOnce({
+      success: true,
+      data: [
+        { name: 'id', key: 'PRI' },
+        { name: 'contract_code', key: '' },
+      ],
+    });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<QueryEditor tab={createTab({ dbName: 'main', query: sql })} />);
+    });
+    await act(async () => {
+      await findButton(renderer!, '运行').props.onClick();
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(dataGridState.latestProps?.tableName).toBe('contract');
+    expect(dataGridState.latestProps?.editLocator).toMatchObject({
+      strategy: 'primary-key',
+      columns: ['id'],
+      readOnly: false,
+    });
+    expect(dataGridState.latestProps?.readOnly).toBe(false);
     renderer!.unmount();
   });
 

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -64,7 +64,7 @@ import {
     isSqlEditorSchemaChangingStatement,
     shouldUseSqlEditorManagedTransactionForType,
 } from '../utils/sqlEditorTransaction';
-import { findSqlStatementRanges, resolveCurrentSqlStatementRange, resolveExecutableSql } from '../utils/sqlStatementSelection';
+import { findSqlStatementRanges, resolveCurrentSqlStatementRange, resolveExecutableSql, stripLeadingSqlTrivia } from '../utils/sqlStatementSelection';
 import { isMacLikePlatform } from '../utils/appearance';
 import { splitSidebarQualifiedName } from '../utils/sidebarLocate';
 import { buildMySQLCompatibleViewMetadataSqls, isSidebarViewTableType, normalizeSidebarViewName } from '../utils/sidebarMetadata';
@@ -8619,6 +8619,10 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
     return findSqlStatementRanges(sql, dbType).map((range) => range.text);
   };
 
+  const normalizeExecutableStatementList = (statements: string[], dbType = ''): string[] => (
+      statements.map((statement) => stripLeadingSqlTrivia(statement, dbType))
+  );
+
   const containsOraclePlsqlDefinition = (statements: string[]): boolean => (
       statements.some((statement) => /^\s*CREATE\s+(?:OR\s+REPLACE\s+)?(?:EDITIONABLE\s+|NONEDITIONABLE\s+)?(?:PROCEDURE|FUNCTION|PACKAGE|TRIGGER)\b/i.test(
           maskQueryEditorSqlLiteralsAndComments(statement),
@@ -9745,7 +9749,10 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                 && currentQuery.startsWith(lastExecutedEditorQueryRef.current)
                 && normalizedRawSQL.trim() === currentQuery.slice(lastExecutedEditorQueryRef.current.length).replace(/；/g, ';').trim();
             const didExecuteWholeEditor = areSqlStatementListsEqual(
-                splitSQLStatements(currentQuery.replace(/；/g, ';'), normalizedDbType),
+                normalizeExecutableStatementList(
+                    splitSQLStatements(currentQuery.replace(/；/g, ';'), normalizedDbType),
+                    normalizedDbType,
+                ),
                 statements,
             );
             if (statements.length === 0) {
@@ -9915,7 +9922,10 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                 && currentQuery.startsWith(lastExecutedEditorQueryRef.current)
                 && normalizedRawSQL.trim() === currentQuery.slice(lastExecutedEditorQueryRef.current.length).replace(/；/g, ';').trim();
             const didExecuteWholeEditor = areSqlStatementListsEqual(
-                splitSQLStatements(currentQuery.replace(/；/g, ';'), normalizedDbType),
+                normalizeExecutableStatementList(
+                    splitSQLStatements(currentQuery.replace(/；/g, ';'), normalizedDbType),
+                    normalizedDbType,
+                ),
                 sourceStatements,
             );
             if (sourceStatements.length === 0) {

--- a/frontend/src/components/queryEditor/QueryEditorHelpers.test.ts
+++ b/frontend/src/components/queryEditor/QueryEditorHelpers.test.ts
@@ -4,6 +4,7 @@ import { getCurrentLanguage, setCurrentLanguage } from '../../i18n';
 
 import {
     buildBoundedQueryEditorCompletionSuggestions,
+    appendQuerySelectExpressions,
     buildQueryEditorAliasMap,
     buildQueryEditorTableSourceAlias,
     buildQueryEditorResultSetMergeKey,
@@ -29,10 +30,37 @@ import {
     resolveQueryEditorMonacoLanguage,
     resolveQueryEditorNavigationTarget,
     resolveQueryEditorNavigationDecorations,
+    rewriteOracleSelectAllWithExpressions,
     selectUnqualifiedCompletionSynonyms,
     shouldHandleQueryEditorRunShortcutFallback,
     splitCompletionSchemaAndTable,
+    splitTopLevelComma,
 } from './QueryEditorHelpers';
+
+describe('QueryEditor SELECT structure parsing', () => {
+    it.each([
+        ['leading line comment', '-- exported row\nSELECT * FROM users'],
+        ['leading block comment', '/* exported row */\nSELECT * FROM users'],
+        ['comment in select list', 'SELECT * -- keep all columns\nFROM users'],
+        ['comment before FROM table', 'SELECT * FROM /* source table */ users'],
+    ])('recognizes a writable SELECT with %s', (_label, sql) => {
+        const appended = appendQuerySelectExpressions(sql, ['id AS __gonavi_locator_1_id']);
+        expect(appended).toContain('id AS __gonavi_locator_1_id');
+        expect(appended).toMatch(/SELECT[\s\S]+FROM[\s\S]+users/i);
+        expect(appended).not.toMatch(/--[^\n]*id AS __gonavi_locator_1_id/i);
+    });
+
+    it('does not split select items on commas inside comments or bracket identifiers', () => {
+        expect(splitTopLevelComma('id /* historical, retained */, [name, legacy], code -- source, legacy\n'))
+            .toEqual(['id /* historical, retained */', '[name, legacy]', 'code -- source, legacy']);
+    });
+
+    it('preserves comments when Oracle adds a hidden row locator to SELECT *', () => {
+        const sql = '-- exported row\nSELECT * /* current fields */\nFROM /* live source */ users';
+        expect(rewriteOracleSelectAllWithExpressions(sql, ['ROWID AS "__gonavi_oracle_rowid__"']))
+            .toBe('-- exported row\nSELECT gonavi_query_source.*, gonavi_query_source.ROWID AS "__gonavi_oracle_rowid__" /* current fields */\nFROM /* live source */ users gonavi_query_source');
+    });
+});
 
 describe('QueryEditor connection timeout', () => {
     it('keeps the configured MySQL timeout instead of forcing a 120 second minimum', () => {

--- a/frontend/src/components/queryEditor/QueryEditorHelpers.ts
+++ b/frontend/src/components/queryEditor/QueryEditorHelpers.ts
@@ -547,10 +547,29 @@ export const splitTopLevelComma = (text: string): string[] => {
     let inSingle = false;
     let inDouble = false;
     let inBacktick = false;
+    let inBracket = false;
+    let inLineComment = false;
+    let inBlockComment = false;
     let escaped = false;
 
     for (let index = 0; index < text.length; index++) {
         const ch = text[index];
+        const next = text[index + 1] || '';
+        const previous = text[index - 1] || '';
+        if (inLineComment) {
+            current += ch;
+            if (ch === '\n' || ch === '\r') inLineComment = false;
+            continue;
+        }
+        if (inBlockComment) {
+            current += ch;
+            if (ch === '*' && next === '/') {
+                current += next;
+                index += 1;
+                inBlockComment = false;
+            }
+            continue;
+        }
         if (escaped) {
             current += ch;
             escaped = false;
@@ -576,7 +595,37 @@ export const splitTopLevelComma = (text: string): string[] => {
             current += ch;
             continue;
         }
+        if (!inSingle && !inDouble && !inBacktick && ch === '[') {
+            inBracket = true;
+            current += ch;
+            continue;
+        }
+        if (inBracket) {
+            current += ch;
+            if (ch === ']' && next === ']') {
+                current += next;
+                index += 1;
+            } else if (ch === ']') {
+                inBracket = false;
+            }
+            continue;
+        }
         if (!inSingle && !inDouble && !inBacktick) {
+            if (ch === '/' && next === '*') {
+                current += ch;
+                inBlockComment = true;
+                continue;
+            }
+            if (ch === '-' && next === '-' && (index === 0 || /\s/.test(previous))) {
+                current += ch;
+                inLineComment = true;
+                continue;
+            }
+            if (ch === '#' && next !== '>' && next !== '-') {
+                current += ch;
+                inLineComment = true;
+                continue;
+            }
             if (ch === '(') parenDepth++;
             if (ch === ')' && parenDepth > 0) parenDepth--;
             if (ch === ',' && parenDepth === 0) {
@@ -644,7 +693,12 @@ export const resolveSimpleSelectItemColumn = (item: string): { resultName: strin
 };
 
 export const parseSimpleSelectInfo = (sql: string): SimpleSelectInfo | undefined => {
-    const match = String(sql || '').match(/^\s*SELECT\s+([\s\S]+?)\s+FROM\s+/i);
+    const text = String(sql || '');
+    // Keep offsets identical to the original SQL while hiding comments and
+    // string literals from the SELECT/FROM structure matcher. A comment before
+    // SELECT must not make an otherwise writable result look read-only.
+    const structuralText = maskQueryEditorSqlLiteralsAndComments(text);
+    const match = structuralText.match(/^\s*SELECT\s+([\s\S]+?)\s+FROM\s+/i);
     if (!match) return undefined;
     const selectList = match[1].trim();
     if (!selectList || /^DISTINCT\b/i.test(selectList)) return undefined;
@@ -670,10 +724,19 @@ export const parseSimpleSelectInfo = (sql: string): SimpleSelectInfo | undefined
 
 export const appendQuerySelectExpressions = (sql: string, expressions: string[]): string => {
     if (expressions.length === 0) return sql;
-    return String(sql || '').replace(
-        /^(\s*SELECT\s+)([\s\S]+?)(\s+FROM\s+[\s\S]*)$/i,
-        (_match, prefix, selectList, rest) => `${prefix}${String(selectList).trimEnd()}, ${expressions.join(', ')}${rest}`,
-    );
+    const text = String(sql || '');
+    const structuralText = maskQueryEditorSqlLiteralsAndComments(text);
+    const match = structuralText.match(/^(\s*SELECT\s+)([\s\S]+?)(\s+FROM\s+[\s\S]*)$/i);
+    if (!match) return text;
+    const prefixLength = match[1].length;
+    const selectListLength = match[2].length;
+    const selectListStructure = structuralText.slice(prefixLength, prefixLength + selectListLength);
+    let insertionOffset = selectListStructure.length;
+    while (insertionOffset > 0 && /\s/.test(selectListStructure[insertionOffset - 1] || '')) {
+        insertionOffset -= 1;
+    }
+    const insertionPoint = prefixLength + insertionOffset;
+    return `${text.slice(0, insertionPoint)}, ${expressions.join(', ')}${text.slice(insertionPoint)}`;
 };
 
 export const QUERY_LOCATOR_SOURCE_ALIAS = 'gonavi_query_source';
@@ -681,31 +744,36 @@ export const QUERY_LOCATOR_SOURCE_ALIAS = 'gonavi_query_source';
 export const rewriteOracleSelectAllWithExpressions = (sql: string, expressions: string[]): string | undefined => {
     if (expressions.length === 0) return undefined;
 
-    const match = String(sql || '').match(/^(\s*SELECT\s+)([\s\S]+?)(\s+FROM\s+)([\s\S]*)$/i);
+    const text = String(sql || '');
+    const structuralText = maskQueryEditorSqlLiteralsAndComments(text);
+    const match = structuralText.match(/^(\s*SELECT\s+)([\s\S]+?)(\s+FROM\s+)([\s\S]*)$/i);
     if (!match) return undefined;
 
     const prefix = match[1];
-    const selectList = match[2].trim();
-    const fromKeyword = match[3];
-    const fromTail = match[4];
+    const selectList = text.slice(prefix.length, prefix.length + match[2].length).trim();
+    const fromSeparatorStart = prefix.length + match[2].length;
+    const fromSeparator = text.slice(fromSeparatorStart, fromSeparatorStart + match[3].length);
+    const fromTailStart = fromSeparatorStart + match[3].length;
     const selectItems = splitTopLevelComma(selectList);
     if (selectItems.length === 0) return undefined;
 
     let selectAllFound = false;
     for (const item of selectItems) {
-        if (String(item || '').trim() === '*') {
+        if (maskQueryEditorSqlLiteralsAndComments(item).trim() === '*') {
             selectAllFound = true;
             break;
         }
     }
     if (!selectAllFound) return undefined;
 
-    const fromTrimmed = fromTail.trimStart();
-    const tableMatch = fromTrimmed.match(QUERY_EDITOR_SQL_LEADING_IDENTIFIER_PATH_REGEX);
+    const structuralFromTail = structuralText.slice(fromTailStart);
+    const tableMatch = structuralFromTail.match(new RegExp(`^(\\s*)(${QUERY_EDITOR_SQL_IDENTIFIER_PATH_PATTERN})([\\s\\S]*)$`));
     if (!tableMatch) return undefined;
 
-    const tableText = tableMatch[1];
-    const afterTable = tableMatch[2] || '';
+    const tableStart = fromTailStart + (tableMatch[1] || '').length;
+    const tableEnd = tableStart + tableMatch[2].length;
+    const tableText = text.slice(tableStart, tableEnd);
+    const afterTable = text.slice(tableEnd);
 
     const parseAlias = (tail: string): { alias: string; remainder: string } => {
         const trimmedTail = String(tail || '').trimStart();
@@ -747,16 +815,18 @@ export const rewriteOracleSelectAllWithExpressions = (sql: string, expressions: 
     if (qualifiedExpressions.length === 0) return undefined;
 
     const rewrittenSelectItems = selectItems.map((item) => {
-        const trimmed = String(item || '').trim();
-        if (trimmed === '*') {
-            return `${sourceAlias}.*`;
+        const rawItem = String(item || '');
+        const structuralItem = maskQueryEditorSqlLiteralsAndComments(rawItem);
+        if (structuralItem.trim() === '*') {
+            const wildcardOffset = structuralItem.indexOf('*');
+            return `${rawItem.slice(0, wildcardOffset)}${sourceAlias}.*${rawItem.slice(wildcardOffset + 1)}`;
         }
-        return item.trimEnd();
+        return rawItem.trimEnd();
     });
 
     const aliasClause = parsedAlias.alias ? ` ${parsedAlias.alias}` : ` ${sourceAlias}`;
     const finalSelectItems = [...rewrittenSelectItems, ...qualifiedExpressions];
-    return `${prefix}${finalSelectItems.join(', ')}${fromKeyword}${tableText}${aliasClause}${parsedAlias.remainder}`;
+    return `${text.slice(0, prefix.length)}${finalSelectItems.join(', ')}${fromSeparator}${text.slice(fromTailStart, tableStart)}${tableText}${aliasClause}${parsedAlias.remainder}`;
 };
 
 export const rewriteOracleDuplicateSelectColumns = (sql: string, tableColumnNames: string[]): string | undefined => {
@@ -767,12 +837,14 @@ export const rewriteOracleDuplicateSelectColumns = (sql: string, tableColumnName
     );
     if (metadataNames.size === 0) return undefined;
 
-    const match = String(sql || '').match(/^(\s*SELECT\s+)([\s\S]+?)(\s+FROM\s+[\s\S]*)$/i);
+    const text = String(sql || '');
+    const structuralText = maskQueryEditorSqlLiteralsAndComments(text);
+    const match = structuralText.match(/^(\s*SELECT\s+)([\s\S]+?)(\s+FROM\s+[\s\S]*)$/i);
     if (!match) return undefined;
 
     const prefix = match[1];
-    const selectList = match[2].trim();
-    const rest = match[3];
+    const selectList = text.slice(prefix.length, prefix.length + match[2].length).trim();
+    const rest = text.slice(prefix.length + match[2].length);
     const selectItems = splitTopLevelComma(selectList);
     if (selectItems.length === 0) return undefined;
 
@@ -807,7 +879,7 @@ export const rewriteOracleDuplicateSelectColumns = (sql: string, tableColumnName
         return `${info.expression} AS ${alias}`;
     });
 
-    return changed ? `${prefix}${rewrittenItems.join(', ')}${rest}` : undefined;
+    return changed ? `${text.slice(0, prefix.length)}${rewrittenItems.join(', ')}${rest}` : undefined;
 };
 
 export const findWritableResultColumnForSource = (writableColumns: Record<string, string>, target: string): string | undefined => {
@@ -1626,12 +1698,16 @@ export const splitQueryIdentifierPathSegments = (qualifiedName: string): QueryId
 };
 
 export const matchLeadingSelectTableReference = (sql: string): { prefix: string; tableText: string; suffix: string } | null => {
-    const match = String(sql || '').match(new RegExp(`^(\\s*SELECT\\s+[\\s\\S]+?\\s+FROM\\s+)(${QUERY_EDITOR_SQL_IDENTIFIER_PATH_PATTERN})([\\s\\S]*)$`, 'i'));
+    const text = String(sql || '');
+    const structuralText = maskQueryEditorSqlLiteralsAndComments(text);
+    const match = structuralText.match(new RegExp(`^(\\s*SELECT\\s+[\\s\\S]+?\\s+FROM\\s+)(${QUERY_EDITOR_SQL_IDENTIFIER_PATH_PATTERN})([\\s\\S]*)$`, 'i'));
     if (!match) return null;
+    const tableStart = match[1].length;
+    const tableEnd = tableStart + match[2].length;
     return {
-        prefix: match[1],
-        tableText: match[2],
-        suffix: match[3] || '',
+        prefix: text.slice(0, tableStart),
+        tableText: text.slice(tableStart, tableEnd),
+        suffix: text.slice(tableEnd),
     };
 };
 

--- a/frontend/src/utils/queryResultTable.test.ts
+++ b/frontend/src/utils/queryResultTable.test.ts
@@ -204,4 +204,18 @@ describe('extractQueryResultTableRef', () => {
     expect(extractQueryResultTableRef('SELECT DISTINCT ID FROM users', 'mysql', 'app'))
       .toBeUndefined();
   });
+
+  it.each([
+    ['leading line comments', '-- query source\nSELECT * FROM users', 'users'],
+    ['leading block comments', '/* query source */\nSELECT * FROM users', 'users'],
+    ['comments that mention JOIN', '/* JOIN legacy documentation */\nSELECT * FROM users', 'users'],
+    ['leading hash comments', '# JOIN legacy documentation\nSELECT * FROM users', 'users'],
+    ['comments between FROM and the table', 'SELECT * FROM /* primary source */ users', 'users'],
+  ])('keeps single-table metadata for %s', (_label, sql, tableName) => {
+    expect(extractQueryResultTableRef(sql, 'mysql', 'app')).toMatchObject({
+      tableName,
+      metadataDbName: 'app',
+      metadataTableName: tableName,
+    });
+  });
 });

--- a/frontend/src/utils/queryResultTable.ts
+++ b/frontend/src/utils/queryResultTable.ts
@@ -68,13 +68,47 @@ const QUERY_RESULT_TABLE_REFERENCE_REGEX = new RegExp(
   'i',
 );
 
-const maskNestedAndQuotedSql = (raw: string): string => {
+const HASH_COMMENT_DIALECTS = new Set([
+  'mysql', 'mariadb', 'oceanbase', 'starrocks', 'tidb', 'diros', 'goldendb', 'sphinx', 'clickhouse',
+]);
+
+const skipSqlTrivia = (text: string, position: number, dialect: string): number => {
+  const normalizedDialect = String(dialect || '').trim().toLowerCase();
+  let index = Math.max(0, position);
+  while (index < text.length) {
+    if (/\s/.test(text[index] || '')) {
+      index += 1;
+      continue;
+    }
+    if (text.startsWith('--', index)) {
+      const lineEnd = text.indexOf('\n', index + 2);
+      index = lineEnd < 0 ? text.length : lineEnd + 1;
+      continue;
+    }
+    if (HASH_COMMENT_DIALECTS.has(normalizedDialect) && text[index] === '#') {
+      const lineEnd = text.indexOf('\n', index + 1);
+      index = lineEnd < 0 ? text.length : lineEnd + 1;
+      continue;
+    }
+    if (text.startsWith('/*', index)) {
+      const blockEnd = text.indexOf('*/', index + 2);
+      index = blockEnd < 0 ? text.length : blockEnd + 2;
+      continue;
+    }
+    break;
+  }
+  return index;
+};
+
+const maskNestedAndQuotedSql = (raw: string, dialect = ''): string => {
   const text = String(raw || '');
   const output: string[] = [];
   let depth = 0;
   let quote = '';
   let lineComment = false;
   let blockComment = false;
+  const normalizedDialect = String(dialect || '').trim().toLowerCase();
+  const supportsHashComment = !normalizedDialect || HASH_COMMENT_DIALECTS.has(normalizedDialect);
 
   for (let index = 0; index < text.length; index += 1) {
     const char = text[index];
@@ -131,6 +165,11 @@ const maskNestedAndQuotedSql = (raw: string): string => {
       blockComment = true;
       output.push(' ', ' ');
       index += 1;
+      continue;
+    }
+    if (supportsHashComment && char === '#') {
+      lineComment = true;
+      output.push(' ');
       continue;
     }
     if (char === '\'' || char === '"' || char === '`' || char === '[') {
@@ -240,11 +279,11 @@ export const extractQueryResultTableRef = (
 ): QueryResultTableRef | undefined => {
   const text = String(sql || '').trim();
   if (!text) return undefined;
-  if (/\b(JOIN|UNION|INTERSECT|EXCEPT|MINUS)\b/i.test(text)) return undefined;
-  if (/^\s*SELECT\s+DISTINCT\b/i.test(text)) return undefined;
-  if (/\bGROUP\s+BY\b|\bHAVING\b/i.test(text)) return undefined;
 
-  const topLevelSql = maskNestedAndQuotedSql(text);
+  const topLevelSql = maskNestedAndQuotedSql(text, dialect);
+  if (/\b(JOIN|UNION|INTERSECT|EXCEPT|MINUS)\b/i.test(topLevelSql)) return undefined;
+  if (/^\s*SELECT\s+DISTINCT\b/i.test(topLevelSql)) return undefined;
+  if (/\bGROUP\s+BY\b|\bHAVING\b/i.test(topLevelSql)) return undefined;
   const topLevelFromMatch = /\bFROM\b/i.exec(topLevelSql);
   if (topLevelFromMatch?.index === undefined) return undefined;
   const sourceOffset = topLevelFromMatch.index + topLevelFromMatch[0].length;
@@ -253,7 +292,8 @@ export const extractQueryResultTableRef = (
   )?.[1] || '';
   if (topLevelFromClause.includes(',') || /\bAPPLY\b/i.test(topLevelFromClause)) return undefined;
 
-  const tableMatch = text.slice(sourceOffset).match(QUERY_RESULT_TABLE_REFERENCE_REGEX);
+  const tableStart = skipSqlTrivia(text, sourceOffset, dialect);
+  const tableMatch = text.slice(tableStart).match(QUERY_RESULT_TABLE_REFERENCE_REGEX);
   if (!tableMatch) return undefined;
 
   const parts = normalizeQualifiedNameParts(tableMatch[1], dialect);

--- a/frontend/src/utils/sqlStatementSelection.test.ts
+++ b/frontend/src/utils/sqlStatementSelection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { findSqlStatementRanges, resolveCurrentSqlStatementRange, resolveExecutableSql } from './sqlStatementSelection';
+import { findSqlStatementRanges, resolveCurrentSqlStatementRange, resolveExecutableSql, stripLeadingSqlTrivia } from './sqlStatementSelection';
 
 describe('sqlStatementSelection', () => {
   it('resolves the statement containing the cursor', () => {
@@ -320,14 +320,9 @@ describe('sqlStatementSelection', () => {
       ].join('\n'),
       'SELECT 1 FROM dual',
     ]);
-    expect(resolveExecutableSql(sql, sql.indexOf('CREATE OR REPLACE'))).toEqual({
-      sql: ranges[0],
-      source: 'statement',
-    });
-    expect(resolveExecutableSql(sql, sql.indexOf('p_msg_out := SQLERRM'))).toEqual({
-      sql: ranges[0],
-      source: 'statement',
-    });
+    expect(resolveExecutableSql(sql, sql.indexOf('CREATE OR REPLACE'))).toMatchObject({ source: 'statement' });
+    expect(resolveExecutableSql(sql, sql.indexOf('CREATE OR REPLACE'))?.sql).toBe(ranges[0].replace(/^--[^\n]*\n--[^\n]*\n/, ''));
+    expect(resolveExecutableSql(sql, sql.indexOf('p_msg_out := SQLERRM'))?.sql).toBe(ranges[0].replace(/^--[^\n]*\n--[^\n]*\n/, ''));
   });
 
   it('keeps large Oracle procedures intact when the cursor is in the exception tail', () => {
@@ -379,12 +374,10 @@ describe('sqlStatementSelection', () => {
     expect(ranges[0]).toContain('EXCEPTION');
     expect(ranges[0]).toContain('END cproc_tzhssr_order2sale_A1;');
     expect(ranges[1]).toBe('SELECT 1 FROM dual');
-    expect(resolveExecutableSql(sql, sql.indexOf('p_msg_out := substr'))).toEqual({
-      sql: ranges[0],
-      source: 'statement',
-    });
+    expect(resolveExecutableSql(sql, sql.indexOf('p_msg_out := substr'))).toMatchObject({ source: 'statement' });
+    expect(resolveExecutableSql(sql, sql.indexOf('p_msg_out := substr'))?.sql).toBe(ranges[0].replace(/^--[^\n]*\n--[^\n]*\n/, ''));
     expect(resolveExecutableSql(sql, sql.indexOf('/ -- SQLPlus delimiter'))).toEqual({
-      sql: ranges[0],
+      sql: ranges[0].replace(/^--[^\n]*\n--[^\n]*\n/, ''),
       source: 'statement',
     });
     expect(resolveCurrentSqlStatementRange(sql, sql.indexOf('/ -- SQLPlus delimiter'))?.text).toBe(ranges[0]);
@@ -575,5 +568,23 @@ describe('sqlStatementSelection', () => {
   it('returns null for empty or comment-only SQL', () => {
     expect(resolveExecutableSql('  \n\t  ', 0)).toBeNull();
     expect(resolveExecutableSql('-- nothing to execute\n\n/* still nothing */', 3)).toBeNull();
+  });
+
+  it('does not send detached leading comments when executing the cursor statement', () => {
+    const sql = '-- exported row\n-- exported batch\nSELECT * FROM contract WHERE contract_code = \'YEC202608039\';';
+    const cursorAtSemicolon = sql.length - 1;
+    expect(resolveExecutableSql(sql, cursorAtSemicolon)).toEqual({
+      sql: "SELECT * FROM contract WHERE contract_code = 'YEC202608039'",
+      source: 'statement',
+    });
+    expect(stripLeadingSqlTrivia('/* documentation */\n# mysql note\nSELECT * FROM users', 'mysql'))
+      .toBe('SELECT * FROM users');
+  });
+
+  it('keeps executable and optimizer hint comments at the start of a statement', () => {
+    expect(stripLeadingSqlTrivia('/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE */ SELECT * FROM users', 'mysql'))
+      .toBe('/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE */ SELECT * FROM users');
+    expect(stripLeadingSqlTrivia('/*+ parallel(4) */ SELECT * FROM users', 'oracle'))
+      .toBe('/*+ parallel(4) */ SELECT * FROM users');
   });
 });

--- a/frontend/src/utils/sqlStatementSelection.ts
+++ b/frontend/src/utils/sqlStatementSelection.ts
@@ -90,6 +90,40 @@ const hasExecutableSqlStatementContent = (sql: string, dbType = ''): boolean => 
   return false;
 };
 
+/**
+ * Remove only non-executable trivia before a statement keyword. Statement
+ * ranges intentionally retain comments for editor navigation, but the SQL
+ * sent to the driver should not include detached documentation comments.
+ */
+export const stripLeadingSqlTrivia = (sql: string, dbType = ''): string => {
+  const text = String(sql || '');
+  let index = 0;
+  while (index < text.length) {
+    const ch = text[index];
+    const next = text[index + 1] || '';
+    if (isWhitespace(ch)) {
+      index += 1;
+      continue;
+    }
+    if ((ch === '#' && supportsSqlHashLineComment(dbType))
+      || (ch === '-' && next === '-' && isSqlDashLineCommentStart(dbType, text[index + 2] || ''))) {
+      const lineEnd = text.indexOf('\n', index + (ch === '#' ? 1 : 2));
+      index = lineEnd < 0 ? text.length : lineEnd + 1;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      if (isExecutableSqlBlockComment(text, index, dbType) || text.startsWith('/*+', index)) {
+        break;
+      }
+      const blockEnd = text.indexOf('*/', index + 2);
+      index = blockEnd < 0 ? text.length : blockEnd + 2;
+      continue;
+    }
+    break;
+  }
+  return text.slice(index).replace(/\s+$/, '');
+};
+
 const skipSqlWhitespaceAndComments = (text: string, position: number): number => {
   let index = position;
   while (index < text.length) {
@@ -524,14 +558,14 @@ export const resolveExecutableSql = (
   }
   const statement = ranges.find((range) => offset >= range.start && offset <= range.end);
   if (statement?.text.trim()) {
-    return { sql: statement.text, source: 'statement' };
+    return { sql: stripLeadingSqlTrivia(statement.text, dbType), source: 'statement' };
   }
 
   const slashLine = resolveStandaloneSqlSlashLineAtOffset(text, offset);
   if (slashLine) {
     const previousStatement = findPreviousSqlStatementRange(ranges, slashLine.lineStart);
     return previousStatement?.text.trim()
-      ? { sql: previousStatement.text, source: 'statement' }
+      ? { sql: stripLeadingSqlTrivia(previousStatement.text, dbType), source: 'statement' }
       : null;
   }
 
@@ -542,7 +576,7 @@ export const resolveExecutableSql = (
   if (line) {
     const lineStatement = [...ranges].reverse().find((range) => range.start < lineEnd && range.end >= lineStart);
     if (lineStatement?.text.trim()) {
-      return { sql: lineStatement.text, source: 'statement' };
+      return { sql: stripLeadingSqlTrivia(lineStatement.text, dbType), source: 'statement' };
     }
   }
   if (line) {


### PR DESCRIPTION
## 背景

执行 QueryEditor 中光标所在的单条 SQL 时，语句前存在普通行注释或块注释会导致注释被一并发送到后端；同时，注释会干扰单表结果的表引用与可编辑 locator 识别，出现同一条 SQL 挪到其他位置后才能修改的问题。

## 变更

- 执行光标所在语句时移除前置普通注释，保留 MySQL executable comments 与 Oracle optimizer hints 等有执行语义的注释。
- 统一注释感知的 SELECT、FROM、表引用和定位列注入解析，避免注释中的关键字、逗号影响结构判断。
- 规范化整篇编辑器执行判断，避免剥离前置注释后被误判为追加执行并重复生成结果集。
- 增加行注释、块注释、`#` 注释、注释关键字/逗号、FROM 与表名之间注释的回归覆盖。

## 影响范围

- QueryEditor 光标执行、快捷键执行与当前语句选择。
- 单表查询结果集的表元数据识别和行编辑能力。
- Oracle 隐藏 ROWID 定位列注入及 MySQL/SQLite 等方言的结果表解析。

## 验证

- frontend：5 个受影响 Vitest 文件，333 项通过。
- TypeScript：`tsc --noEmit` 通过。
- PR 分支已基于最新 `dev`，GitHub mergeable 状态为 `MERGEABLE`。

## 风险与回滚

改动仅调整 SQL 语句范围清理、结果集 metadata 识别与可编辑定位逻辑，不改用户数据。若出现方言兼容问题，可直接回滚本 PR 的 commit。