### PR TITLE
✨ feat(data-grid): 支持 Excel 风格结果表范围选区与拖拽自动滚动

### DIFF
--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -186,7 +186,11 @@ import { useExportProgressDialog } from './ExportProgressModal';
 import { useDataGridFilters } from './useDataGridFilters';
 import { useDataGridDdlView } from './useDataGridDdlView';
 import { useDataGridModalEditors } from './useDataGridModalEditors';
-import { useDataGridBatchActions } from './useDataGridBatchActions';
+import {
+    useDataGridBatchActions,
+    type CellSelectionAutoScrollController,
+    type CellSelectionAutoScrollViewport,
+} from './useDataGridBatchActions';
 import { useDataGridV2Actions } from './useDataGridV2Actions';
 import { useDataGridMetadata } from './useDataGridMetadata';
 import { useDataGridColumnResize } from './useDataGridColumnResize';
@@ -997,6 +1001,7 @@ const DataGrid: React.FC<DataGridProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const tableContainerRef = useRef<HTMLDivElement | null>(null);
   const tableRef = useRef<VirtualTableScrollReference | null>(null);
+  const cellSelectionAutoScrollControllerRef = useRef<CellSelectionAutoScrollController | null>(null);
   const tableScrollTargetsRef = useRef<HTMLElement[]>([]);
   const externalHorizontalScrollRef = useRef<HTMLDivElement | null>(null);
   const virtualHorizontalElementsRef = useRef<{
@@ -2115,6 +2120,7 @@ const DataGrid: React.FC<DataGridProps> = ({
     cancelAnimationFrame,
     cellEditModeRef,
     cellSelectionAutoScrollRafRef,
+    cellSelectionAutoScrollControllerRef,
     cellSelectionPointerRef,
     cellSelectionRafRef,
     cellSelectionScrollRafRef,
@@ -4701,6 +4707,88 @@ const DataGrid: React.FC<DataGridProps> = ({
       const body = tableContainer.querySelector('.ant-table-body') as HTMLElement | null;
       return virtualHolder || rcVirtualHolder || body;
   }, []);
+
+  const getCellSelectionAutoScrollViewport = useCallback((): CellSelectionAutoScrollViewport | null => {
+      if (!enableVirtual || !isTableSurfaceActive) return null;
+      const tableContainer = tableContainerRef.current;
+      if (!(tableContainer instanceof HTMLElement)) return null;
+
+      const verticalTarget = pickVerticalScrollTarget(tableContainer);
+      if (!(verticalTarget instanceof HTMLElement)) return null;
+
+      const horizontalTarget = pickHorizontalScrollTargets(tableContainer)[0] || verticalTarget;
+      const rect = verticalTarget.getBoundingClientRect();
+      const clientWidth = Math.max(0, horizontalTarget.clientWidth || verticalTarget.clientWidth);
+      return {
+          rect,
+          scrollTop: Number.isFinite(verticalTarget.scrollTop) ? verticalTarget.scrollTop : 0,
+          scrollLeft: readVirtualHorizontalOffset(tableContainer),
+          maxScrollTop: Math.max(0, verticalTarget.scrollHeight - verticalTarget.clientHeight),
+          maxScrollLeft: Math.max(0, tableScrollX - clientWidth),
+      };
+  }, [enableVirtual, isTableSurfaceActive, pickHorizontalScrollTargets, pickVerticalScrollTarget, readVirtualHorizontalOffset, tableScrollX]);
+
+  const scrollCellSelectionBy = useCallback((deltaX: number, deltaY: number): boolean => {
+      if (!enableVirtual || !isTableSurfaceActive) return false;
+      const tableContainer = tableContainerRef.current;
+      if (!(tableContainer instanceof HTMLElement)) return false;
+
+      let didScroll = false;
+      if (deltaY !== 0) {
+          const verticalTarget = pickVerticalScrollTarget(tableContainer);
+          if (verticalTarget instanceof HTMLElement) {
+              const currentTop = Number.isFinite(verticalTarget.scrollTop) ? verticalTarget.scrollTop : 0;
+              const maxTop = Math.max(0, verticalTarget.scrollHeight - verticalTarget.clientHeight);
+              const nextTop = Math.max(0, Math.min(maxTop, currentTop + deltaY));
+              if (Math.abs(nextTop - currentTop) > 0.5) {
+                  const tableInstance = tableRef.current;
+                  if (tableInstance && typeof tableInstance.scrollTo === 'function') {
+                      tableInstance.scrollTo({ top: nextTop });
+                  } else {
+                      verticalTarget.scrollTop = nextTop;
+                  }
+                  didScroll = true;
+              }
+          }
+      }
+
+      if (deltaX !== 0) {
+          const currentLeft = readVirtualHorizontalOffset(tableContainer);
+          const applied = applyVirtualHorizontalOffset(tableContainer, currentLeft + deltaX, {
+              forceInternalScroll: true,
+          });
+          if (applied) {
+              const resolvedLeft = readVirtualHorizontalOffset(tableContainer);
+              const externalScroll = externalHorizontalScrollRef.current;
+              if (externalScroll && Math.abs(externalScroll.scrollLeft - resolvedLeft) > 1) {
+                  externalScroll.scrollLeft = resolvedLeft;
+              }
+              lastTableScrollLeftRef.current = resolvedLeft;
+              lastExternalScrollLeftRef.current = externalScroll?.scrollLeft ?? resolvedLeft;
+              didScroll = didScroll || Math.abs(resolvedLeft - currentLeft) > 0.5;
+          }
+      }
+
+      return didScroll;
+  }, [applyVirtualHorizontalOffset, enableVirtual, isTableSurfaceActive, pickVerticalScrollTarget, readVirtualHorizontalOffset]);
+
+  useEffect(() => {
+      if (!enableVirtual || !isTableSurfaceActive) {
+          cellSelectionAutoScrollControllerRef.current = null;
+          return;
+      }
+
+      const controller: CellSelectionAutoScrollController = {
+          getViewport: getCellSelectionAutoScrollViewport,
+          scrollBy: scrollCellSelectionBy,
+      };
+      cellSelectionAutoScrollControllerRef.current = controller;
+      return () => {
+          if (cellSelectionAutoScrollControllerRef.current === controller) {
+              cellSelectionAutoScrollControllerRef.current = null;
+          }
+      };
+  }, [enableVirtual, getCellSelectionAutoScrollViewport, isTableSurfaceActive, scrollCellSelectionBy]);
 
   const focusPageFindMatch = useCallback((match: DataGridFindMatch) => {
       if (!match) return;

--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -1054,6 +1054,7 @@ const DataGrid: React.FC<DataGridProps> = ({
   // editable/delete eligibility guard. Read-only result grids still support
   // selecting cells and should report that selection in the footer.
   const cellSelectionUserSourceDataRef = useRef<Item[] | null>(null);
+  const cellSelectionAnchorSourceRef = useRef<'user' | 'page-find' | null>(null);
   const [copiedCellPatch, setCopiedCellPatch] = useState<{ sourceRowKey: string; values: Record<string, any> } | null>(null);
   const [copiedRowsForPaste, setCopiedRowsForPaste] = useState<Array<Record<string, any>>>([]);
 
@@ -2049,6 +2050,7 @@ const DataGrid: React.FC<DataGridProps> = ({
     markCellSelectionUserSelection(false);
     currentSelectionRef.current = new Set();
     selectionStartRef.current = null;
+    cellSelectionAnchorSourceRef.current = null;
     pendingCellSelectionStartRef.current = null;
     isDraggingRef.current = false;
     cellSelectionPointerRef.current = null;
@@ -2141,6 +2143,7 @@ const DataGrid: React.FC<DataGridProps> = ({
     selectedCells,
     selectedRowKeysRef,
     selectionStartRef,
+    cellSelectionAnchorSourceRef,
     setAddedRows,
     setCellContextMenu,
     setCellEditMode,
@@ -2916,6 +2919,7 @@ const DataGrid: React.FC<DataGridProps> = ({
       setSelectedCells(emptySelection);
       currentSelectionRef.current = emptySelection;
       selectionStartRef.current = null;
+      cellSelectionAnchorSourceRef.current = null;
       updateCellSelection(emptySelection);
   }, [markCellSelectionUserSelection, normalizedPageFindText, updateCellSelection]);
 
@@ -4703,6 +4707,7 @@ const DataGrid: React.FC<DataGridProps> = ({
       const nextSelection = new Set([makeCellKey(match.rowKey, match.columnName)]);
       markCellSelectionUserSelection(false);
       markCellSelectionDeleteEligible(false);
+      cellSelectionAnchorSourceRef.current = 'page-find';
       setSelectedCells(nextSelection);
       currentSelectionRef.current = nextSelection;
       selectionStartRef.current = {

--- a/frontend/src/components/DataGridCore.tsx
+++ b/frontend/src/components/DataGridCore.tsx
@@ -254,6 +254,42 @@ const splitCellKey = (cellKey: string): { rowKey: string; colName: string } | nu
         colName: cellKey.slice(sepIndex + CELL_KEY_SEP.length),
     };
 };
+const buildDataGridCellSelectionRectangle = ({
+    startRowIndex,
+    startColIndex,
+    endRowIndex,
+    endColIndex,
+    rows,
+    columnNames,
+    rowKeyField = GONAVI_ROW_KEY,
+    canSelectColumn = () => true,
+}: {
+    startRowIndex: number;
+    startColIndex: number;
+    endRowIndex: number;
+    endColIndex: number;
+    rows: Array<Record<string, any>>;
+    columnNames: string[];
+    rowKeyField?: string;
+    canSelectColumn?: (columnName: string) => boolean;
+}): Set<string> => {
+    const selectedCells = new Set<string>();
+    const minRowIndex = Math.min(startRowIndex, endRowIndex);
+    const maxRowIndex = Math.max(startRowIndex, endRowIndex);
+    const minColIndex = Math.min(startColIndex, endColIndex);
+    const maxColIndex = Math.max(startColIndex, endColIndex);
+
+    for (let rowIndex = minRowIndex; rowIndex <= maxRowIndex; rowIndex++) {
+        const rowKey = rows[rowIndex]?.[rowKeyField];
+        if (rowKey === undefined || rowKey === null) continue;
+        for (let colIndex = minColIndex; colIndex <= maxColIndex; colIndex++) {
+            const columnName = columnNames[colIndex];
+            if (!columnName || !canSelectColumn(columnName)) continue;
+            selectedCells.add(makeCellKey(String(rowKey), columnName));
+        }
+    }
+    return selectedCells;
+};
 const collectDataGridCellSelectionRowKeys = (cellKeys: Iterable<string>): string[] => {
     const rowKeys = new Set<string>();
     for (const cellKey of cellKeys) {
@@ -2002,6 +2038,7 @@ export {
     useDataGridI18nLanguage,
     makeCellKey,
     splitCellKey,
+    buildDataGridCellSelectionRectangle,
     collectDataGridCellSelectionRowKeys,
     filterDataGridCellSelectionToVisibleRows,
     resolveDataGridCellSelectionAnchor,

--- a/frontend/src/components/dataGridSelectionAutoScroll.test.ts
+++ b/frontend/src/components/dataGridSelectionAutoScroll.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DATA_GRID_SELECTION_AUTO_SCROLL_EDGE_THRESHOLD_PX,
+  DATA_GRID_SELECTION_AUTO_SCROLL_MAX_STEP,
+  DATA_GRID_SELECTION_AUTO_SCROLL_MIN_STEP,
+  clampDataGridSelectionAutoScrollDelta,
+  getDataGridSelectionAutoScrollStep,
+} from './dataGridSelectionAutoScroll';
+
+describe('dataGridSelectionAutoScroll helpers', () => {
+  it('returns no scroll step for a negative edge distance', () => {
+    expect(getDataGridSelectionAutoScrollStep(-1)).toBe(0);
+    expect(getDataGridSelectionAutoScrollStep(0)).toBe(0);
+    expect(getDataGridSelectionAutoScrollStep(Number.NaN)).toBe(0);
+    expect(getDataGridSelectionAutoScrollStep(Number.NEGATIVE_INFINITY)).toBe(0);
+  });
+
+  it('uses the configured constants and quadratic distance curve', () => {
+    expect(DATA_GRID_SELECTION_AUTO_SCROLL_EDGE_THRESHOLD_PX).toBe(64);
+    expect(DATA_GRID_SELECTION_AUTO_SCROLL_MIN_STEP).toBe(4);
+    expect(DATA_GRID_SELECTION_AUTO_SCROLL_MAX_STEP).toBe(48);
+    expect(getDataGridSelectionAutoScrollStep(1)).toBe(4);
+    expect(getDataGridSelectionAutoScrollStep(32)).toBe(15);
+    expect(getDataGridSelectionAutoScrollStep(64)).toBe(48);
+    expect(getDataGridSelectionAutoScrollStep(100)).toBe(48);
+    expect(getDataGridSelectionAutoScrollStep(32, 0)).toBe(15);
+  });
+
+  it('saturates oversized distances at the maximum step', () => {
+    expect(getDataGridSelectionAutoScrollStep(Number.POSITIVE_INFINITY)).toBe(
+      DATA_GRID_SELECTION_AUTO_SCROLL_MAX_STEP,
+    );
+    expect(getDataGridSelectionAutoScrollStep(10_000)).toBe(
+      DATA_GRID_SELECTION_AUTO_SCROLL_MAX_STEP,
+    );
+  });
+
+  it('clamps positive and negative deltas symmetrically at scroll boundaries', () => {
+    const step = getDataGridSelectionAutoScrollStep(
+      DATA_GRID_SELECTION_AUTO_SCROLL_EDGE_THRESHOLD_PX / 2,
+    );
+
+    expect(clampDataGridSelectionAutoScrollDelta(step, 50, 100)).toBe(
+      -clampDataGridSelectionAutoScrollDelta(-step, 50, 100),
+    );
+    expect(clampDataGridSelectionAutoScrollDelta(step, 90, 100)).toBe(10);
+    expect(clampDataGridSelectionAutoScrollDelta(-step, 5, 100)).toBe(-5);
+    expect(clampDataGridSelectionAutoScrollDelta(step, 100, 100)).toBe(0);
+    expect(clampDataGridSelectionAutoScrollDelta(-step, 0, 100)).toBe(0);
+    expect(clampDataGridSelectionAutoScrollDelta(Number.NaN, 50, 100)).toBe(0);
+    expect(clampDataGridSelectionAutoScrollDelta(step, Number.NaN, 100)).toBe(0);
+    expect(clampDataGridSelectionAutoScrollDelta(step, 50, Number.POSITIVE_INFINITY)).toBe(0);
+  });
+
+  it('returns enough delta to recover an out-of-range current scroll position', () => {
+    const delta = clampDataGridSelectionAutoScrollDelta(-4, 110, 100);
+
+    expect(delta).toBe(-10);
+    expect(110 + delta).toBe(100);
+  });
+});

--- a/frontend/src/components/dataGridSelectionAutoScroll.ts
+++ b/frontend/src/components/dataGridSelectionAutoScroll.ts
@@ -1,0 +1,40 @@
+export const DATA_GRID_SELECTION_AUTO_SCROLL_EDGE_THRESHOLD_PX = 64;
+export const DATA_GRID_SELECTION_AUTO_SCROLL_MIN_STEP = 4;
+export const DATA_GRID_SELECTION_AUTO_SCROLL_MAX_STEP = 48;
+
+export const getDataGridSelectionAutoScrollStep = (
+  distance: number,
+  edgeThreshold = DATA_GRID_SELECTION_AUTO_SCROLL_EDGE_THRESHOLD_PX,
+): number => {
+  if (!Number.isFinite(distance)) {
+    return distance === Number.POSITIVE_INFINITY
+      ? DATA_GRID_SELECTION_AUTO_SCROLL_MAX_STEP
+      : 0;
+  }
+  if (distance <= 0) {
+    return 0;
+  }
+
+  const threshold = Number.isFinite(edgeThreshold) && edgeThreshold > 0
+    ? edgeThreshold
+    : DATA_GRID_SELECTION_AUTO_SCROLL_EDGE_THRESHOLD_PX;
+  const proximity = Math.min(distance, threshold) / threshold;
+  const step = DATA_GRID_SELECTION_AUTO_SCROLL_MIN_STEP
+    + (DATA_GRID_SELECTION_AUTO_SCROLL_MAX_STEP - DATA_GRID_SELECTION_AUTO_SCROLL_MIN_STEP)
+      * proximity ** 2;
+  return Math.round(step);
+};
+
+export const clampDataGridSelectionAutoScrollDelta = (
+  delta: number,
+  currentScroll: number,
+  maxScroll: number,
+): number => {
+  if (!Number.isFinite(delta) || !Number.isFinite(currentScroll) || !Number.isFinite(maxScroll)) {
+    return 0;
+  }
+
+  const limit = Math.max(0, maxScroll);
+  const next = Math.min(limit, Math.max(0, currentScroll + delta));
+  return next - currentScroll;
+};

--- a/frontend/src/components/useDataGridBatchActions.test.tsx
+++ b/frontend/src/components/useDataGridBatchActions.test.tsx
@@ -86,12 +86,13 @@ describe('useDataGridBatchActions clipboard paste', () => {
     selectedRowKeys = [] as React.Key[],
     copiedCellPatch = null as { sourceRowKey: string; values: Record<string, any> } | null,
     canUseCellSelectionAsFillTemplateTargets = true,
+    selectionScrollController = null as any,
   } = {}) => {
     const containerTarget = createEventTarget();
     const container = {
       ...containerTarget,
       contains: vi.fn(() => true),
-      querySelector: vi.fn(() => null),
+      querySelector: vi.fn<(selector: string) => HTMLElement | null>(() => null),
       querySelectorAll: vi.fn(() => []),
     };
     const rows = [
@@ -109,6 +110,24 @@ describe('useDataGridBatchActions clipboard paste', () => {
     const setSelectedCells = vi.fn();
     const updateCellSelection = vi.fn();
     const resetCellSelection = vi.fn();
+    const animationFrameCallbacks = new Map<number, FrameRequestCallback>();
+    let nextAnimationFrameId = 1;
+    const requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      const frameId = nextAnimationFrameId++;
+      animationFrameCallbacks.set(frameId, callback);
+      return frameId;
+    });
+    const cancelAnimationFrame = vi.fn((frameId: number) => {
+      animationFrameCallbacks.delete(frameId);
+    });
+    const runNextAnimationFrame = () => {
+      const next = animationFrameCallbacks.entries().next().value;
+      if (!next) return false;
+      const [frameId, callback] = next;
+      animationFrameCallbacks.delete(frameId);
+      act(() => callback(0));
+      return true;
+    };
 
     const ctx = {
       CELL_SELECTION_DRAG_THRESHOLD_PX: 4,
@@ -117,12 +136,13 @@ describe('useDataGridBatchActions clipboard paste', () => {
       batchEditSetNull: false,
       batchEditValue: '',
       canModifyData,
-      cancelAnimationFrame: vi.fn(),
+      cancelAnimationFrame,
       cellEditModeRef: { current: false },
       cellSelectionAutoScrollRafRef: { current: null },
       cellSelectionPointerRef: { current: null },
       cellSelectionRafRef: { current: null },
       cellSelectionScrollRafRef: { current: null },
+      cellSelectionAutoScrollControllerRef: { current: selectionScrollController },
       closeBatchEditModal: vi.fn(),
       columnIndexMap: new Map([['id', 0], ['generated', 1], ['name', 2]]),
       containerRef: { current: container },
@@ -143,7 +163,7 @@ describe('useDataGridBatchActions clipboard paste', () => {
       markCellSelectionUserSelection: vi.fn(),
       modifiedRows,
       pendingCellSelectionStartRef: { current: null },
-      requestAnimationFrame: (callback: FrameRequestCallback) => { callback(0); return 1; },
+      requestAnimationFrame,
       resetCellSelection,
       rowIndexMapRef: { current: new Map<string, number>() },
       rowKeyStr: String,
@@ -183,6 +203,7 @@ describe('useDataGridBatchActions clipboard paste', () => {
       setSelectedCells,
       updateCellSelection,
       resetCellSelection,
+      runNextAnimationFrame,
       getActions: () => actions!,
       rerender: () => act(() => { renderer?.update(<Harness />); }),
     };
@@ -216,6 +237,282 @@ describe('useDataGridBatchActions clipboard paste', () => {
     });
     return { cell, preventDefault, clickPreventDefault, stopPropagation };
   };
+
+  it('accelerates lower-right drag auto-scroll and clamps it at grid bounds', () => {
+    const hook = renderHook();
+    const tableBody = {
+      clientHeight: 200,
+      clientWidth: 200,
+      scrollHeight: 400,
+      scrollLeft: 0,
+      scrollTop: 0,
+      scrollWidth: 400,
+      getBoundingClientRect: () => ({ top: 0, right: 200, bottom: 200, left: 0 }),
+    };
+    hook.container.querySelector.mockReturnValue(tableBody as unknown as HTMLElement);
+    hook.ctx.cellEditModeRef.current = true;
+    const startCell = new MockHTMLElement({ 'data-row-key': 'row-1', 'data-col-name': 'id' });
+
+    const dragTo = (x: number, y: number) => {
+      act(() => {
+        (hook.container.listeners.get('mousedown') as any)?.({
+          button: 0,
+          target: startCell,
+          clientX: 10,
+          clientY: 10,
+          preventDefault: vi.fn(),
+        });
+        (hook.container.listeners.get('mousemove') as any)?.({
+          target: {},
+          clientX: x,
+          clientY: y,
+          preventDefault: vi.fn(),
+        });
+      });
+      expect(hook.runNextAnimationFrame()).toBe(true);
+      act(() => {
+        (documentTarget.listeners.get('mouseup') as any)?.({ target: {}, clientX: x, clientY: y });
+      });
+    };
+
+    dragTo(137, 137);
+    expect({ top: tableBody.scrollTop, left: tableBody.scrollLeft }).toEqual({ top: 4, left: 4 });
+
+    tableBody.scrollTop = 0;
+    tableBody.scrollLeft = 0;
+    dragTo(168, 168);
+    expect({ top: tableBody.scrollTop, left: tableBody.scrollLeft }).toEqual({ top: 15, left: 15 });
+
+    tableBody.scrollTop = 200;
+    tableBody.scrollLeft = 200;
+    dragTo(200, 200);
+    expect({ top: tableBody.scrollTop, left: tableBody.scrollLeft }).toEqual({ top: 200, left: 200 });
+  });
+
+  it('uses the injected virtual scroll controller when no ant table body exists', () => {
+    const virtualViewport = {
+      rect: { top: 0, right: 200, bottom: 200, left: 0 },
+      scrollTop: 0,
+      scrollLeft: 0,
+      maxScrollTop: 200,
+      maxScrollLeft: 200,
+    };
+    const scrollBy = vi.fn((deltaX: number, deltaY: number) => {
+      virtualViewport.scrollLeft += deltaX;
+      virtualViewport.scrollTop += deltaY;
+      return deltaX !== 0 || deltaY !== 0;
+    });
+    const hook = renderHook({
+      selectionScrollController: {
+        getViewport: () => virtualViewport,
+        scrollBy,
+      },
+    });
+    hook.ctx.cellEditModeRef.current = true;
+    const startCell = new MockHTMLElement({ 'data-row-key': 'row-1', 'data-col-name': 'id' });
+
+    act(() => {
+      (hook.container.listeners.get('mousedown') as any)?.({
+        button: 0,
+        target: startCell,
+        clientX: 10,
+        clientY: 10,
+        preventDefault: vi.fn(),
+      });
+      (hook.container.listeners.get('mousemove') as any)?.({
+        target: {},
+        clientX: 168,
+        clientY: 168,
+        preventDefault: vi.fn(),
+      });
+    });
+
+    expect(hook.runNextAnimationFrame()).toBe(true);
+    expect(scrollBy).toHaveBeenCalledWith(15, 15);
+    expect(virtualViewport).toMatchObject({ scrollTop: 15, scrollLeft: 15 });
+
+    act(() => {
+      (documentTarget.listeners.get('mouseup') as any)?.({ target: {}, clientX: 168, clientY: 168 });
+    });
+  });
+
+  it('extends the selection from the visible edge cell when the pointer leaves the table body', () => {
+    const hook = renderHook();
+    const tableBody = {
+      clientHeight: 200,
+      clientWidth: 200,
+      scrollHeight: 400,
+      scrollLeft: 0,
+      scrollTop: 0,
+      scrollWidth: 400,
+      getBoundingClientRect: () => ({ top: 0, right: 200, bottom: 200, left: 0 }),
+    };
+    const edgeCell = new MockHTMLElement({ 'data-row-key': 'row-2', 'data-col-name': 'name' });
+    documentTarget.elementFromPoint.mockImplementation((x: number, y: number) => (
+      x === 199 && y === 199 ? edgeCell : null
+    ));
+    hook.container.querySelector.mockReturnValue(tableBody as unknown as HTMLElement);
+    hook.ctx.cellEditModeRef.current = true;
+    const startCell = new MockHTMLElement({ 'data-row-key': 'row-1', 'data-col-name': 'id' });
+
+    act(() => {
+      (hook.container.listeners.get('mousedown') as any)?.({
+        button: 0,
+        target: startCell,
+        clientX: 10,
+        clientY: 10,
+        preventDefault: vi.fn(),
+      });
+      (hook.container.listeners.get('mousemove') as any)?.({
+        target: {},
+        clientX: 220,
+        clientY: 220,
+        preventDefault: vi.fn(),
+      });
+    });
+
+    expect(hook.runNextAnimationFrame()).toBe(true);
+    expect(hook.runNextAnimationFrame()).toBe(true);
+    expect(hook.currentSelectionRef.current).toEqual(new Set([
+      makeCellKey('row-1', 'id'),
+      makeCellKey('row-1', 'name'),
+      makeCellKey('row-2', 'id'),
+      makeCellKey('row-2', 'name'),
+    ]));
+
+    act(() => {
+      (documentTarget.listeners.get('mouseup') as any)?.({ target: {}, clientX: 220, clientY: 220 });
+    });
+  });
+
+  it('uses the visible edge cell when releasing the drag outside the table body', () => {
+    const hook = renderHook();
+    const tableBody = {
+      clientHeight: 200,
+      clientWidth: 200,
+      scrollHeight: 400,
+      scrollLeft: 200,
+      scrollTop: 200,
+      scrollWidth: 400,
+      getBoundingClientRect: () => ({ top: 0, right: 200, bottom: 200, left: 0 }),
+    };
+    const edgeCell = new MockHTMLElement({ 'data-row-key': 'row-3', 'data-col-name': 'name' });
+    documentTarget.elementFromPoint.mockImplementation((x: number, y: number) => (
+      x === 199 && y === 199 ? edgeCell : null
+    ));
+    hook.container.querySelector.mockReturnValue(tableBody as unknown as HTMLElement);
+    hook.ctx.cellEditModeRef.current = true;
+    const startCell = new MockHTMLElement({ 'data-row-key': 'row-1', 'data-col-name': 'id' });
+
+    act(() => {
+      (hook.container.listeners.get('mousedown') as any)?.({
+        button: 0,
+        target: startCell,
+        clientX: 10,
+        clientY: 10,
+        preventDefault: vi.fn(),
+      });
+      (hook.container.listeners.get('mousemove') as any)?.({
+        target: {},
+        clientX: 220,
+        clientY: 220,
+        preventDefault: vi.fn(),
+      });
+    });
+
+    expect(hook.runNextAnimationFrame()).toBe(true);
+    expect(hook.currentSelectionRef.current).toEqual(new Set([makeCellKey('row-1', 'id')]));
+
+    act(() => {
+      (documentTarget.listeners.get('mouseup') as any)?.({ target: {}, clientX: 220, clientY: 220 });
+    });
+    expect(hook.currentSelectionRef.current).toEqual(new Set([
+      makeCellKey('row-1', 'id'),
+      makeCellKey('row-1', 'name'),
+      makeCellKey('row-2', 'id'),
+      makeCellKey('row-2', 'name'),
+      makeCellKey('row-3', 'id'),
+      makeCellKey('row-3', 'name'),
+    ]));
+  });
+
+  it('does not treat the center of a compact table body as an edge', () => {
+    const hook = renderHook();
+    const tableBody = {
+      clientHeight: 100,
+      clientWidth: 100,
+      scrollHeight: 200,
+      scrollLeft: 50,
+      scrollTop: 50,
+      scrollWidth: 200,
+      getBoundingClientRect: () => ({ top: 0, right: 100, bottom: 100, left: 0 }),
+    };
+    hook.container.querySelector.mockReturnValue(tableBody as unknown as HTMLElement);
+    hook.ctx.cellEditModeRef.current = true;
+    const startCell = new MockHTMLElement({ 'data-row-key': 'row-1', 'data-col-name': 'id' });
+
+    act(() => {
+      (hook.container.listeners.get('mousedown') as any)?.({
+        button: 0,
+        target: startCell,
+        clientX: 10,
+        clientY: 10,
+        preventDefault: vi.fn(),
+      });
+      (hook.container.listeners.get('mousemove') as any)?.({
+        target: {},
+        clientX: 50,
+        clientY: 50,
+        preventDefault: vi.fn(),
+      });
+    });
+
+    expect(hook.runNextAnimationFrame()).toBe(true);
+    expect({ top: tableBody.scrollTop, left: tableBody.scrollLeft }).toEqual({ top: 50, left: 50 });
+
+    act(() => {
+      (documentTarget.listeners.get('mouseup') as any)?.({ target: {}, clientX: 50, clientY: 50 });
+    });
+  });
+
+  it('recovers an out-of-range scroll position while the pointer is away from the edges', () => {
+    const hook = renderHook();
+    const tableBody = {
+      clientHeight: 200,
+      clientWidth: 200,
+      scrollHeight: 400,
+      scrollLeft: 250,
+      scrollTop: -12,
+      scrollWidth: 400,
+      getBoundingClientRect: () => ({ top: 0, right: 200, bottom: 200, left: 0 }),
+    };
+    hook.container.querySelector.mockReturnValue(tableBody as unknown as HTMLElement);
+    hook.ctx.cellEditModeRef.current = true;
+    const startCell = new MockHTMLElement({ 'data-row-key': 'row-1', 'data-col-name': 'id' });
+
+    act(() => {
+      (hook.container.listeners.get('mousedown') as any)?.({
+        button: 0,
+        target: startCell,
+        clientX: 10,
+        clientY: 10,
+        preventDefault: vi.fn(),
+      });
+      (hook.container.listeners.get('mousemove') as any)?.({
+        target: {},
+        clientX: 100,
+        clientY: 100,
+        preventDefault: vi.fn(),
+      });
+    });
+
+    expect(hook.runNextAnimationFrame()).toBe(true);
+    expect({ top: tableBody.scrollTop, left: tableBody.scrollLeft }).toEqual({ top: 0, left: 200 });
+
+    act(() => {
+      (documentTarget.listeners.get('mouseup') as any)?.({ target: {}, clientX: 100, clientY: 100 });
+    });
+  });
 
   it('builds a closed rectangle from the current rows and skips unavailable columns', () => {
     expect(buildDataGridCellSelectionRectangle({

--- a/frontend/src/components/useDataGridBatchActions.test.tsx
+++ b/frontend/src/components/useDataGridBatchActions.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { buildDataGridCellSelectionRectangle } from './DataGridCore';
 import { useDataGridBatchActions } from './useDataGridBatchActions';
 
 const messageApi = vi.hoisted(() => ({
@@ -101,6 +102,7 @@ describe('useDataGridBatchActions clipboard paste', () => {
     ];
     const currentSelectionRef = { current: selectedCells };
     const selectionStartRef = { current: null as null | { rowKey: string; colName: string; rowIndex: number; colIndex: number } };
+    const cellSelectionAnchorSourceRef = { current: null as 'user' | 'page-find' | null };
     const setAddedRows = vi.fn();
     const setModifiedRows = vi.fn();
     const setModifiedColumns = vi.fn();
@@ -148,6 +150,7 @@ describe('useDataGridBatchActions clipboard paste', () => {
       selectedCells,
       selectedRowKeysRef: { current: selectedRowKeys },
       selectionStartRef,
+      cellSelectionAnchorSourceRef,
       setAddedRows,
       setCellContextMenu: vi.fn(),
       setCellEditMode: vi.fn(),
@@ -173,6 +176,7 @@ describe('useDataGridBatchActions clipboard paste', () => {
       ctx,
       currentSelectionRef,
       selectionStartRef,
+      cellSelectionAnchorSourceRef,
       setAddedRows,
       setModifiedRows,
       setModifiedColumns,
@@ -192,6 +196,50 @@ describe('useDataGridBatchActions clipboard paste', () => {
     });
     return cell;
   };
+
+  const shiftSelectCell = (container: ReturnType<typeof renderHook>['container'], rowKey: string, colName: string) => {
+    const cell = new MockHTMLElement({ 'data-row-key': rowKey, 'data-col-name': colName });
+    const preventDefault = vi.fn();
+    const clickPreventDefault = vi.fn();
+    const stopPropagation = vi.fn();
+    act(() => {
+      (container.listeners.get('mousedown') as any)?.({
+        button: 0,
+        target: cell,
+        clientX: 10,
+        clientY: 10,
+        shiftKey: true,
+        preventDefault,
+      });
+      (documentTarget.listeners.get('mouseup') as any)?.({ target: cell, clientX: 10, clientY: 10 });
+      (container.listeners.get('click') as any)?.({ preventDefault: clickPreventDefault, stopPropagation });
+    });
+    return { cell, preventDefault, clickPreventDefault, stopPropagation };
+  };
+
+  it('builds a closed rectangle from the current rows and skips unavailable columns', () => {
+    expect(buildDataGridCellSelectionRectangle({
+      startRowIndex: 2,
+      startColIndex: 2,
+      endRowIndex: 0,
+      endColIndex: 0,
+      rows: [
+        { key: 'row-1' },
+        { key: 'row-2' },
+        { key: 'row-3' },
+      ],
+      columnNames: ['id', 'generated', 'name'],
+      rowKeyField: 'key',
+      canSelectColumn: (columnName) => columnName !== 'generated',
+    })).toEqual(new Set([
+      makeCellKey('row-1', 'id'),
+      makeCellKey('row-1', 'name'),
+      makeCellKey('row-2', 'id'),
+      makeCellKey('row-2', 'name'),
+      makeCellKey('row-3', 'id'),
+      makeCellKey('row-3', 'name'),
+    ]));
+  });
 
   it('pastes a two-dimensional matrix from the selected anchor cell', () => {
     const hook = renderHook({ modifiedRows: { 'row-1': { name: 'draft' } } });
@@ -687,6 +735,107 @@ describe('useDataGridBatchActions clipboard paste', () => {
     expect(hook.ctx.markCellSelectionDeleteEligible).toHaveBeenCalledWith(false);
     expect(hook.ctx.markCellSelectionUserSelection).toHaveBeenCalledWith(false);
     expect(hook.updateCellSelection).toHaveBeenCalledWith(new Set([makeCellKey('row-1', 'id')]));
+  });
+
+  it('extends from the original anchor across a Shift-clicked rectangle', () => {
+    const hook = renderHook();
+    selectCell(hook.container, 'row-1', 'id');
+
+    const { preventDefault, clickPreventDefault, stopPropagation } = shiftSelectCell(hook.container, 'row-3', 'name');
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(clickPreventDefault).toHaveBeenCalledOnce();
+    expect(stopPropagation).toHaveBeenCalledOnce();
+    expect(hook.selectionStartRef.current).toEqual({ rowKey: 'row-1', colName: 'id', rowIndex: 0, colIndex: 0 });
+    expect(hook.currentSelectionRef.current).toEqual(new Set([
+      makeCellKey('row-1', 'id'), makeCellKey('row-1', 'name'),
+      makeCellKey('row-2', 'id'), makeCellKey('row-2', 'name'),
+      makeCellKey('row-3', 'id'), makeCellKey('row-3', 'name'),
+    ]));
+  });
+
+  it('enters cell edit mode when an editable result uses Shift to extend a range', () => {
+    const hook = renderHook();
+    selectCell(hook.container, 'row-1', 'id');
+
+    shiftSelectCell(hook.container, 'row-2', 'name');
+
+    expect(hook.ctx.cellEditModeRef.current).toBe(true);
+    expect(hook.ctx.setCellEditMode).toHaveBeenCalledWith(true);
+  });
+
+  it('keeps the original anchor for consecutive Shift-clicks', () => {
+    const hook = renderHook();
+    selectCell(hook.container, 'row-1', 'id');
+    shiftSelectCell(hook.container, 'row-3', 'name');
+    shiftSelectCell(hook.container, 'row-2', 'name');
+
+    expect(hook.selectionStartRef.current).toEqual({ rowKey: 'row-1', colName: 'id', rowIndex: 0, colIndex: 0 });
+    expect(hook.currentSelectionRef.current).toEqual(new Set([
+      makeCellKey('row-1', 'id'), makeCellKey('row-1', 'name'),
+      makeCellKey('row-2', 'id'), makeCellKey('row-2', 'name'),
+    ]));
+  });
+
+  it('limits a Shift range to rows in the current filtered result', () => {
+    const hook = renderHook();
+    selectCell(hook.container, 'row-1', 'id');
+    hook.ctx.displayDataRef.current = [
+      { key: 'row-1', id: '1', generated: 'A', name: 'alpha' },
+      { key: 'row-3', id: '3', generated: 'C', name: 'gamma' },
+    ];
+
+    shiftSelectCell(hook.container, 'row-3', 'name');
+
+    expect(hook.currentSelectionRef.current).toEqual(new Set([
+      makeCellKey('row-1', 'id'), makeCellKey('row-1', 'name'),
+      makeCellKey('row-3', 'id'), makeCellKey('row-3', 'name'),
+    ]));
+  });
+
+  it('falls back to a normal single-cell selection when the anchor is no longer visible', () => {
+    const hook = renderHook();
+    selectCell(hook.container, 'row-1', 'id');
+    hook.ctx.displayDataRef.current = [
+      { key: 'row-4', id: '4', generated: 'D', name: 'delta' },
+    ];
+
+    shiftSelectCell(hook.container, 'row-4', 'name');
+
+    expect(hook.selectionStartRef.current).toEqual({
+      rowKey: 'row-4',
+      colName: 'name',
+      rowIndex: 0,
+      colIndex: 2,
+    });
+    expect(hook.currentSelectionRef.current).toEqual(new Set([makeCellKey('row-4', 'name')]));
+  });
+
+  it('does not use a page-find focus as a Shift-selection anchor', () => {
+    const hook = renderHook();
+    hook.selectionStartRef.current = { rowKey: 'row-1', colName: 'id', rowIndex: 0, colIndex: 0 };
+    hook.cellSelectionAnchorSourceRef.current = 'page-find';
+    hook.currentSelectionRef.current = new Set([makeCellKey('row-1', 'id')]);
+
+    shiftSelectCell(hook.container, 'row-3', 'name');
+
+    expect(hook.selectionStartRef.current).toEqual({ rowKey: 'row-3', colName: 'name', rowIndex: 2, colIndex: 2 });
+    expect(hook.cellSelectionAnchorSourceRef.current).toBe('user');
+    expect(hook.currentSelectionRef.current).toEqual(new Set([makeCellKey('row-3', 'name')]));
+  });
+
+  it('keeps all displayed columns selectable in read-only results', () => {
+    const hook = renderHook({ canModifyData: false });
+    selectCell(hook.container, 'row-1', 'id');
+
+    shiftSelectCell(hook.container, 'row-2', 'generated');
+
+    expect(hook.currentSelectionRef.current).toEqual(new Set([
+      makeCellKey('row-1', 'id'), makeCellKey('row-1', 'generated'),
+      makeCellKey('row-2', 'id'), makeCellKey('row-2', 'generated'),
+    ]));
+    expect(hook.ctx.markCellSelectionDeleteEligible).toHaveBeenCalledWith(false);
+    expect(hook.ctx.markCellSelectionUserSelection).toHaveBeenCalledWith(true);
   });
 
   it('moves a single active cell with arrow keys without changing row-selection semantics', () => {

--- a/frontend/src/components/useDataGridBatchActions.ts
+++ b/frontend/src/components/useDataGridBatchActions.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect } from 'react';
 import type React from 'react';
 import { message } from 'antd';
 import {
+  buildDataGridCellSelectionRectangle,
   collectDataGridFillTemplateTargetRowKeys,
   filterDataGridCellSelectionToVisibleRows,
 } from './DataGridCore';
@@ -28,6 +29,7 @@ type DataGridBatchActionsContext = Record<string, any> & {
     rowIndex: number;
     colIndex: number;
   } | null>;
+  cellSelectionAnchorSourceRef: React.MutableRefObject<'user' | 'page-find' | null>;
   cellEditModeRef: React.MutableRefObject<boolean>;
   cellSelectionAutoScrollRafRef: React.MutableRefObject<number | null>;
   cellSelectionPointerRef: React.MutableRefObject<{ x: number; y: number } | null>;
@@ -103,6 +105,7 @@ export const useDataGridBatchActions = (ctx: DataGridBatchActionsContext) => {
     selectedCells,
     selectedRowKeysRef,
     selectionStartRef,
+    cellSelectionAnchorSourceRef,
     setAddedRows,
     setCellContextMenu,
     setCellEditMode,
@@ -213,6 +216,7 @@ const handleBatchFillCells = useCallback(() => {
     markCellSelectionUserSelection(false);
     currentSelectionRef.current = new Set();
     selectionStartRef.current = null;
+    cellSelectionAnchorSourceRef.current = null;
     isDraggingRef.current = false;
     cellSelectionPointerRef.current = null;
     if (cellSelectionAutoScrollRafRef.current !== null) {
@@ -416,42 +420,38 @@ const handleBatchFillCells = useCallback(() => {
       return getCellInfo(target);
     };
 
-    const applySelectionUpdate = (cellInfo: { rowKey: string; colName: string }) => {
+    const applySelectionUpdate = (cellInfo: { rowKey: string; colName: string }): boolean => {
       const start = selectionStartRef.current;
-      if (!start) return;
+      if (!start) return false;
 
       const currentData = displayDataRef.current;
-      const rowIndexMap = rowIndexMapRef.current;
-      const startRowIndex = start.rowIndex;
-      const endRowIndex = rowIndexMap.get(cellInfo.rowKey) ?? -1;
-      if (startRowIndex === -1 || endRowIndex === -1) return;
+      const startRowIndex = currentData.findIndex((row) => rowKeyStr(row?.[GONAVI_ROW_KEY]) === start.rowKey);
+      const endRowIndex = currentData.findIndex((row) => rowKeyStr(row?.[GONAVI_ROW_KEY]) === cellInfo.rowKey);
+      if (startRowIndex === -1 || endRowIndex === -1) return false;
 
-      const startColIndex = start.colIndex;
+      const startColIndex = columnIndexMap.get(start.colName) ?? -1;
       const endColIndex = columnIndexMap.get(cellInfo.colName) ?? -1;
-      if (startColIndex === -1 || endColIndex === -1) return;
+      if (startColIndex === -1 || endColIndex === -1) return false;
 
-      const minRowIndex = Math.min(startRowIndex, endRowIndex);
-      const maxRowIndex = Math.max(startRowIndex, endRowIndex);
-      const minColIndex = Math.min(startColIndex, endColIndex);
-      const maxColIndex = Math.max(startColIndex, endColIndex);
-
-      const newSelectedCells = new Set<string>();
-      for (let i = minRowIndex; i <= maxRowIndex; i++) {
-        const row = currentData[i];
-        const rKey = String(row?.[GONAVI_ROW_KEY]);
-        for (let j = minColIndex; j <= maxColIndex; j++) {
-          const colName = displayColumnNames[j];
-          if (!canSelectGridCellForClipboard({
-            canModifyData,
-            isDisplayedColumn: true,
-            isWritableColumn: isWritableResultColumn(colName, effectiveEditLocator),
-          })) continue;
-          newSelectedCells.add(makeCellKey(rKey, colName));
-        }
-      }
+      const newSelectedCells = buildDataGridCellSelectionRectangle({
+        startRowIndex,
+        startColIndex,
+        endRowIndex,
+        endColIndex,
+        rows: currentData,
+        columnNames: displayColumnNames,
+        rowKeyField: GONAVI_ROW_KEY,
+        canSelectColumn: (columnName) => canSelectGridCellForClipboard({
+          canModifyData,
+          isDisplayedColumn: true,
+          isWritableColumn: isWritableResultColumn(columnName, effectiveEditLocator),
+        }),
+      });
+      if (newSelectedCells.size === 0) return false;
 
       currentSelectionRef.current = newSelectedCells;
       updateCellSelection(newSelectedCells);
+      return true;
     };
 
     const scheduleSelectionUpdate = (cellInfo: { rowKey: string; colName: string }) => {
@@ -566,6 +566,7 @@ const handleBatchFillCells = useCallback(() => {
       const startRowIndex = nextRowIndexMap.get(cellInfo.rowKey) ?? -1;
       const startColIndex = columnIndexMap.get(cellInfo.colName) ?? -1;
       selectionStartRef.current = { rowKey: cellInfo.rowKey, colName: cellInfo.colName, rowIndex: startRowIndex, colIndex: startColIndex };
+      cellSelectionAnchorSourceRef.current = 'user';
       currentSelectionRef.current = new Set([makeCellKey(cellInfo.rowKey, cellInfo.colName)]);
       updateCellSelection(currentSelectionRef.current);
       ensureAutoScroll();
@@ -584,6 +585,7 @@ const handleBatchFillCells = useCallback(() => {
         rowIndex,
         colIndex,
       };
+      cellSelectionAnchorSourceRef.current = 'user';
       currentSelectionRef.current = nextSelection;
       setSelectedCells(nextSelection);
       markCellSelectionDeleteEligible(false);
@@ -666,6 +668,20 @@ const handleBatchFillCells = useCallback(() => {
       if (isInteractiveTarget(target)) return;
       const cellInfo = getCellInfo(target);
       if (!cellInfo) return;
+
+      if (e.shiftKey && cellSelectionAnchorSourceRef.current === 'user' && selectionStartRef.current && applySelectionUpdate(cellInfo)) {
+        e.preventDefault();
+        pendingCellSelectionStartRef.current = null;
+        suppressCellSelectionClickRef.current = true;
+        if (canModifyData && !cellEditModeRef.current) {
+          cellEditModeRef.current = true;
+          setCellEditMode(true);
+        }
+        setSelectedCells(new Set(currentSelectionRef.current));
+        markCellSelectionDeleteEligible(canModifyData);
+        markCellSelectionUserSelection(true);
+        return;
+      }
 
       if (cellEditModeRef.current) {
         e.preventDefault();
@@ -1071,6 +1087,7 @@ const handleBatchFillCells = useCallback(() => {
       rowIndex: anchorRowIndex,
       colIndex,
     };
+    cellSelectionAnchorSourceRef.current = 'user';
     currentSelectionRef.current = nextSelection;
     setSelectedCells(nextSelection);
     markCellSelectionDeleteEligible(true);

--- a/frontend/src/components/useDataGridBatchActions.ts
+++ b/frontend/src/components/useDataGridBatchActions.ts
@@ -9,6 +9,29 @@ import {
 import type { Item } from './DataGridCore';
 import { buildDataGridClipboardPasteRows, parseDataGridClipboardData } from './dataGridClipboardPaste';
 import { canSelectGridCellForClipboard } from './dataGridSelectionCopy';
+import {
+  clampDataGridSelectionAutoScrollDelta,
+  DATA_GRID_SELECTION_AUTO_SCROLL_EDGE_THRESHOLD_PX,
+  getDataGridSelectionAutoScrollStep,
+} from './dataGridSelectionAutoScroll';
+
+export type CellSelectionAutoScrollRect = Pick<
+  DOMRect,
+  'top' | 'right' | 'bottom' | 'left'
+> & Partial<Pick<DOMRect, 'width' | 'height'>>;
+
+export type CellSelectionAutoScrollViewport = {
+  rect: CellSelectionAutoScrollRect;
+  scrollTop: number;
+  scrollLeft: number;
+  maxScrollTop: number;
+  maxScrollLeft: number;
+};
+
+export type CellSelectionAutoScrollController = {
+  getViewport: () => CellSelectionAutoScrollViewport | null;
+  scrollBy: (deltaX: number, deltaY: number) => boolean;
+};
 
 type DataGridBatchActionsContext = Record<string, any> & {
   CELL_SELECTION_DRAG_THRESHOLD_PX: number;
@@ -32,6 +55,7 @@ type DataGridBatchActionsContext = Record<string, any> & {
   cellSelectionAnchorSourceRef: React.MutableRefObject<'user' | 'page-find' | null>;
   cellEditModeRef: React.MutableRefObject<boolean>;
   cellSelectionAutoScrollRafRef: React.MutableRefObject<number | null>;
+  cellSelectionAutoScrollControllerRef?: React.MutableRefObject<CellSelectionAutoScrollController | null>;
   cellSelectionPointerRef: React.MutableRefObject<{ x: number; y: number } | null>;
   cellSelectionRafRef: React.MutableRefObject<number | null>;
   cellSelectionScrollRafRef: React.MutableRefObject<number | null>;
@@ -77,6 +101,7 @@ export const useDataGridBatchActions = (ctx: DataGridBatchActionsContext) => {
     cancelAnimationFrame,
     cellEditModeRef,
     cellSelectionAutoScrollRafRef,
+    cellSelectionAutoScrollControllerRef,
     cellSelectionPointerRef,
     cellSelectionRafRef,
     cellSelectionScrollRafRef,
@@ -384,9 +409,6 @@ const handleBatchFillCells = useCallback(() => {
     const container = containerRef.current;
     if (!isActive || !isTableSurfaceActive) return;
     if (!container) return;
-    const EDGE_THRESHOLD_PX = 28;
-    const MIN_SCROLL_STEP = 8;
-    const MAX_SCROLL_STEP = 24;
 
     const isInteractiveTarget = (target: HTMLElement | null): boolean => {
       if (!target) return false;
@@ -415,9 +437,23 @@ const handleBatchFillCells = useCallback(() => {
       return { rowKey, colName };
     };
 
-    const getCellInfoFromPoint = (x: number, y: number): { rowKey: string; colName: string } | null => {
-      const target = document.elementFromPoint(x, y) as HTMLElement | null;
-      return getCellInfo(target);
+    const getCellInfoFromPoint = (
+      x: number,
+      y: number,
+      fallbackRect?: Pick<DOMRect, 'top' | 'right' | 'bottom' | 'left'>,
+    ): { rowKey: string; colName: string } | null => {
+      const directCell = getCellInfo(document.elementFromPoint(x, y) as HTMLElement | null);
+      if (directCell || !fallbackRect) return directCell;
+
+      const clampToInterior = (value: number, start: number, end: number) => {
+        const inset = Math.min(1, Math.max(0, (end - start) / 2));
+        return Math.min(end - inset, Math.max(start + inset, value));
+      };
+      const fallbackX = clampToInterior(x, fallbackRect.left, fallbackRect.right);
+      const fallbackY = clampToInterior(y, fallbackRect.top, fallbackRect.bottom);
+      if (fallbackX === x && fallbackY === y) return null;
+
+      return getCellInfo(document.elementFromPoint(fallbackX, fallbackY) as HTMLElement | null);
     };
 
     const applySelectionUpdate = (cellInfo: { rowKey: string; colName: string }): boolean => {
@@ -472,9 +508,32 @@ const handleBatchFillCells = useCallback(() => {
       }
     };
 
-    const getScrollStep = (distanceToEdge: number): number => {
-      const ratio = Math.min(1, Math.max(0, distanceToEdge / EDGE_THRESHOLD_PX));
-      return Math.round(MIN_SCROLL_STEP + (MAX_SCROLL_STEP - MIN_SCROLL_STEP) * ratio);
+    const getScrollViewport = (): {
+      viewport: CellSelectionAutoScrollViewport;
+      tableBody: HTMLElement | null;
+      controller: CellSelectionAutoScrollController | null;
+    } | null => {
+      const controller = cellSelectionAutoScrollControllerRef?.current || null;
+      const controlledViewport = controller?.getViewport() || null;
+      if (controlledViewport) {
+        return { viewport: controlledViewport, tableBody: null, controller };
+      }
+
+      const tableBody = container.querySelector('.ant-table-body') as HTMLElement | null;
+      if (!tableBody) return null;
+
+      const rect = tableBody.getBoundingClientRect();
+      return {
+        viewport: {
+          rect,
+          scrollTop: Number.isFinite(tableBody.scrollTop) ? tableBody.scrollTop : 0,
+          scrollLeft: Number.isFinite(tableBody.scrollLeft) ? tableBody.scrollLeft : 0,
+          maxScrollTop: Math.max(0, tableBody.scrollHeight - tableBody.clientHeight),
+          maxScrollLeft: Math.max(0, tableBody.scrollWidth - tableBody.clientWidth),
+        },
+        tableBody,
+        controller: null,
+      };
     };
 
     const autoScrollTick = () => {
@@ -484,53 +543,67 @@ const handleBatchFillCells = useCallback(() => {
       }
 
       const pointer = cellSelectionPointerRef.current;
-      const tableBody = container.querySelector('.ant-table-body') as HTMLElement | null;
-      if (!pointer || !tableBody) {
+      const scrollViewport = getScrollViewport();
+      if (!pointer || !scrollViewport) {
         cellSelectionAutoScrollRafRef.current = requestAnimationFrame(autoScrollTick);
         return;
       }
 
-      const rect = tableBody.getBoundingClientRect();
-      const maxScrollTop = Math.max(0, tableBody.scrollHeight - tableBody.clientHeight);
-      const maxScrollLeft = Math.max(0, tableBody.scrollWidth - tableBody.clientWidth);
+      const { viewport, tableBody, controller } = scrollViewport;
+      const { rect, scrollTop, scrollLeft, maxScrollTop, maxScrollLeft } = viewport;
+      const rectHeight = typeof rect.height === 'number' && Number.isFinite(rect.height)
+        ? rect.height
+        : rect.bottom - rect.top;
+      const rectWidth = typeof rect.width === 'number' && Number.isFinite(rect.width)
+        ? rect.width
+        : rect.right - rect.left;
+      const verticalEdgeThreshold = Math.min(
+        DATA_GRID_SELECTION_AUTO_SCROLL_EDGE_THRESHOLD_PX,
+        Math.max(0, rectHeight / 2),
+      );
+      const horizontalEdgeThreshold = Math.min(
+        DATA_GRID_SELECTION_AUTO_SCROLL_EDGE_THRESHOLD_PX,
+        Math.max(0, rectWidth / 2),
+      );
       let deltaY = 0;
       let deltaX = 0;
 
-      if (pointer.y < rect.top + EDGE_THRESHOLD_PX && tableBody.scrollTop > 0) {
-        const distance = rect.top + EDGE_THRESHOLD_PX - pointer.y;
-        deltaY = -getScrollStep(distance);
-      } else if (pointer.y > rect.bottom - EDGE_THRESHOLD_PX && tableBody.scrollTop < maxScrollTop) {
-        const distance = pointer.y - (rect.bottom - EDGE_THRESHOLD_PX);
-        deltaY = getScrollStep(distance);
+      if (pointer.y < rect.top + verticalEdgeThreshold) {
+        const distance = rect.top + verticalEdgeThreshold - pointer.y;
+        deltaY = -getDataGridSelectionAutoScrollStep(distance);
+      } else if (pointer.y > rect.bottom - verticalEdgeThreshold) {
+        const distance = pointer.y - (rect.bottom - verticalEdgeThreshold);
+        deltaY = getDataGridSelectionAutoScrollStep(distance);
       }
 
-      if (pointer.x < rect.left + EDGE_THRESHOLD_PX && tableBody.scrollLeft > 0) {
-        const distance = rect.left + EDGE_THRESHOLD_PX - pointer.x;
-        deltaX = -getScrollStep(distance);
-      } else if (pointer.x > rect.right - EDGE_THRESHOLD_PX && tableBody.scrollLeft < maxScrollLeft) {
-        const distance = pointer.x - (rect.right - EDGE_THRESHOLD_PX);
-        deltaX = getScrollStep(distance);
+      if (pointer.x < rect.left + horizontalEdgeThreshold) {
+        const distance = rect.left + horizontalEdgeThreshold - pointer.x;
+        deltaX = -getDataGridSelectionAutoScrollStep(distance);
+      } else if (pointer.x > rect.right - horizontalEdgeThreshold) {
+        const distance = pointer.x - (rect.right - horizontalEdgeThreshold);
+        deltaX = getDataGridSelectionAutoScrollStep(distance);
       }
 
       let didScroll = false;
-      if (deltaY !== 0) {
-        const nextTop = Math.max(0, Math.min(maxScrollTop, tableBody.scrollTop + deltaY));
-        if (nextTop !== tableBody.scrollTop) {
-          tableBody.scrollTop = nextTop;
+      const clampedDeltaY = clampDataGridSelectionAutoScrollDelta(deltaY, scrollTop, maxScrollTop);
+      const clampedDeltaX = clampDataGridSelectionAutoScrollDelta(deltaX, scrollLeft, maxScrollLeft);
+      if (controller) {
+        if (clampedDeltaX !== 0 || clampedDeltaY !== 0) {
+          didScroll = controller.scrollBy(clampedDeltaX, clampedDeltaY);
+        }
+      } else if (tableBody) {
+        if (clampedDeltaY !== 0) {
+          tableBody.scrollTop = scrollTop + clampedDeltaY;
           didScroll = true;
         }
-      }
-
-      if (deltaX !== 0) {
-        const nextLeft = Math.max(0, Math.min(maxScrollLeft, tableBody.scrollLeft + deltaX));
-        if (nextLeft !== tableBody.scrollLeft) {
-          tableBody.scrollLeft = nextLeft;
+        if (clampedDeltaX !== 0) {
+          tableBody.scrollLeft = scrollLeft + clampedDeltaX;
           didScroll = true;
         }
       }
 
       if (didScroll) {
-        const cellInfo = getCellInfoFromPoint(pointer.x, pointer.y);
+        const cellInfo = getCellInfoFromPoint(pointer.x, pointer.y, rect);
         if (cellInfo) scheduleSelectionUpdate(cellInfo);
       }
 
@@ -713,7 +786,12 @@ const handleBatchFillCells = useCallback(() => {
       ensureAutoScroll();
 
       const target = e.target instanceof HTMLElement ? e.target : null;
-      const cellInfo = getCellInfo(target) || getCellInfoFromPoint(e.clientX, e.clientY);
+      const scrollViewport = getScrollViewport();
+      const cellInfo = getCellInfo(target) || getCellInfoFromPoint(
+        e.clientX,
+        e.clientY,
+        scrollViewport?.viewport.rect,
+      );
       if (!cellInfo) return;
       scheduleSelectionUpdate(cellInfo);
     };
@@ -737,7 +815,12 @@ const handleBatchFillCells = useCallback(() => {
       }
 
       const target = e.target instanceof HTMLElement ? e.target : null;
-      const cellInfo = getCellInfo(target) || getCellInfoFromPoint(e.clientX, e.clientY);
+      const scrollViewport = getScrollViewport();
+      const cellInfo = getCellInfo(target) || getCellInfoFromPoint(
+        e.clientX,
+        e.clientY,
+        scrollViewport?.viewport.rect,
+      );
       if (cellInfo) applySelectionUpdate(cellInfo);
 
       if (currentSelectionRef.current.size > 0) {


### PR DESCRIPTION
## 背景

SQL 查询结果表拖拽扩大行或单元格选区时，鼠标靠近表格边缘后的自动滚动速度较慢，长结果集下难以快速扩大选区。

## 变更

- 支持结果表按 Excel 风格拖拽扩大行和单元格范围选区。
- 增加拖拽选区期间的边缘自动滚动，覆盖普通表格和虚拟表格的上下、左右滚动。
- 根据鼠标距离表格边缘的位置动态计算滚动速度：越靠近或越超出边缘，滚动越快。
- 鼠标移出表体后仍可持续扩大选区。
- 补充自动滚动速度与批量选择行为回归测试。

## 影响范围

- SQL 查询结果表的行、单元格范围选择与拖拽交互。
- DataGrid 虚拟表格的横向、纵向滚动交互。
- 依赖结果表选区的批量操作。

## 验证

- 聚焦 Vitest 测试：44 项通过。
- `tsc --noEmit`：通过。
- `npm run build`：通过。
- `git diff --check`：通过。

## 风险与回滚

改动仅涉及前端结果表拖拽选区与自动滚动交互，不修改查询执行、结果数据或数据库写入逻辑。若出现特定表格场景兼容问题，可直接回滚本 PR 的 squash commit。