### PR TITLE
🐛 fix(query): 关闭标签时清理托管事务

### DIFF
--- a/frontend/src/components/QueryEditor.external-sql-save.test.tsx
+++ b/frontend/src/components/QueryEditor.external-sql-save.test.tsx
@@ -14287,6 +14287,55 @@ END;`;
     expect(textContent(renderer!.root)).not.toContain('未提交');
   });
 
+  it('cancels and rolls back a managed transaction that returns after the SQL tab closes', async () => {
+    let resolveTransaction!: (result: any) => void;
+    backendApp.DBQueryMultiTransactional.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveTransaction = resolve;
+    }));
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <React.StrictMode>
+          <QueryEditor tab={createTab({ query: 'UPDATE users SET active = 0 WHERE id = 1' })} />
+        </React.StrictMode>,
+      );
+    });
+    let runPromise!: Promise<void>;
+    act(() => {
+      runPromise = Promise.resolve(findButton(renderer!, '运行').props.onClick());
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(backendApp.DBQueryMultiTransactional).toHaveBeenCalledWith(
+      expect.anything(),
+      'main',
+      'UPDATE users SET active = 0 WHERE id = 1',
+      'query-1',
+    );
+
+    await act(async () => {
+      renderer.unmount();
+    });
+    expect(backendApp.CancelQuery).toHaveBeenCalledWith('query-1');
+
+    await act(async () => {
+      resolveTransaction({
+        success: true,
+        transactionId: 'tx-tab-close',
+        transactionPending: true,
+        data: [],
+      });
+      await runPromise;
+    });
+
+    expect(backendApp.DBRollbackTransactionWithTrigger).toHaveBeenCalledWith('tx-tab-close', 'tab_close');
+    expect(storeState.sqlEditorPendingTransactions['tab-1']).toBeUndefined();
+  });
+
   it('auto commits SQL editor DML transactions after the configured delay', async () => {
     vi.useFakeTimers();
     storeState.sqlEditorTransactionOptions = {

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -18,7 +18,7 @@ import { format } from 'sql-formatter';
 import { v4 as uuidv4 } from 'uuid';
 import { TabData, ColumnDefinition, type ConnectionConfig, type SavedQuery, type SqlSnippet } from '../types';
 import { type SqlLog, useStore } from '../store';
-import { DBQuery, DBQueryWithCancel, DBQueryMulti, DBQueryMultiInTransaction, DBQueryMultiTransactional, DBQueryAudited, DBGetTables, DBTableExists, DBGetAllColumns, DBGetDatabases, DBGetColumns, DBGetTriggers, DBShowCreateTable, CancelQuery, GenerateQueryID, WriteSQLFile, ExportSQLFile, InspectElasticsearchConsole, ExecuteElasticsearchConsole } from '../../wailsjs/go/app/App';
+import { DBQuery, DBQueryWithCancel, DBQueryMulti, DBQueryMultiInTransaction, DBQueryMultiTransactional, DBQueryAudited, DBGetTables, DBTableExists, DBGetAllColumns, DBGetDatabases, DBGetColumns, DBGetTriggers, DBShowCreateTable, CancelQuery, DBRollbackTransactionWithTrigger, GenerateQueryID, WriteSQLFile, ExportSQLFile, InspectElasticsearchConsole, ExecuteElasticsearchConsole } from '../../wailsjs/go/app/App';
 import { GONAVI_ROW_KEY } from './DataGrid';
 import { EventsOn, LogError, LogInfo } from '../../wailsjs/runtime';
 import {
@@ -2141,6 +2141,7 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
   const [sqlSnippetPickerKeyword, setSqlSnippetPickerKeyword] = useState('');
   const runSeqRef = useRef(0);
   const currentQueryIdRef = useRef('');
+  const queryEditorUnmountedRef = useRef(false);
   const requestScopedRPCControllersRef = useRef(new Set<AbortController>());
   const invokeRequestScopedApp = useCallback(<T,>(
       method: string,
@@ -2155,6 +2156,21 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
   useEffect(() => () => {
       requestScopedRPCControllersRef.current.forEach((controller) => controller.abort());
       requestScopedRPCControllersRef.current.clear();
+  }, []);
+  useEffect(() => {
+      queryEditorUnmountedRef.current = false;
+      return () => {
+          queryEditorUnmountedRef.current = true;
+          // A managed DML run receives its query ID before the RPC can expose a
+          // transaction ID. Cancel by that ID when the tab disappears so the
+          // backend can stop the in-flight statement and roll it back.
+          runSeqRef.current += 1;
+          const queryId = currentQueryIdRef.current;
+          currentQueryIdRef.current = '';
+          if (queryId) {
+              void Promise.resolve(CancelQuery(queryId)).catch(() => undefined);
+          }
+      };
   }, []);
   const resultTotalCountSeqRef = useRef(0);
   const resultTotalCountRequestsRef = useRef<Record<string, { sequence: number; queryId: string }>>({});
@@ -10908,6 +10924,17 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
                     data: Array.isArray(res?.data) ? res.data : [],
                     outcomeUnknown: true,
                 };
+            }
+            if (queryEditorUnmountedRef.current) {
+                // The tab may have closed after the backend created the
+                // transaction but before this RPC response reached React.
+                // It was never registered in the transaction controller, so
+                // roll it back directly instead of leaving an orphaned lock.
+                if (res?.transactionPending && res?.transactionId) {
+                    void Promise.resolve(DBRollbackTransactionWithTrigger(String(res.transactionId), 'tab_close'))
+                        .catch(() => undefined);
+                }
+                return;
             }
             if (!isCurrentRun()) return;
             const duration = Date.now() - startTime;

--- a/internal/app/methods_db_multi_test.go
+++ b/internal/app/methods_db_multi_test.go
@@ -1196,6 +1196,66 @@ func TestDBQueryMultiTransactionalKeepsDMLTransactionOpenUntilCommit(t *testing.
 	}
 }
 
+func TestDBQueryMultiTransactionalCancellationRollsBackWithoutLeavingPendingTransaction(t *testing.T) {
+	originalNewDatabaseFunc := newDatabaseFunc
+	t.Cleanup(func() {
+		newDatabaseFunc = originalNewDatabaseFunc
+	})
+
+	statement := "UPDATE users SET active = 0 WHERE id = 1"
+	execStarted := make(chan string, 2)
+	fakeDB := &fakeBatchWriteDB{
+		execDelay: map[string]time.Duration{statement: 10 * time.Second},
+		execStarted: execStarted,
+	}
+	newDatabaseFunc = func(dbType string) (db.Database, error) {
+		return fakeDB, nil
+	}
+
+	app := NewAppWithSecretStore(secretstore.NewUnavailableStore("test"))
+	config := connection.ConnectionConfig{Type: "mysql", Host: "127.0.0.1", Port: 3306, User: "root"}
+	resultCh := make(chan connection.QueryResult, 1)
+	go func() {
+		resultCh <- app.DBQueryMultiTransactional(config, "main", statement, "tx-close-before-result")
+	}()
+
+	for _, expected := range []string{"START TRANSACTION", statement} {
+		select {
+		case executed := <-execStarted:
+			if executed != expected {
+				t.Fatalf("executed statement = %q, want %q", executed, expected)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for %q", expected)
+		}
+	}
+
+	if cancelled := app.CancelQuery("tx-close-before-result"); !cancelled.Success {
+		t.Fatalf("CancelQuery failed: %#v", cancelled)
+	}
+	select {
+	case result := <-resultCh:
+		if result.Success || result.TransactionID != "" || result.TransactionPending {
+			t.Fatalf("cancelled transaction must not become pending: %#v", result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("managed transaction did not stop after cancellation")
+	}
+
+	app.sqlTransactionMu.Lock()
+	pendingCount := len(app.sqlTransactions)
+	app.sqlTransactionMu.Unlock()
+	if pendingCount != 0 {
+		t.Fatalf("cancelled transaction left %d pending entries", pendingCount)
+	}
+	if fakeDB.session == nil || !fakeDB.session.closed {
+		t.Fatal("cancelled transaction session was not closed")
+	}
+	if got := fakeDB.execQueries[len(fakeDB.execQueries)-1]; got != "ROLLBACK" {
+		t.Fatalf("final transaction statement = %q, want ROLLBACK", got)
+	}
+}
+
 func TestDBQueryMultiTransactionalKeepsSQLServerBeginEndBlockOpenUntilRollback(t *testing.T) {
 	installFakeOptionalDriverRuntime(t)
 	originalNewDatabaseFunc := newDatabaseFunc


### PR DESCRIPTION
## 问题背景

SQL 编辑器的托管事务执行尚未返回时关闭标签，前端还没有拿到事务 ID，可能导致后端事务继续存在并占用数据库锁。

## 修复内容

- 标签卸载时按当前查询 ID 取消执行，阻止仍在进行的托管事务继续运行。
- 若托管事务在标签关闭后才返回 pending 状态，立即以 `tab_close` 触发后端回滚，避免产生未注册的事务。
- 补充 StrictMode 前端回归测试，以及后端取消后自动回滚、关闭会话且不遗留事务记录的测试。

## 验证方式

- `npx vitest run src/components/QueryEditor.external-sql-save.test.tsx`
- `npx vitest run src/components/QueryEditor.external-sql-save.test.tsx -t "cancels and rolls back a managed transaction"`
- `go test ./internal/app -run "TestDBQueryMultiTransactional" -count=1`
- `npm run build`
- 子 agent 代码审查：未发现 P0/P1 问题。

## 影响与风险

- 仅影响 SQL 编辑器标签关闭期间仍在执行的查询和其迟到的托管事务响应。
- 已返回并被正常注册的 pending 事务仍沿用原有提交、回滚和自动提交流程。

## 关联 Issue

Closes #1143
