### PR TITLE
fix(query-editor): 修复分号边界执行漂移

### DIFF
--- a/frontend/src/components/QueryEditor.external-sql-save.test.tsx
+++ b/frontend/src/components/QueryEditor.external-sql-save.test.tsx
@@ -2343,7 +2343,7 @@ describe('QueryEditor external SQL save', () => {
         editorState.modelContentListeners.forEach((listener) => listener({
           changes: [{ text: 'E' }],
         }));
-        vi.advanceTimersByTime(120);
+        vi.advanceTimersByTime(220);
         for (let i = 0; i < 8; i += 1) {
           await Promise.resolve();
         }
@@ -11907,6 +11907,43 @@ END;`;
     expect(editorState.editor.getModel().getValue).not.toHaveBeenCalled();
   });
 
+  it('does not build the full inline AI snapshot synchronously during typing', async () => {
+    vi.useFakeTimers();
+    Object.assign(window, {
+      setTimeout: globalThis.setTimeout.bind(globalThis),
+      clearTimeout: globalThis.clearTimeout.bind(globalThis),
+    });
+    try {
+      await act(async () => {
+        create(<QueryEditor tab={createTab({ query: 'select 1;' })} />);
+      });
+
+      const model = editorState.editor.getModel();
+      const getValueInRangeSpy = vi.spyOn(model, 'getValueInRange');
+      editorState.value = `SELECT * FROM users ${'x'.repeat(60_000)}`;
+      editorState.position = { lineNumber: 1, column: editorState.value.length + 1 };
+
+      await act(async () => {
+        editorState.latestOnChange?.(editorState.value);
+        editorState.modelContentListeners.forEach((listener) => listener({
+          changes: [{ text: ' ' }],
+        }));
+      });
+
+      try {
+        expect(getValueInRangeSpy).not.toHaveBeenCalled();
+      } finally {
+        getValueInRangeSpy.mockRestore();
+      }
+    } finally {
+      vi.useRealTimers();
+      Object.assign(window, {
+        setTimeout: globalThis.setTimeout.bind(globalThis),
+        clearTimeout: globalThis.clearTimeout.bind(globalThis),
+      });
+    }
+  });
+
   it('debounces object decoration rescans and colors newly typed tables in the same database context', async () => {
     vi.useFakeTimers();
     Object.assign(window, {
@@ -15932,6 +15969,47 @@ WHERE GRANTEE = 'APPUSER';`;
     expect(storeState.addSqlLog).toHaveBeenCalledWith(expect.objectContaining({
       sql: expect.stringContaining('select 2 as two'),
     }));
+  });
+
+  it('keeps the same statement when a run-button focus shift moves the caret past its semicolon', async () => {
+    backendApp.DBQueryMulti.mockResolvedValue({ success: true, data: [] });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<QueryEditor tab={createTab({
+        dbName: 'main',
+        query: 'select 1 as a; select 2 as b;',
+      })} />);
+    });
+
+    const firstSemicolonColumn = 'select 1 as a'.length + 1;
+    editorState.position = { lineNumber: 1, column: firstSemicolonColumn };
+    const runButton = findButton(renderer!, '运行');
+
+    await act(async () => {
+      runButton.props.onMouseDown?.({ preventDefault: vi.fn() });
+      await runButton.props.onClick();
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    editorState.position = { lineNumber: 1, column: firstSemicolonColumn + 1 };
+    await act(async () => {
+      runButton.props.onMouseDown?.({ preventDefault: vi.fn() });
+      await runButton.props.onClick();
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(backendApp.DBQueryMulti).toHaveBeenCalledTimes(2);
+    expect(String(backendApp.DBQueryMulti.mock.calls[0][2])).toContain('select 1 as a');
+    expect(String(backendApp.DBQueryMulti.mock.calls[0][2])).not.toContain('select 2 as b');
+    expect(String(backendApp.DBQueryMulti.mock.calls[1][2])).toContain('select 1 as a');
+    expect(String(backendApp.DBQueryMulti.mock.calls[1][2])).not.toContain('select 2 as b');
   });
 
   it('keeps cursor statement execution available in v2 UI', async () => {

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -3109,6 +3109,11 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
       queryEditorMountedRef.current = true;
       return () => {
           queryEditorMountedRef.current = false;
+          if (aiInlineGhostTimerRef.current !== null) {
+              clearTimeout(aiInlineGhostTimerRef.current);
+              aiInlineGhostTimerRef.current = null;
+          }
+          aiInlineGhostRequestSeqRef.current += 1;
       };
   }, []);
 
@@ -6301,6 +6306,16 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
       const requestAiInlineGhost = (delayMs: number, focusEditor = false, manualTrigger = false) => {
           clearAiInlineGhost();
           if (aiInlineGhostAcceptingRef.current || editorRef.current !== editor) {
+              return;
+          }
+          // Automatic ghost completion is debounced to keep model snapshotting
+          // off the Monaco content-change hot path. Manual triggers still use
+          // delay 0 and retain their immediate behavior.
+          if (delayMs > 0) {
+              aiInlineGhostTimerRef.current = setTimeout(() => {
+                  aiInlineGhostTimerRef.current = null;
+                  requestAiInlineGhost(0, focusEditor, manualTrigger);
+              }, delayMs);
               return;
           }
           if (focusEditor) {

--- a/frontend/src/utils/sqlStatementSelection.test.ts
+++ b/frontend/src/utils/sqlStatementSelection.test.ts
@@ -612,6 +612,49 @@ describe('sqlStatementSelection', () => {
     });
   });
 
+  it('keeps a caret reported on the newline after a semicolon with the preceding statement', () => {
+    const sql = 'select 1 as a;\nselect 2 as b;';
+    const firstSemicolon = sql.indexOf(';');
+
+    expect(resolveExecutableSql(sql, firstSemicolon + 1)).toEqual({
+      sql: 'select 1 as a',
+      source: 'statement',
+    });
+  });
+
+  it('does not swallow the next statement when it starts immediately after a semicolon', () => {
+    const sql = 'select 1;select 2;';
+
+    expect(resolveExecutableSql(sql, sql.indexOf('select 2'))).toEqual({
+      sql: 'select 2',
+      source: 'statement',
+    });
+  });
+
+  it('keeps whitespace before a delimiter attached to the preceding statement', () => {
+    const sql = 'select 1   ;\nselect 2;';
+    const delimiterFollowup = sql.indexOf(';') + 1;
+
+    expect(resolveExecutableSql(sql, delimiterFollowup)).toEqual({
+      sql: 'select 1',
+      source: 'statement',
+    });
+  });
+
+  it('keeps execution on the preceding statement across same-line semicolon whitespace', () => {
+    const sql = 'select 1 as a; select 2 as b;';
+    const semicolon = sql.indexOf(';');
+
+    expect(resolveExecutableSql(sql, semicolon)).toEqual({
+      sql: 'select 1 as a',
+      source: 'statement',
+    });
+    expect(resolveExecutableSql(sql, semicolon + 1)).toEqual({
+      sql: 'select 1 as a',
+      source: 'statement',
+    });
+  });
+
   it('falls back to all SQL when the cursor is on a blank line between statements', () => {
     const sql = 'select 1;\n\n  select 2';
 

--- a/frontend/src/utils/sqlStatementSelection.ts
+++ b/frontend/src/utils/sqlStatementSelection.ts
@@ -19,6 +19,29 @@ const isHorizontalWhitespace = (ch: string): boolean => (
   ch === ' ' || ch === '\t' || ch === '\r' || ch === '\f'
 );
 
+const isDelimiterFollowupOffset = (text: string, offset: number): boolean => {
+  if (offset <= 0 || (text[offset - 1] !== ';' && text[offset - 1] !== '；')) {
+    return false;
+  }
+  if (offset >= text.length || isWhitespace(text[offset])) {
+    return true;
+  }
+  return (text[offset] === '-' && text[offset + 1] === '-')
+    || (text[offset] === '/' && text[offset + 1] === '*');
+};
+
+const findStatementBeforeDelimiter = (
+  text: string,
+  ranges: SqlStatementRange[],
+  delimiterIndex: number,
+): SqlStatementRange | null => [...ranges]
+  .reverse()
+  .find((range) => (
+    range.start <= delimiterIndex
+    && range.end <= delimiterIndex
+    && text.slice(range.end, delimiterIndex).trim() === ''
+  )) || null;
+
 const isSqlIdentifierStart = (ch: string): boolean => /^[A-Za-z_]$/.test(ch);
 
 const isSqlIdentifierPart = (ch: string): boolean => /^[A-Za-z0-9_$#]$/.test(ch);
@@ -588,6 +611,16 @@ export const resolveCurrentSqlStatementRange = (sql: string, cursorOffset: numbe
     return null;
   }
 
+  // Monaco may report a caret clicked on a trailing semicolon as the offset
+  // immediately after it (for example, on the following newline). Keep that
+  // caret attached to the statement whose delimiter was clicked.
+  if (isDelimiterFollowupOffset(text, offset)) {
+    const delimiterStatement = findStatementBeforeDelimiter(text, ranges, offset - 1);
+    if (delimiterStatement) {
+      return delimiterStatement;
+    }
+  }
+
   const containingRange = ranges.find((range) => offset >= range.start && offset <= range.end);
   if (containingRange) {
     return containingRange;
@@ -623,6 +656,14 @@ export const resolveExecutableSql = (
   if (ranges.length === 0) {
     return null;
   }
+
+  if (isDelimiterFollowupOffset(text, offset)) {
+    const delimiterStatement = findStatementBeforeDelimiter(text, ranges, offset - 1);
+    if (delimiterStatement?.text.trim()) {
+      return { sql: stripLeadingSqlTrivia(delimiterStatement.text, dbType), source: 'statement' };
+    }
+  }
+
   const statement = ranges.find((range) => offset >= range.start && offset <= range.end);
   if (statement?.text.trim()) {
     return { sql: stripLeadingSqlTrivia(statement.text, dbType), source: 'statement' };
@@ -641,7 +682,14 @@ export const resolveExecutableSql = (
   const lineEnd = nextLineBreak === -1 ? text.length : nextLineBreak;
   const line = text.slice(lineStart, lineEnd).trim();
   if (line) {
-    const lineStatement = [...ranges].reverse().find((range) => range.start < lineEnd && range.end >= lineStart);
+    const lineStatements = ranges.filter((range) => range.start < lineEnd && range.end >= lineStart);
+    // A caret immediately after a semicolon is still attached to the statement
+    // on its left. Prefer the nearest completed statement on this line so a
+    // toolbar click cannot move execution to the next statement.
+    const lineStatement = [...lineStatements]
+      .reverse()
+      .find((range) => range.end < offset)
+      || lineStatements[0];
     if (lineStatement?.text.trim()) {
       return { sql: stripLeadingSqlTrivia(lineStatement.text, dbType), source: 'statement' };
     }


### PR DESCRIPTION
## 背景

查询编辑器自动 AI inline completion 会在输入事件中同步读取整篇 Monaco 文档，长 SQL 下可能阻塞光标响应；同时光标落在 SQL 结尾分号及其相邻空白、换行或注释时，点击执行可能在相邻语句间漂移。

## 变更

- 将自动 AI inline completion 的完整文档快照移动至 debounce 回调，避免阻塞输入热路径。
- 组件卸载时清理补全定时器并废弃未完成请求。
- 统一分号边界的语句归属：分号后的空白、换行或注释仍执行前一条语句。
- 保留紧接分号的下一条 SQL 作为独立语句，避免过度回溯。
- 补充 QueryEditor 执行按钮与 SQL 选择器的边界回归覆盖。

## 影响范围

- QueryEditor 自动 AI inline completion 的输入响应。
- QueryEditor 工具栏、快捷键和上下文菜单的当前语句执行定位。

## 验证

- `npm exec vitest run src/utils/sqlStatementSelection.test.ts src/components/QueryEditor.external-sql-save.test.tsx --reporter=dot`：420 项通过。
- `npm exec tsc -- --noEmit`：通过。
- `git diff --check origin/dev...HEAD`：通过。

## 风险与回滚

改动仅调整前端输入调度与当前 SQL 语句定位，不涉及数据库数据或执行协议。若出现定位兼容问题，可直接回滚本 PR 的 squash commit。