### PR TITLE
修复查询编辑器手输别名分号上下文丢失

### DIFF
--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -3428,8 +3428,8 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
           return;
       }
 
-      const intent = resolveQueryEditorInlineCompletionIntentDetails(editorSnapshot);
       const metadataDialect = normalizeMetadataDialect(contextConnection);
+      const intent = resolveQueryEditorInlineCompletionIntentDetails(editorSnapshot, metadataDialect);
       const normalizedDbName = buildQueryEditorMetadataIdentityKey(metadataDialect, dbName);
       const needsTables = intent.intent === 'table_name'
           || !tablesRef.current.some((table) => (
@@ -6123,7 +6123,10 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
               currentLineBeforeCursor: lineBeforeCursor.slice(0, -1),
               currentLineAfterCursor: String(snapshot.currentLineAfterCursor || ''),
           };
-          const intent = resolveQueryEditorInlineCompletionIntentDetails(sanitizedSnapshot);
+          const markerDialect = normalizeMetadataDialect(connectionsRef.current.find(
+              (item) => item.id === currentConnectionIdRef.current,
+          ));
+          const intent = resolveQueryEditorInlineCompletionIntentDetails(sanitizedSnapshot, markerDialect);
           if (intent.intent !== 'table_name' && intent.intent !== 'column_name') {
               return { position, snapshot, recovered: false };
           }
@@ -6313,7 +6316,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
           if (!autoAddTableAlias && isQueryEditorInlineTableAliasPending(editorSnapshot, inlineDialect)) {
               return;
           }
-          const intent = resolveQueryEditorInlineCompletionIntentDetails(editorSnapshot);
+          const intent = resolveQueryEditorInlineCompletionIntentDetails(editorSnapshot, inlineDialect);
           const shouldUseInlineMemory = manualTrigger || intent.intent !== 'general_sql';
           let memoryInsertText = '';
           if (shouldUseInlineMemory) {
@@ -6322,6 +6325,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                   editorSnapshot,
                   memoryEntries: inlineSqlMemoryEntries,
                   sourceType: initialAiContext.sourceType,
+                  sqlDialect: initialAiContext.sqlDialect,
               });
               // Empty fragments do not need metadata-based case correction and retain
               // the previous immediate memory-completion behavior.
@@ -6355,6 +6359,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                                   editorSnapshot,
                                   memoryEntries: inlineSqlMemoryEntries,
                                   sourceType: initialAiContext.sourceType,
+                                  sqlDialect: initialAiContext.sqlDialect,
                               });
                           }
                           if (memoryInsertText.trim()) {
@@ -6380,7 +6385,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                               return;
                           }
                       }
-                      if (!shouldRequestQueryEditorInlineCompletion(editorSnapshot)) {
+                      if (!shouldRequestQueryEditorInlineCompletion(editorSnapshot, inlineDialect)) {
                           return;
                       }
                       const aiContext = buildQueryEditorAiContext();
@@ -6986,8 +6991,11 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
               markerOffset,
               1,
           );
+          const fallbackDialect = normalizeMetadataDialect(connectionsRef.current.find(
+              (item) => item.id === currentConnectionIdRef.current,
+          ));
           const fallbackIntent = fallbackSnapshot
-              ? resolveQueryEditorInlineCompletionIntentDetails(fallbackSnapshot)
+              ? resolveQueryEditorInlineCompletionIntentDetails(fallbackSnapshot, fallbackDialect)
               : null;
           const hasStructuredSqlCompletionContext = fallbackIntent?.intent === 'table_name'
               || fallbackIntent?.intent === 'column_name';

--- a/frontend/src/components/queryEditor/QueryEditorAiAssist.test.ts
+++ b/frontend/src/components/queryEditor/QueryEditorAiAssist.test.ts
@@ -870,6 +870,79 @@ describe('QueryEditorAiAssist', () => {
         expect(service.AIGetActiveProvider).not.toHaveBeenCalled();
     });
 
+    it('keeps manual table-alias context across semicolons in strings and comments', async () => {
+        const service = readyService('SELECT * FROM system_user su;');
+        const request = {
+            service,
+            aiContext: {
+                connectionName: 'Local MySQL',
+                sourceType: 'mysql',
+                currentDb: 'shop',
+                tables: [
+                    { dbName: 'shop', tableName: 'system_user' },
+                    { dbName: 'shop', tableName: 'service_user' },
+                ],
+                columns: [],
+            },
+        };
+        const makeSnapshot = (prefix: string) => ({
+            prefix,
+            suffix: '',
+            currentLineBeforeCursor: prefix.split(/\r?\n/).pop() || '',
+            currentLineAfterCursor: '',
+        });
+
+        for (const prefix of [
+            "SELECT * FROM system_user su WHERE note = ';' JOIN service_user ",
+            'SELECT * FROM system_user su -- ;\r\nJOIN service_user ',
+            'SELECT * FROM system_user su # ;\r\nJOIN service_user ',
+            'SELECT * FROM shop.system_user su /* ; */ JOIN shop.service_user ',
+        ]) {
+            await expect(requestQueryEditorInlineCompletion({
+                ...request,
+                editorSnapshot: makeSnapshot(prefix),
+            })).resolves.toBe('AS su2');
+            expect(isQueryEditorInlineTableAliasPending(makeSnapshot(prefix), 'mysql')).toBe(true);
+        }
+        expect(service.AISubmitAgentInput).not.toHaveBeenCalled();
+    });
+
+    it('starts manual alias generation from the new statement after a real separator', async () => {
+        const service = readyService('SELECT * FROM system_user su;');
+        const prefix = 'SELECT * FROM system_user su; SELECT * FROM service_user ';
+        const editorSnapshot = {
+            prefix,
+            suffix: '',
+            currentLineBeforeCursor: prefix,
+            currentLineAfterCursor: '',
+        };
+
+        await expect(requestQueryEditorInlineCompletion({
+            service,
+            aiContext: {
+                connectionName: 'Local MySQL',
+                sourceType: 'mysql',
+                currentDb: 'shop',
+                tables: [
+                    { dbName: 'shop', tableName: 'system_user' },
+                    { dbName: 'shop', tableName: 'service_user' },
+                ],
+                columns: [],
+            },
+            editorSnapshot,
+        })).resolves.toBe('AS su');
+        expect(resolveQueryEditorInlineCompletionIntentDetails({
+            ...editorSnapshot,
+            prefix: 'SELECT * FROM system_user su; SELECT * FROM ser',
+            currentLineBeforeCursor: 'SELECT * FROM system_user su; SELECT * FROM ser',
+        }, 'mysql')).toEqual({
+            intent: 'table_name',
+            fragment: 'ser',
+            qualifier: '',
+        });
+        expect(service.AISubmitAgentInput).not.toHaveBeenCalled();
+    });
+
     it('uses an alias without AS after a manually entered Oracle table name', async () => {
         const service = readyService('SELECT * FROM system_user su;');
         await expect(requestQueryEditorInlineCompletion({
@@ -889,6 +962,42 @@ describe('QueryEditorAiAssist', () => {
             },
         })).resolves.toBe('su');
         expect(service.AISubmitAgentInput).not.toHaveBeenCalled();
+    });
+
+    it('keeps Oracle alias syntax after a comment semicolon, including OceanBase Oracle mode', async () => {
+        const prefix = 'SELECT * FROM system_user su /* ; */ JOIN service_user ';
+        const editorSnapshot = {
+            prefix,
+            suffix: '',
+            currentLineBeforeCursor: prefix,
+            currentLineAfterCursor: '',
+        };
+        for (const aiContext of [
+            {
+                connectionName: 'Local Oracle',
+                sourceType: 'oracle',
+                currentDb: 'ORCL',
+            },
+            {
+                connectionName: 'OceanBase Oracle',
+                sourceType: 'oceanbase',
+                sqlDialect: 'oracle',
+                currentDb: 'ORCL',
+            },
+        ]) {
+            await expect(requestQueryEditorInlineCompletion({
+                service: readyService('SELECT * FROM system_user su;'),
+                aiContext: {
+                    ...aiContext,
+                    tables: [
+                        { dbName: 'ORCL', tableName: 'system_user' },
+                        { dbName: 'ORCL', tableName: 'service_user' },
+                    ],
+                    columns: [],
+                },
+                editorSnapshot,
+            })).resolves.toBe('su2');
+        }
     });
 
     it('does not suggest aliases after DML targets but keeps INSERT SELECT aliases', async () => {

--- a/frontend/src/components/queryEditor/QueryEditorAiAssist.ts
+++ b/frontend/src/components/queryEditor/QueryEditorAiAssist.ts
@@ -19,6 +19,7 @@ import {
 import { isPostgresSchemaDialect } from '../../utils/connectionDriverType';
 import { buildMetadataIdentityKey } from '../../utils/metadataIdentity';
 import { appendTableAlias, resolveTableAliasSyntax } from '../../utils/sqlDialect';
+import { resolveSqlStatementPrefix } from '../../utils/sqlStatementSelection';
 import {
     readAgentRun,
     submitAgentInput,
@@ -237,13 +238,14 @@ export const resolveQueryEditorInlineRuntimeReadiness = (
 
 export const shouldRequestQueryEditorInlineCompletion = (
     snapshot: QueryEditorAiEditorSnapshot,
+    sqlDialect = '',
 ): boolean => {
-    if (!shouldAllowQueryEditorInlineMemoryCompletion(snapshot)) {
+    if (!shouldAllowQueryEditorInlineMemoryCompletion(snapshot, sqlDialect)) {
         return false;
     }
 
     const prefix = String(snapshot.prefix || '');
-    const currentStatement = getCurrentStatementPrefix(prefix);
+    const currentStatement = getCurrentStatementPrefix(prefix, sqlDialect);
     const trimmedStatement = currentStatement.trim();
     if (trimmedStatement.length < 3) {
         return false;
@@ -253,6 +255,7 @@ export const shouldRequestQueryEditorInlineCompletion = (
 
 export const shouldAllowQueryEditorInlineMemoryCompletion = (
     snapshot: QueryEditorAiEditorSnapshot,
+    sqlDialect = '',
 ): boolean => {
     const lineAfterCursor = String(snapshot.currentLineAfterCursor || '');
     if (lineAfterCursor.length > 0) {
@@ -260,7 +263,7 @@ export const shouldAllowQueryEditorInlineMemoryCompletion = (
     }
 
     const prefix = String(snapshot.prefix || '');
-    const currentStatement = getCurrentStatementPrefix(prefix);
+    const currentStatement = getCurrentStatementPrefix(prefix, sqlDialect);
     const trimmedStatement = currentStatement.trim();
     if (/[;)]\s*$/.test(trimmedStatement)) {
         return false;
@@ -337,16 +340,19 @@ export const resolveQueryEditorInlineMemoryInsertText = ({
     editorSnapshot,
     memoryEntries,
     sourceType,
+    sqlDialect,
 }: {
     editorSnapshot: QueryEditorAiEditorSnapshot;
     memoryEntries: QueryEditorInlineMemoryEntry[];
     sourceType?: string;
+    sqlDialect?: string;
 }): string => {
-    if (!shouldAllowQueryEditorInlineMemoryCompletion(editorSnapshot)) {
+    const dialect = sqlDialect || sourceType || '';
+    if (!shouldAllowQueryEditorInlineMemoryCompletion(editorSnapshot, dialect)) {
         return '';
     }
 
-    const statementPrefix = getCurrentStatementPrefix(editorSnapshot.prefix);
+    const statementPrefix = getCurrentStatementPrefix(editorSnapshot.prefix, dialect);
     const normalizedStatementPrefix = normalizeInlineMemoryMatchText(statementPrefix);
     for (const entry of memoryEntries || []) {
         const candidateSql = normalizeInlineMemoryCandidateSql(entry?.sql || '');
@@ -356,8 +362,8 @@ export const resolveQueryEditorInlineMemoryInsertText = ({
         if (normalizedStatementPrefix && !normalizeInlineMemoryMatchText(candidateSql).startsWith(normalizedStatementPrefix)) {
             continue;
         }
-        const insertText = resolveInlineSqlInsertText(candidateSql, editorSnapshot.prefix);
-        const intent = resolveQueryEditorInlineCompletionIntentDetails(editorSnapshot);
+        const insertText = resolveInlineSqlInsertText(candidateSql, editorSnapshot.prefix, dialect);
+        const intent = resolveQueryEditorInlineCompletionIntentDetails(editorSnapshot, dialect);
         return limitInlineInsertText(
             intent.intent === 'table_name' || intent.intent === 'column_name'
                 ? applyInlineMemoryObjectCase(insertText, intent.fragment, isPostgresSchemaDialect(sourceType || ''))
@@ -378,14 +384,14 @@ export const resolveQueryEditorInlineLocalCompletion = ({
     deferEmptySchemaCompletion?: boolean;
     autoAddTableAlias?: boolean;
 }): { handled: boolean; insertText: string } => {
-    if (!shouldRequestQueryEditorInlineCompletion(editorSnapshot)) {
+    const dialect = aiContext.sqlDialect || aiContext.sourceType || '';
+    if (!shouldRequestQueryEditorInlineCompletion(editorSnapshot, dialect)) {
         return {
             handled: true,
             insertText: '',
         };
     }
 
-    const dialect = aiContext.sqlDialect || aiContext.sourceType || '';
     const isTableAliasContext = isQueryEditorInlineTableAliasPending(editorSnapshot, dialect);
     const tableAliasInsertText = autoAddTableAlias
         ? resolveDeterministicInlineTableAliasInsertText(editorSnapshot, dialect)
@@ -406,7 +412,7 @@ export const resolveQueryEditorInlineLocalCompletion = ({
         };
     }
 
-    const inlineIntent = resolveQueryEditorInlineCompletionIntentDetails(editorSnapshot);
+    const inlineIntent = resolveQueryEditorInlineCompletionIntentDetails(editorSnapshot, dialect);
     const deterministicCompletion = resolveDeterministicInlineSchemaCompletion(
         aiContext,
         editorSnapshot,
@@ -437,7 +443,7 @@ export const resolveQueryEditorInlineLocalCompletion = ({
         }
     }
 
-    return resolveDeterministicInlineSyntaxCompletion(editorSnapshot);
+    return resolveDeterministicInlineSyntaxCompletion(editorSnapshot, dialect);
 };
 
 const nextQueryEditorAgentRequestID = (): string => {
@@ -571,6 +577,7 @@ export const requestQueryEditorInlineCompletion = async ({
     editorSnapshot: QueryEditorAiEditorSnapshot;
     autoAddTableAlias?: boolean;
 }): Promise<string> => {
+    const dialect = aiContext.sqlDialect || aiContext.sourceType || '';
     const localCompletion = resolveQueryEditorInlineLocalCompletion({
         aiContext,
         editorSnapshot,
@@ -579,7 +586,7 @@ export const requestQueryEditorInlineCompletion = async ({
     if (localCompletion.handled) {
         return localCompletion.insertText;
     }
-    const inlineIntent = resolveQueryEditorInlineCompletionIntentDetails(editorSnapshot);
+    const inlineIntent = resolveQueryEditorInlineCompletionIntentDetails(editorSnapshot, dialect);
     const readiness = await resolveQueryEditorInlineRuntimeReadiness(service);
     if (!service || !readiness.ready || !readiness.provider) {
         return '';
@@ -605,7 +612,7 @@ export const requestQueryEditorInlineCompletion = async ({
     }
 
     const sanitized = sanitizeSqlAssistantResponse(responseContent);
-    const insertText = resolveInlineSqlInsertText(sanitized, editorSnapshot.prefix);
+    const insertText = resolveInlineSqlInsertText(sanitized, editorSnapshot.prefix, dialect);
     if (inlineIntent.intent === 'table_name') {
         return limitInlineInsertText(resolveValidatedInlineTableAiInsertText(
             inlineAiContext,
@@ -636,7 +643,10 @@ export const shouldTriggerQueryEditorInlineObjectSuggestFallback = ({
     aiContext: QueryEditorAiContext;
     editorSnapshot: QueryEditorAiEditorSnapshot;
 }): boolean => {
-    const intent = resolveQueryEditorInlineCompletionIntentDetails(editorSnapshot);
+    const intent = resolveQueryEditorInlineCompletionIntentDetails(
+        editorSnapshot,
+        aiContext.sqlDialect || aiContext.sourceType || '',
+    );
     if (intent.intent === 'table_name') {
         return shouldAllowInlineTableAiFallback(aiContext, intent.fragment);
     }
@@ -898,14 +908,14 @@ export const sanitizeSqlAssistantResponse = (raw: string): string => {
     return text;
 };
 
-export const resolveInlineSqlInsertText = (generatedSql: string, prefix: string): string => {
+export const resolveInlineSqlInsertText = (generatedSql: string, prefix: string, sqlDialect = ''): string => {
     const generated = String(generatedSql || '').trimEnd();
     if (!generated.trim()) {
         return '';
     }
 
     const prefixText = String(prefix || '');
-    const statementPrefix = getCurrentStatementPrefix(prefixText);
+    const statementPrefix = getCurrentStatementPrefix(prefixText, sqlDialect);
     const candidates = [
         prefixText.slice(-INLINE_PREFIX_LIMIT),
         statementPrefix,
@@ -986,8 +996,8 @@ export const buildQueryEditorInlineCompletionContext = (
 ): QueryEditorAiContext => {
     const currentDb = String(context.currentDb || '').trim();
     const dialect = context.sqlDialect || context.sourceType || '';
-    const statementPrefix = getCurrentStatementPrefix(editorSnapshot.prefix);
-    const intent = resolveQueryEditorInlineCompletionIntentDetails(editorSnapshot);
+    const statementPrefix = getCurrentStatementPrefix(editorSnapshot.prefix, dialect);
+    const intent = resolveQueryEditorInlineCompletionIntentDetails(editorSnapshot, dialect);
     const referencedTables = collectInlineTableReferences(statementPrefix, currentDb, context.visibleDbs || [], dialect);
 
     let nextContext: QueryEditorAiContext;
@@ -1488,8 +1498,9 @@ const collectCurrentDatabaseTables = (
 
 export const resolveQueryEditorInlineCompletionIntentDetails = (
     editorSnapshot: QueryEditorAiEditorSnapshot,
+    sqlDialect = '',
 ): QueryEditorInlineCompletionIntentDetails => {
-    const statementPrefix = getCurrentStatementPrefix(editorSnapshot.prefix);
+    const statementPrefix = getCurrentStatementPrefix(editorSnapshot.prefix, sqlDialect);
     const tableMatch = statementPrefix.match(INLINE_TABLE_COMPLETION_RE);
     if (tableMatch) {
         const rawFragment = String(tableMatch[1] || '').trim();
@@ -1564,7 +1575,7 @@ const resolveInlineColumnOwnerReference = (
 
     const currentDb = String(context.currentDb || '').trim();
     const dialect = context.sqlDialect || context.sourceType || '';
-    const statementPrefix = getCurrentStatementPrefix(editorSnapshot.prefix);
+    const statementPrefix = getCurrentStatementPrefix(editorSnapshot.prefix, dialect);
     const aliasMap = buildQueryEditorAliasMap(statementPrefix, currentDb, dialect);
     const qualifierSegments = splitQueryIdentifierPathSegments(qualifier, dialect);
     const qualifierKey = buildQueryEditorIdentifierIdentityKey(qualifierSegments, dialect);
@@ -1720,6 +1731,7 @@ const resolveValidatedInlineObjectCandidateInsertText = ({
     fragment,
     insertText,
     prefix,
+    sqlDialect,
     normalizer,
     safePattern,
     preserveCandidateCase = false,
@@ -1728,6 +1740,7 @@ const resolveValidatedInlineObjectCandidateInsertText = ({
     fragment: string;
     insertText: string;
     prefix: string;
+    sqlDialect?: string;
     normalizer: (value: string) => string;
     safePattern: RegExp;
     preserveCandidateCase?: boolean;
@@ -1759,6 +1772,7 @@ const resolveValidatedInlineObjectCandidateInsertText = ({
     return resolveInlineSqlInsertText(
         applyQueryEditorCompletionFragmentCase(matchedCandidate, fragment, preserveCandidateCase),
         prefix,
+        sqlDialect,
     );
 };
 
@@ -1805,7 +1819,7 @@ const resolveDeterministicInlineTableAliasInsertText = (
     editorSnapshot: QueryEditorAiEditorSnapshot,
     dialect?: string,
 ): string => {
-    const statementPrefix = getCurrentStatementPrefix(editorSnapshot.prefix);
+    const statementPrefix = getCurrentStatementPrefix(editorSnapshot.prefix, dialect);
     if (!/\s$/.test(statementPrefix) || !isQueryEditorTableAliasCompletionContext(statementPrefix, dialect || '')) {
         return '';
     }
@@ -1822,7 +1836,7 @@ export const isQueryEditorInlineTableAliasPending = (
     editorSnapshot: QueryEditorAiEditorSnapshot,
     dialect = '',
 ): boolean => {
-    const statementPrefix = getCurrentStatementPrefix(editorSnapshot.prefix);
+    const statementPrefix = getCurrentStatementPrefix(editorSnapshot.prefix, dialect);
     if (!/\s$/.test(statementPrefix) || !isQueryEditorTableAliasCompletionContext(statementPrefix, dialect)) {
         return false;
     }
@@ -1855,6 +1869,7 @@ const resolveValidatedInlineTableAiInsertText = (
     fragment,
     insertText,
     prefix: editorSnapshot.prefix,
+    sqlDialect: context.sqlDialect || context.sourceType || '',
     normalizer: normalizeInlineIdentifierPath,
     safePattern: INLINE_TABLE_FRAGMENT_SAFE_RE,
     preserveCandidateCase: isPostgresSchemaDialect(context.sourceType || ''),
@@ -1871,6 +1886,7 @@ const resolveValidatedInlineColumnAiInsertText = (
     fragment,
     insertText,
     prefix: editorSnapshot.prefix,
+    sqlDialect: context.sqlDialect || context.sourceType || '',
     normalizer: stripInlineIdentifierQuotes,
     safePattern: INLINE_COLUMN_FRAGMENT_SAFE_RE,
     preserveCandidateCase: isPostgresSchemaDialect(context.sourceType || ''),
@@ -1901,7 +1917,10 @@ const resolveDeterministicInlineSchemaCompletion = (
     editorSnapshot: QueryEditorAiEditorSnapshot,
     intentDetails?: QueryEditorInlineCompletionIntentDetails,
 ): { handled: boolean; insertText: string } => {
-    const intent = intentDetails || resolveQueryEditorInlineCompletionIntentDetails(editorSnapshot);
+    const intent = intentDetails || resolveQueryEditorInlineCompletionIntentDetails(
+        editorSnapshot,
+        context.sqlDialect || context.sourceType || '',
+    );
     if (intent.intent === 'table_name') {
         return {
             handled: true,
@@ -1945,7 +1964,10 @@ export const resolveQueryEditorInlineCompletionEdit = ({
         editText: insertText,
         replacePrefixLength: 0,
     };
-    const intent = resolveQueryEditorInlineCompletionIntentDetails(editorSnapshot);
+    const intent = resolveQueryEditorInlineCompletionIntentDetails(
+        editorSnapshot,
+        aiContext.sqlDialect || aiContext.sourceType || '',
+    );
     if ((intent.intent !== 'table_name' && intent.intent !== 'column_name') || !intent.fragment) {
         return fallback;
     }
@@ -1996,8 +2018,9 @@ const buildKeywordSuffixInsertText = (statementPrefix: string, suffix: string): 
 
 const resolveDeterministicInlineSyntaxCompletion = (
     editorSnapshot: QueryEditorAiEditorSnapshot,
+    sqlDialect = '',
 ): { handled: boolean; insertText: string } => {
-    const statementPrefix = getCurrentStatementPrefix(editorSnapshot.prefix);
+    const statementPrefix = getCurrentStatementPrefix(editorSnapshot.prefix, sqlDialect);
     const trimmedStatement = statementPrefix.trim();
 
     if (!trimmedStatement) {
@@ -2136,11 +2159,9 @@ const isInlineCompletionScopedToKnownContext = (
     });
 };
 
-const getCurrentStatementPrefix = (prefix: string): string => {
-    const text = String(prefix || '');
-    const semicolonIndex = text.lastIndexOf(';');
-    return semicolonIndex >= 0 ? text.slice(semicolonIndex + 1) : text;
-};
+const getCurrentStatementPrefix = (prefix: string, sqlDialect = ''): string => (
+    resolveSqlStatementPrefix(prefix, sqlDialect)
+);
 
 const hasUnclosedBlockComment = (text: string): boolean =>
     String(text || '').lastIndexOf('/*') > String(text || '').lastIndexOf('*/');

--- a/frontend/src/utils/sqlStatementSelection.test.ts
+++ b/frontend/src/utils/sqlStatementSelection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { findSqlStatementRanges, resolveCurrentSqlStatementRange, resolveExecutableSql, stripLeadingSqlTrivia } from './sqlStatementSelection';
+import { findSqlStatementRanges, resolveCurrentSqlStatementRange, resolveExecutableSql, resolveSqlStatementPrefix, stripLeadingSqlTrivia } from './sqlStatementSelection';
 
 describe('sqlStatementSelection', () => {
   it('resolves the statement containing the cursor', () => {
@@ -26,6 +26,23 @@ describe('sqlStatementSelection', () => {
       "-- comment ;\nselect 'a; b' as text",
       "select $$a; b$$ as body",
     ]);
+  });
+
+  it('resolves the editable statement prefix without falling back across a completed statement', () => {
+    expect(resolveSqlStatementPrefix("SELECT ';' AS marker JOIN service_user ", 'mysql')).toBe(
+      "SELECT ';' AS marker JOIN service_user ",
+    );
+    expect(resolveSqlStatementPrefix('SELECT 1 -- ;\r\nJOIN service_user ', 'mysql')).toBe(
+      'SELECT 1 -- ;\nJOIN service_user ',
+    );
+    expect(resolveSqlStatementPrefix('SELECT 1 # ;\r\nJOIN service_user ', 'mysql')).toBe(
+      'SELECT 1 # ;\nJOIN service_user ',
+    );
+    expect(resolveSqlStatementPrefix('SELECT 1 /* ; */ JOIN service_user ', 'mysql')).toBe(
+      'SELECT 1 /* ; */ JOIN service_user ',
+    );
+    expect(resolveSqlStatementPrefix('\uFEFFSELECT 1\r\n', 'mysql')).toBe('\uFEFFSELECT 1\n');
+    expect(resolveSqlStatementPrefix('SELECT 1; -- completed statement\r\n', 'mysql')).toBe('');
   });
 
   it('ignores semicolons inside escaped delimited identifiers', () => {

--- a/frontend/src/utils/sqlStatementSelection.ts
+++ b/frontend/src/utils/sqlStatementSelection.ts
@@ -567,6 +567,19 @@ export const findSqlStatementRanges = (sql: string, dbType = ''): SqlStatementRa
   return ranges;
 };
 
+/**
+ * Returns the executable statement currently being edited at the end of sql.
+ * Unlike cursor navigation, a completed statement followed by only trivia has
+ * no active statement and must not inherit the previous statement's context.
+ */
+export const resolveSqlStatementPrefix = (sql: string, dbType = ''): string => {
+  const text = String(sql || '').replace(/\r\n/g, '\n');
+  const ranges = findSqlStatementRanges(text, dbType);
+  const currentRange = ranges[ranges.length - 1];
+  const trimmedEnd = text.trimEnd().length;
+  return currentRange && currentRange.end === trimmedEnd ? text.slice(currentRange.start) : '';
+};
+
 export const resolveCurrentSqlStatementRange = (sql: string, cursorOffset: number, dbType = ''): SqlStatementRange | null => {
   const text = String(sql || '').replace(/\r\n/g, '\n');
   const offset = Math.max(0, Math.min(text.length, Number.isFinite(cursorOffset) ? cursorOffset : 0));


### PR DESCRIPTION
## 修复内容

- 使用词法感知的 SQL 语句范围解析手输内联补全前缀，字符串、`--`/`#` 行注释、块注释与引用标识符中的分号不再截断别名上下文。
- 真实分号后的空白或纯注释不回退到上一条语句，避免跨语句继承表别名。
- 手输触发、内联记忆、局部 schema/AI 上下文、插入重叠、标记恢复与回退路径统一传递已解析 SQL 方言。

## 验收覆盖

- 同一语句内第二张表在字符串、`--`、`#`、块注释伪分号后仍生成递增别名。
- 真实多语句分隔后重新使用初始别名。
- 覆盖 BOM、CRLF、限定名、MySQL `AS`、Oracle 无 `AS` 与 OceanBase Oracle 方言。

## 验证

- `npm --prefix frontend test -- QueryEditorAiAssist.test.ts sqlStatementSelection.test.ts`
- `npm --prefix frontend run build`
- `git diff --check`

Closes #1146
