### PR TITLE
feat(sidebar): 支持 schema 节点新建查询

### DIFF
--- a/frontend/src/components/Sidebar.locate-toolbar.test.tsx
+++ b/frontend/src/components/Sidebar.locate-toolbar.test.tsx
@@ -2784,6 +2784,7 @@ describe('Sidebar locate toolbar', () => {
     expect(markup).toContain('SCHEMA');
     expect(markup).toContain('app_db · Schema actions');
     expect(markup).toContain('Maintenance');
+    expect(markup).toContain('New query');
     expect(markup).toContain('Edit schema');
     expect(markup).toContain('Refresh object tree');
     expect(markup).toContain('Export and backup');

--- a/frontend/src/components/V2TableContextMenu.tsx
+++ b/frontend/src/components/V2TableContextMenu.tsx
@@ -370,6 +370,7 @@ export type V2DatabaseContextMenuActionKey =
   | 'drop-db';
 
 export type V2SchemaContextMenuActionKey =
+  | 'new-query'
   | 'rename-schema'
   | 'refresh-schema'
   | 'export-schema'
@@ -492,6 +493,7 @@ export const V2SchemaContextMenuView: React.FC<{
       <div className="gn-v2-context-menu-body">
         <div className="gn-v2-context-menu-section-title">{t('sidebar.v2_table_menu.maintenance_section')}</div>
         {renderItems([
+          { action: 'new-query', icon: <ConsoleSqlOutlined />, title: t('sidebar.menu.new_query'), featured: true },
           { action: 'rename-schema', icon: <EditOutlined />, title: t('sidebar.v2_schema_menu.edit_schema'), kbd: 'F2', featured: true },
           { action: 'refresh-schema', icon: <ReloadOutlined />, title: t('sidebar.v2_database_menu.refresh_object_tree'), kbd: primaryShortcut('R', shortcutPlatform) },
         ])}

--- a/frontend/src/components/sidebar/sidebarLegacyNodeMenu.query-capability.test.tsx
+++ b/frontend/src/components/sidebar/sidebarLegacyNodeMenu.query-capability.test.tsx
@@ -26,6 +26,26 @@ const buildConnectionRootItems = (
 const itemKeys = (items: any[]) => items.map((item) => item?.key);
 
 describe('connection root menu query entry gating', () => {
+  it('offers new query from a PostgreSQL-compatible schema node', () => {
+    const items = buildSidebarLegacyNodeMenuItems({
+      key: 'conn-1-app-schema-sales',
+      type: 'object-group',
+      dataRef: {
+        id: 'conn-1',
+        dbName: 'app',
+        schemaName: 'sales',
+        groupKey: 'schema',
+        config: { type: 'kingbase' },
+      },
+    }, {
+      getMetadataDialect: () => 'kingbase',
+      isPostgresSchemaDialect: () => true,
+      handleV2DatabaseContextMenuAction: vi.fn(),
+    }) as any[];
+
+    expect(itemKeys(items)).toContain('new-query');
+  });
+
   it('hides new query and run SQL file for JVM connections', () => {
     const items = buildConnectionRootItems({
       id: 'jvm-1',

--- a/frontend/src/components/sidebar/sidebarLegacyNodeMenu.tsx
+++ b/frontend/src/components/sidebar/sidebarLegacyNodeMenu.tsx
@@ -414,6 +414,12 @@ export const buildSidebarLegacyNodeMenuItems = (
         }
         return [
             {
+                key: 'new-query',
+                label: t('sidebar.menu.new_query'),
+                icon: <ConsoleSqlOutlined />,
+                onClick: () => handleV2DatabaseContextMenuAction(node, 'new-query'),
+            },
+            {
                 key: 'rename-schema',
                 label: t('sidebar.menu.edit_schema'),
                 icon: <EditOutlined />,

--- a/frontend/src/components/sidebar/useSidebarV2ActionHandlers.elasticsearch.test.ts
+++ b/frontend/src/components/sidebar/useSidebarV2ActionHandlers.elasticsearch.test.ts
@@ -92,4 +92,26 @@ describe('useSidebarV2ActionHandlers Elasticsearch create action', () => {
     expect(setIsCreateDbModalOpen).toHaveBeenCalledWith(true);
     expect(addTab).not.toHaveBeenCalled();
   });
+
+  it('opens a schema-scoped query with both database and schema context', () => {
+    const { handlers, addTab } = buildHandlers();
+    handlers.handleV2DatabaseContextMenuAction({
+      key: 'conn-1-app-schema-sales',
+      title: 'sales',
+      dataRef: {
+        id: 'conn-1',
+        dbName: 'app',
+        schemaName: 'sales',
+        config: { type: 'kingbase' },
+      },
+    }, 'new-query');
+
+    expect(addTab).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'query',
+      connectionId: 'conn-1',
+      dbName: 'app',
+      schemaName: 'sales',
+      query: '',
+    }));
+  });
 });

--- a/frontend/src/components/sidebar/useSidebarV2ActionHandlers.tsx
+++ b/frontend/src/components/sidebar/useSidebarV2ActionHandlers.tsx
@@ -394,13 +394,15 @@ export const useSidebarV2ActionHandlers = ({
 
   const openDatabaseQuery = (node: any) => {
     const dbName = String(node.dataRef?.dbName || node.title || '').trim();
+    const schemaName = String(node.dataRef?.schemaName || '').trim();
     const dbType = getMetadataDialect(node.dataRef as SavedConnection);
     addTab({
       id: `query-${Date.now()}`,
-      title: t('sidebar.tab.new_query_database', { database: node.title }),
+      title: t('sidebar.tab.new_query_database', { database: dbName }),
       type: 'query',
       connectionId: node.dataRef.id,
       dbName,
+      schemaName: schemaName || undefined,
       query: isElasticsearchDbType(dbType)
         ? buildTableSelectQuery(dbType, dbName)
         : '',

--- a/frontend/src/components/sidebar/useSidebarV2ContextMenu.tsx
+++ b/frontend/src/components/sidebar/useSidebarV2ContextMenu.tsx
@@ -420,6 +420,9 @@ export const useSidebarV2ContextMenu = ({
 
   const handleV2SchemaContextMenuAction = (node: any, action: V2SchemaContextMenuActionKey) => {
       switch (action) {
+          case 'new-query':
+              handleV2DatabaseContextMenuAction(node, 'new-query');
+              return;
           case 'rename-schema':
               openRenameSchemaModal(node);
               return;


### PR DESCRIPTION
## 背景

Kingbase、PostgreSQL 兼容连接的 schema 节点此前没有“新建查询”入口，用户只能从数据库节点创建查询，无法直接保留当前 schema 上下文。

## 变更

- 为 V2 schema 右键菜单增加“新建查询”。
- Legacy 侧栏 schema 菜单同步增加“新建查询”。
- 新建查询 Tab 传递真实数据库名和 schema 名，保留 schema 作用域。
- 增加 schema 菜单渲染和 action handler 回归测试。

## 影响范围

- Kingbase、PostgreSQL 兼容连接的 schema 节点右键菜单。
- 新建查询 Tab 的数据库和 schema 上下文。
- Legacy/V2 侧栏菜单行为。

## 验证

- 受影响的 3 个 Vitest 文件：115 项通过。
- `npm exec tsc -- --noEmit` 通过。
- `git diff --check` 通过。

## 风险与回滚

改动仅增加 schema 菜单入口并复用已有数据库新建查询 action，不修改数据库数据和连接释放逻辑。如需回滚，可直接回滚本 PR 的 squash commit。