### PR TITLE
🐛 修复 MCP 查询行数上限在完整结果物化后才截断

### DIFF
--- a/internal/app/headless_write_policy_test.go
+++ b/internal/app/headless_write_policy_test.go
@@ -136,7 +136,7 @@ func TestMCPAuthorizedExecutionRechecksLatestConnectionProtection(t *testing.T) 
 	stale := initial.Config
 	stale.ID = initial.ID
 	result := NewMCPQueryExecutor(runtime.app).DBQueryMultiAuthorizedContext(
-		context.Background(), stale, "app", "UPDATE demo SET value = 1", true,
+		context.Background(), stale, "app", "UPDATE demo SET value = 1", true, 0,
 	)
 	if result.Success {
 		t.Fatalf("MCP execution bypassed latest read-only protection: %#v", result)

--- a/internal/app/methods_db.go
+++ b/internal/app/methods_db.go
@@ -1163,6 +1163,9 @@ type dbQueryMultiAuditOptions struct {
 	executionContext          context.Context
 	synchronousConnectionWait bool
 	classifyConnectionErrors  bool
+	// RowBudget 为每个结果集的物化行数上限，0 表示不限制。
+	// 仅无界面调用方（如 MCP）需要设置；达到上限后停止读取并标记截断。
+	RowBudget int
 }
 
 func buildQueryConnectionFailure(err error, queryID string, classify bool) connection.QueryResult {
@@ -1659,6 +1662,13 @@ func (a *App) dbQueryMulti(
 	}
 
 	ctx, cancel := newQueryExecutionContextWithParent(auditOptions.executionContext, runConfig)
+	// 行预算通过 context 下传到 db 层扫描函数：达到上限后扫描停止 rows.Next，
+	// 由方言层既有的 rows.Close 释放 Rows 与连接，而不是物化后再截断。
+	var rowBudget *db.RowBudget
+	if auditOptions.RowBudget > 0 {
+		rowBudget = db.NewRowBudget(auditOptions.RowBudget)
+		ctx = db.ContextWithRowBudget(ctx, rowBudget)
+	}
 	if deadline, ok := ctx.Deadline(); ok {
 		requestTrace.SetRequestMetadata("", "", deadline)
 	}
@@ -1878,6 +1888,7 @@ func (a *App) dbQueryMulti(
 				appendStatementAudit(statement, index+1, auditStartedAt, 0, 0, sqlaudit.BoundaryModeDriverAPI, sqlaudit.CommitModeAuto, nil)
 			}
 		}
+		applyRowBudgetTruncation(results, rowBudget)
 		return summarizeMultiStatementResult(connection.QueryResult{Success: true, Data: results, Messages: resultMessages, QueryID: queryID}, statementCount, 0, sqlaudit.BoundaryModeDriverAPI, false)
 	}
 
@@ -1993,6 +2004,10 @@ func (a *App) dbQueryMulti(
 	summaryBoundaryMode := sqlaudit.BoundaryModeImplicit
 	summaryCommitMode := sqlaudit.CommitModeAuto
 	for idx, stmt := range statements {
+		if rowBudget.Truncated() {
+			// 前一语句已达行预算并停止读取，剩余语句不再执行。
+			break
+		}
 		stmt = strings.TrimSpace(stmt)
 		if stmt == "" {
 			continue
@@ -2244,7 +2259,19 @@ func (a *App) dbQueryMulti(
 	if len(statements) > 1 {
 		fallbackMsg = buildSequentialFallbackMessage(len(statements))
 	}
+	applyRowBudgetTruncation(resultSets, rowBudget)
 	return summarizeMultiStatementResultWithCommitMode(connection.QueryResult{Success: true, Data: resultSets, QueryID: queryID, Message: fallbackMsg}, executedCount, 0, summaryBoundaryMode, summaryCommitMode, false)
+}
+
+// applyRowBudgetTruncation 在达到行预算后，把截断标记落到最后物化的结果集上：
+// 预算耗尽即停止读取，最后一个结果集就是被截断的那个。多结果集扫描路径
+// （scanMultiRows / SQL Server）已在结果集内自带标记，此处是单结果集路径的
+// 统一入口，重复标记幂等。
+func applyRowBudgetTruncation(results []connection.ResultSetData, budget *db.RowBudget) {
+	if budget == nil || !budget.Truncated() || len(results) == 0 {
+		return
+	}
+	results[len(results)-1].Truncated = true
 }
 
 func normalizeNativeResultStatementIndexes(dbType string, statements []string, results []connection.ResultSetData) {

--- a/internal/app/methods_db_audited.go
+++ b/internal/app/methods_db_audited.go
@@ -121,19 +121,22 @@ func (executor *MCPQueryExecutor) DBQueryMulti(
 	dbName string,
 	query string,
 ) connection.QueryResult {
-	return executor.DBQueryMultiContext(context.Background(), config, dbName, query)
+	return executor.DBQueryMultiContext(context.Background(), config, dbName, query, 0)
 }
 
 // DBQueryMultiContext binds an MCP request lifecycle to the underlying
 // database query. This keeps an HTTP client disconnect or stdio shutdown from
 // leaving a query running after its MCP caller has gone away.
+// maxRowsPerResult 是每个结果集的物化行数上限（0 表示不限制）：达到上限后
+// db 层停止读取行并释放连接，避免在完整物化后才截断。
 func (executor *MCPQueryExecutor) DBQueryMultiContext(
 	ctx context.Context,
 	config connection.ConnectionConfig,
 	dbName string,
 	query string,
+	maxRowsPerResult int,
 ) connection.QueryResult {
-	return executor.dbQueryMultiAuthorizedContext(ctx, config, dbName, query, true)
+	return executor.dbQueryMultiAuthorizedContext(ctx, config, dbName, query, true, maxRowsPerResult)
 }
 
 // DBQueryMultiAuthorizedContext is the MCP execution boundary. It resolves
@@ -147,8 +150,9 @@ func (executor *MCPQueryExecutor) DBQueryMultiAuthorizedContext(
 	dbName string,
 	query string,
 	allowMutating bool,
+	maxRowsPerResult int,
 ) connection.QueryResult {
-	return executor.dbQueryMultiAuthorizedContext(ctx, config, dbName, query, allowMutating)
+	return executor.dbQueryMultiAuthorizedContext(ctx, config, dbName, query, allowMutating, maxRowsPerResult)
 }
 
 func (executor *MCPQueryExecutor) dbQueryMultiAuthorizedContext(
@@ -157,6 +161,7 @@ func (executor *MCPQueryExecutor) dbQueryMultiAuthorizedContext(
 	dbName string,
 	query string,
 	allowMutating bool,
+	maxRowsPerResult int,
 ) connection.QueryResult {
 	if executor == nil || executor.app == nil {
 		return connection.QueryResult{Success: false, Message: "MCP query executor is unavailable"}
@@ -178,6 +183,7 @@ func (executor *MCPQueryExecutor) dbQueryMultiAuthorizedContext(
 		auditWrites:      true,
 		source:           "mcp",
 		executionContext: ctx,
+		RowBudget:        maxRowsPerResult,
 	})
 }
 

--- a/internal/app/methods_db_audited_test.go
+++ b/internal/app/methods_db_audited_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -430,7 +431,7 @@ func TestMCPQueryExecutorCancelsUnderlyingQueryWithRequestContext(t *testing.T) 
 
 	resultCh := make(chan connection.QueryResult, 1)
 	go func() {
-		resultCh <- NewMCPQueryExecutor(application).DBQueryMultiContext(requestCtx, config, "app", "SELECT 1")
+		resultCh <- NewMCPQueryExecutor(application).DBQueryMultiContext(requestCtx, config, "app", "SELECT 1", 0)
 	}()
 	select {
 	case <-database.started:
@@ -446,5 +447,58 @@ func TestMCPQueryExecutorCancelsUnderlyingQueryWithRequestContext(t *testing.T) 
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("cancelled MCP query did not return")
+	}
+}
+
+type mcpRowBudgetCaptureDatabase struct {
+	sqlAuditTestDatabase
+	mu   sync.Mutex
+	ctxs []context.Context
+}
+
+func (database *mcpRowBudgetCaptureDatabase) QueryContext(ctx context.Context, _ string) ([]map[string]interface{}, []string, error) {
+	database.mu.Lock()
+	defer database.mu.Unlock()
+	database.ctxs = append(database.ctxs, ctx)
+	return database.rows, database.columns, database.queryErr
+}
+
+func TestMCPQueryExecutorPassesRowBudgetThroughQueryContext(t *testing.T) {
+	originalNewDatabaseFunc := newDatabaseFunc
+	t.Cleanup(func() { newDatabaseFunc = originalNewDatabaseFunc })
+	database := &mcpRowBudgetCaptureDatabase{sqlAuditTestDatabase: sqlAuditTestDatabase{
+		rows:    []map[string]interface{}{{"id": int64(1)}},
+		columns: []string{"id"},
+	}}
+	newDatabaseFunc = func(string) (db.Database, error) { return database, nil }
+	application := newSQLAuditTestApp(t)
+	config := connection.ConnectionConfig{Type: "postgres", Host: "127.0.0.1", Port: 5432, Database: "app"}
+
+	mcpResult := NewMCPQueryExecutor(application).DBQueryMultiAuthorizedContext(
+		context.Background(), config, "app", "SELECT id FROM users", true, 50,
+	)
+	if !mcpResult.Success {
+		t.Fatalf("MCP query with row budget returned failure: %s", mcpResult.Message)
+	}
+	if len(database.ctxs) != 1 {
+		t.Fatalf("expected 1 dispatched query, got %d", len(database.ctxs))
+	}
+	budget := db.RowBudgetFromContext(database.ctxs[0])
+	if budget == nil || budget.MaxRowsPerResult() != 50 {
+		t.Fatalf("MCP query context lacks the 50-row budget: %#v", budget)
+	}
+
+	database.mu.Lock()
+	database.ctxs = nil
+	database.mu.Unlock()
+	appResult := application.DBQueryMulti(config, "app", "SELECT id FROM users", "")
+	if !appResult.Success {
+		t.Fatalf("application query returned failure: %s", appResult.Message)
+	}
+	if len(database.ctxs) != 1 {
+		t.Fatalf("expected 1 dispatched application query, got %d", len(database.ctxs))
+	}
+	if budget := db.RowBudgetFromContext(database.ctxs[0]); budget != nil {
+		t.Fatalf("application query context must not carry an MCP row budget: %#v", budget)
 	}
 }

--- a/internal/connection/types.go
+++ b/internal/connection/types.go
@@ -363,6 +363,8 @@ type ResultSetData struct {
 	Columns        []string                 `json:"columns"`
 	Messages       []string                 `json:"messages,omitempty"`
 	StatementIndex int                      `json:"statementIndex,omitempty"`
+	// Truncated 表示该结果集达到调用方行预算后停止读取，行数可能不完整。
+	Truncated bool `json:"truncated,omitempty"`
 }
 
 const QueryCancellationStateUnsupported = "unsupported"

--- a/internal/db/clickhouse_impl.go
+++ b/internal/db/clickhouse_impl.go
@@ -988,7 +988,7 @@ func (c *ClickHouseDB) QueryContext(ctx context.Context, query string) ([]map[st
 		return nil, nil, err
 	}
 	defer rows.Close()
-	return scanRows(rows)
+	return scanRowsContext(ctx, rows)
 }
 
 func (c *ClickHouseDB) Query(query string) ([]map[string]interface{}, []string, error) {

--- a/internal/db/clickhouse_legacy_http.go
+++ b/internal/db/clickhouse_legacy_http.go
@@ -132,9 +132,17 @@ func (c *clickHouseLegacyHTTPClient) Ping(ctx context.Context) error {
 	return nil
 }
 
+// errRowBudgetExhausted 在流式解码达到行预算时由受限 collector 返回，
+// 用于立即停止读取响应体，Query 侧将其转换为正常截断返回。
+var errRowBudgetExhausted = errors.New("row budget exhausted")
+
 func (c *clickHouseLegacyHTTPClient) Query(ctx context.Context, query string) ([]map[string]interface{}, []string, error) {
 	collector := &clickHouseLegacyHTTPCollector{}
-	if err := c.StreamQuery(ctx, query, collector); err != nil {
+	var consumer QueryStreamConsumer = collector
+	if budget := RowBudgetFromContext(ctx); budget != nil {
+		consumer = &clickHouseLegacyHTTPBudgetCollector{collector: collector, budget: budget}
+	}
+	if err := c.StreamQuery(ctx, query, consumer); err != nil && !errors.Is(err, errRowBudgetExhausted) {
 		return collector.rows, collector.columns, err
 	}
 	return collector.rows, collector.columns, nil
@@ -319,4 +327,26 @@ func (c *clickHouseLegacyHTTPCollector) SetColumns(columns []string) error {
 func (c *clickHouseLegacyHTTPCollector) ConsumeRow(row map[string]interface{}) error {
 	c.rows = append(c.rows, row)
 	return nil
+}
+
+// clickHouseLegacyHTTPBudgetCollector 在达到每结果集行数上限后停止消费，
+// 让流式解码循环提前退出并释放响应体。
+type clickHouseLegacyHTTPBudgetCollector struct {
+	collector *clickHouseLegacyHTTPCollector
+	budget    *RowBudget
+	consumed  int
+}
+
+func (c *clickHouseLegacyHTTPBudgetCollector) SetColumns(columns []string) error {
+	return c.collector.SetColumns(columns)
+}
+
+func (c *clickHouseLegacyHTTPBudgetCollector) ConsumeRow(row map[string]interface{}) error {
+	maxRows := c.budget.MaxRowsPerResult()
+	if maxRows > 0 && c.consumed >= maxRows {
+		c.budget.MarkTruncated()
+		return errRowBudgetExhausted
+	}
+	c.consumed++
+	return c.collector.ConsumeRow(row)
 }

--- a/internal/db/custom_impl.go
+++ b/internal/db/custom_impl.go
@@ -102,7 +102,7 @@ func (c *CustomDB) QueryContext(ctx context.Context, query string) ([]map[string
 	}
 	defer rows.Close()
 
-	return scanRowsForDialect(rows, c.scanDialect())
+	return scanRowsForDialectContext(ctx, rows, c.scanDialect())
 }
 
 func (c *CustomDB) Query(query string) ([]map[string]interface{}, []string, error) {

--- a/internal/db/dameng_impl.go
+++ b/internal/db/dameng_impl.go
@@ -176,7 +176,7 @@ func (d *DamengDB) QueryContext(ctx context.Context, query string) ([]map[string
 	}
 	defer rows.Close()
 
-	return scanRows(rows)
+	return scanRowsContext(ctx, rows)
 }
 
 func (d *DamengDB) Query(query string) ([]map[string]interface{}, []string, error) {

--- a/internal/db/database.go
+++ b/internal/db/database.go
@@ -541,7 +541,7 @@ func (e *sqlConnStatementExecer) QueryContext(ctx context.Context, query string)
 		return nil, nil, err
 	}
 	defer rows.Close()
-	return scanRowsForDialect(rows, e.scanDialect)
+	return scanRowsForDialectContext(ctx, rows, e.scanDialect)
 }
 
 func (e *sqlConnStatementExecer) Query(query string) ([]map[string]interface{}, []string, error) {
@@ -573,7 +573,7 @@ func (e *sqlConnStatementExecer) QueryMultiContext(ctx context.Context, query st
 		return nil, err
 	}
 	defer rows.Close()
-	return scanMultiRowsForDialect(rows, e.scanDialect)
+	return scanMultiRowsForDialectContext(ctx, rows, e.scanDialect)
 }
 
 func (e *sqlConnStatementExecer) QueryMulti(query string) ([]connection.ResultSetData, error) {
@@ -688,7 +688,7 @@ func (e *sqlConnTransactionExecer) QueryContext(ctx context.Context, query strin
 		return nil, nil, err
 	}
 	defer rows.Close()
-	return scanRowsForDialect(rows, e.scanDialect)
+	return scanRowsForDialectContext(ctx, rows, e.scanDialect)
 }
 
 func (e *sqlConnTransactionExecer) Query(query string) ([]map[string]interface{}, []string, error) {
@@ -722,7 +722,7 @@ func (e *sqlConnTransactionExecer) QueryMultiContext(ctx context.Context, query 
 		return nil, err
 	}
 	defer rows.Close()
-	return scanMultiRowsForDialect(rows, e.scanDialect)
+	return scanMultiRowsForDialectContext(ctx, rows, e.scanDialect)
 }
 
 func (e *sqlConnTransactionExecer) QueryMulti(query string) ([]connection.ResultSetData, error) {
@@ -891,7 +891,7 @@ func (e *sqlTxStatementExecer) QueryContext(ctx context.Context, query string) (
 		return nil, nil, err
 	}
 	defer rows.Close()
-	return scanRows(rows)
+	return scanRowsContext(ctx, rows)
 }
 
 func (e *sqlTxStatementExecer) Query(query string) ([]map[string]interface{}, []string, error) {
@@ -925,7 +925,7 @@ func (e *sqlTxStatementExecer) QueryMultiContext(ctx context.Context, query stri
 		return nil, err
 	}
 	defer rows.Close()
-	return scanMultiRows(rows)
+	return scanMultiRowsContext(ctx, rows)
 }
 
 func (e *sqlTxStatementExecer) QueryMulti(query string) ([]connection.ResultSetData, error) {

--- a/internal/db/duckdb_impl.go
+++ b/internal/db/duckdb_impl.go
@@ -109,7 +109,7 @@ func (d *DuckDB) QueryContext(ctx context.Context, query string) ([]map[string]i
 		return nil, nil, err
 	}
 	defer rows.Close()
-	return scanRows(rows)
+	return scanRowsContext(ctx, rows)
 }
 
 func (d *DuckDB) Query(query string) ([]map[string]interface{}, []string, error) {

--- a/internal/db/highgo_impl.go
+++ b/internal/db/highgo_impl.go
@@ -165,7 +165,7 @@ func (h *HighGoDB) QueryContext(ctx context.Context, query string) ([]map[string
 	}
 	defer rows.Close()
 
-	return scanRows(rows)
+	return scanRowsContext(ctx, rows)
 }
 
 func (h *HighGoDB) QueryContextWithMessages(ctx context.Context, query string) ([]map[string]interface{}, []string, []string, error) {

--- a/internal/db/iris_impl.go
+++ b/internal/db/iris_impl.go
@@ -191,7 +191,7 @@ func (i *IrisDB) QueryMultiContext(ctx context.Context, query string) ([]connect
 		return nil, err
 	}
 	defer rows.Close()
-	return scanMultiRows(rows)
+	return scanMultiRowsContext(ctx, rows)
 }
 
 func (i *IrisDB) QueryContext(ctx context.Context, query string) ([]map[string]interface{}, []string, error) {
@@ -203,7 +203,7 @@ func (i *IrisDB) QueryContext(ctx context.Context, query string) ([]map[string]i
 		return nil, nil, err
 	}
 	defer rows.Close()
-	return scanRows(rows)
+	return scanRowsContext(ctx, rows)
 }
 
 func (i *IrisDB) Query(query string) ([]map[string]interface{}, []string, error) {

--- a/internal/db/kingbase_impl.go
+++ b/internal/db/kingbase_impl.go
@@ -378,7 +378,7 @@ func (k *KingbaseDB) QueryContext(ctx context.Context, query string) ([]map[stri
 	}
 	defer rows.Close()
 
-	return scanRows(rows)
+	return scanRowsContext(ctx, rows)
 }
 
 func (k *KingbaseDB) QueryContextWithMessages(ctx context.Context, query string) ([]map[string]interface{}, []string, []string, error) {

--- a/internal/db/mariadb_impl.go
+++ b/internal/db/mariadb_impl.go
@@ -111,7 +111,7 @@ func (m *MariaDB) QueryMultiContext(ctx context.Context, query string) ([]connec
 		return nil, err
 	}
 	defer rows.Close()
-	return scanMultiRowsForDialect(rows, "mariadb")
+	return scanMultiRowsForDialectContext(ctx, rows, "mariadb")
 }
 
 func (m *MariaDB) QueryContext(ctx context.Context, query string) ([]map[string]interface{}, []string, error) {
@@ -125,7 +125,7 @@ func (m *MariaDB) QueryContext(ctx context.Context, query string) ([]map[string]
 	}
 	defer rows.Close()
 
-	return scanRowsForDialect(rows, "mariadb")
+	return scanRowsForDialectContext(ctx, rows, "mariadb")
 }
 
 func (m *MariaDB) Query(query string) ([]map[string]interface{}, []string, error) {

--- a/internal/db/mysql_impl.go
+++ b/internal/db/mysql_impl.go
@@ -946,7 +946,7 @@ func (m *MySQLDB) QueryMultiContext(ctx context.Context, query string) ([]connec
 		return nil, err
 	}
 	defer rows.Close()
-	return scanMultiRowsForDialect(rows, "mysql")
+	return scanMultiRowsForDialectContext(ctx, rows, "mysql")
 }
 
 func (m *MySQLDB) QueryContext(ctx context.Context, query string) ([]map[string]interface{}, []string, error) {
@@ -960,7 +960,7 @@ func (m *MySQLDB) QueryContext(ctx context.Context, query string) ([]map[string]
 	}
 	defer rows.Close()
 
-	return scanRowsForDialect(rows, "mysql")
+	return scanRowsForDialectContext(ctx, rows, "mysql")
 }
 
 func (m *MySQLDB) Query(query string) ([]map[string]interface{}, []string, error) {

--- a/internal/db/notice_query.go
+++ b/internal/db/notice_query.go
@@ -55,6 +55,6 @@ func querySQLConnWithTextNotices(ctx context.Context, conn *sql.Conn, query stri
 	}
 	defer rows.Close()
 
-	data, columns, err := scanRows(rows)
+	data, columns, err := scanRowsContext(ctx, rows)
 	return data, columns, append([]string(nil), notices...), err
 }

--- a/internal/db/oracle_impl.go
+++ b/internal/db/oracle_impl.go
@@ -272,7 +272,7 @@ func (o *OracleDB) QueryContext(ctx context.Context, query string) ([]map[string
 	}
 	defer rows.Close()
 
-	return scanRowsForDialect(rows, o.scanDialect)
+	return scanRowsForDialectContext(ctx, rows, o.scanDialect)
 }
 
 func (o *OracleDB) Query(query string) ([]map[string]interface{}, []string, error) {

--- a/internal/db/postgres_impl.go
+++ b/internal/db/postgres_impl.go
@@ -233,7 +233,7 @@ func (p *PostgresDB) QueryContext(ctx context.Context, query string) ([]map[stri
 	}
 	defer rows.Close()
 
-	return scanRows(rows)
+	return scanRowsContext(ctx, rows)
 }
 
 func (p *PostgresDB) QueryContextWithMessages(ctx context.Context, query string) ([]map[string]interface{}, []string, []string, error) {

--- a/internal/db/row_budget.go
+++ b/internal/db/row_budget.go
@@ -1,0 +1,72 @@
+package db
+
+import (
+	"context"
+	"sync"
+)
+
+// RowBudget 限制单次查询每个结果集最多物化多少行，供 MCP 等无界面调用方
+// 约束结果集扫描的内存与连接占用。扫描达到上限后停止读取并记录截断，
+// 调用方通过 Truncated 获知结果不完整。
+type RowBudget struct {
+	mu               sync.Mutex
+	maxRowsPerResult int
+	truncated        bool
+}
+
+// NewRowBudget 创建行预算；maxRowsPerResult 非正时返回 nil（不限制），
+// 使预算检查点无需区分 nil 与零值。
+func NewRowBudget(maxRowsPerResult int) *RowBudget {
+	if maxRowsPerResult <= 0 {
+		return nil
+	}
+	return &RowBudget{maxRowsPerResult: maxRowsPerResult}
+}
+
+// MaxRowsPerResult 返回每个结果集的行数上限，0 表示不限制。
+func (b *RowBudget) MaxRowsPerResult() int {
+	if b == nil {
+		return 0
+	}
+	return b.maxRowsPerResult
+}
+
+// MarkTruncated 记录“达到预算后停止读取”。
+func (b *RowBudget) MarkTruncated() {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.truncated = true
+}
+
+// Truncated 报告扫描是否因达到预算而停止过。
+func (b *RowBudget) Truncated() bool {
+	if b == nil {
+		return false
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.truncated
+}
+
+type rowBudgetContextKey struct{}
+
+// ContextWithRowBudget 将行预算绑定到查询 context。db 层的扫描函数据此在
+// 达到上限后停止 rows.Next 并让调用方的 rows.Close 释放连接。
+func ContextWithRowBudget(ctx context.Context, budget *RowBudget) context.Context {
+	if ctx == nil || budget == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, rowBudgetContextKey{}, budget)
+}
+
+// RowBudgetFromContext 返回 context 中绑定的行预算；未绑定时返回 nil。
+func RowBudgetFromContext(ctx context.Context) *RowBudget {
+	if ctx == nil {
+		return nil
+	}
+	budget, _ := ctx.Value(rowBudgetContextKey{}).(*RowBudget)
+	return budget
+}

--- a/internal/db/row_budget_test.go
+++ b/internal/db/row_budget_test.go
@@ -1,0 +1,212 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"io"
+	"sync/atomic"
+	"testing"
+)
+
+// 行预算停读测试使用计数 fake driver：DriverRows 记录 Next/Close 次数，
+// 断言达到预算后不再继续读取并释放 Rows（连接随 rows.Close 归还池）。
+type rowBudgetFakeCounter struct {
+	nextCalls  atomic.Int64
+	closeCalls atomic.Int64
+}
+
+type rowBudgetFakeConnector struct {
+	counter *rowBudgetFakeCounter
+	sets    []int // 每个结果集的行数
+}
+
+func (c *rowBudgetFakeConnector) Connect(context.Context) (driver.Conn, error) {
+	return &rowBudgetFakeConn{counter: c.counter, sets: c.sets}, nil
+}
+
+func (c *rowBudgetFakeConnector) Driver() driver.Driver {
+	return rowBudgetFakeDriver{}
+}
+
+type rowBudgetFakeDriver struct{}
+
+func (rowBudgetFakeDriver) Open(string) (driver.Conn, error) {
+	return nil, driver.ErrSkip
+}
+
+type rowBudgetFakeConn struct {
+	counter *rowBudgetFakeCounter
+	sets    []int
+}
+
+func (c *rowBudgetFakeConn) Prepare(string) (driver.Stmt, error) { return nil, driver.ErrSkip }
+func (c *rowBudgetFakeConn) Close() error                        { return nil }
+func (c *rowBudgetFakeConn) Begin() (driver.Tx, error)           { return nil, driver.ErrSkip }
+func (c *rowBudgetFakeConn) BeginTx(context.Context, driver.TxOptions) (driver.Tx, error) {
+	return nil, driver.ErrSkip
+}
+
+func (c *rowBudgetFakeConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+	return &rowBudgetFakeRows{counter: c.counter, sets: c.sets}, nil
+}
+
+type rowBudgetFakeRows struct {
+	counter *rowBudgetFakeCounter
+	sets    []int
+	setIdx  int
+	rowIdx  int
+}
+
+func (r *rowBudgetFakeRows) Columns() []string { return []string{"n"} }
+
+func (r *rowBudgetFakeRows) Close() error {
+	r.counter.closeCalls.Add(1)
+	return nil
+}
+
+func (r *rowBudgetFakeRows) Next(dest []driver.Value) error {
+	r.counter.nextCalls.Add(1)
+	if r.rowIdx >= r.sets[r.setIdx] {
+		return io.EOF
+	}
+	dest[0] = int64(r.rowIdx + 1)
+	r.rowIdx++
+	return nil
+}
+
+func (r *rowBudgetFakeRows) HasNextResultSet() bool { return r.setIdx < len(r.sets)-1 }
+
+func (r *rowBudgetFakeRows) NextResultSet() error {
+	if !r.HasNextResultSet() {
+		return io.EOF
+	}
+	r.setIdx++
+	r.rowIdx = 0
+	return nil
+}
+
+func openRowBudgetFakeDB(t *testing.T, counter *rowBudgetFakeCounter, sets ...int) *sql.DB {
+	t.Helper()
+	db := sql.OpenDB(&rowBudgetFakeConnector{counter: counter, sets: sets})
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func openRowBudgetFakeRows(t *testing.T, db *sql.DB, query string) *sql.Rows {
+	t.Helper()
+	rows, err := db.QueryContext(context.Background(), query)
+	if err != nil {
+		t.Fatalf("query fake db: %v", err)
+	}
+	return rows
+}
+
+func budgetContext(maxRows int) context.Context {
+	return ContextWithRowBudget(context.Background(), NewRowBudget(maxRows))
+}
+
+func TestScanMultiRowsStopsReadingAtRowBudget(t *testing.T) {
+	counter := &rowBudgetFakeCounter{}
+	rows := openRowBudgetFakeRows(t, openRowBudgetFakeDB(t, counter, 300), "SELECT n")
+
+	results, err := scanMultiRowsForDialectContext(budgetContext(50), rows, "")
+	if err != nil {
+		t.Fatalf("scanMultiRowsForDialectContext: %v", err)
+	}
+	if len(results) != 1 || len(results[0].Rows) != 50 {
+		t.Fatalf("expected 1 result set with 50 rows, got %#v", results)
+	}
+	if !results[0].Truncated {
+		t.Fatalf("expected result set marked truncated")
+	}
+	if !counter.nextCalls.CompareAndSwap(51, 51) {
+		t.Fatalf("expected 51 Next calls (50 rows + 1 overflow probe), got %d", counter.nextCalls.Load())
+	}
+	if counter.closeCalls.Load() != 0 {
+		// Rows 由方言层的 defer rows.Close 释放；此处通过显式 Close 模拟并断言可释放。
+	}
+	if err := rows.Close(); err != nil {
+		t.Fatalf("close rows: %v", err)
+	}
+	if counter.closeCalls.Load() != 1 {
+		t.Fatalf("expected rows to be closed exactly once, got %d", counter.closeCalls.Load())
+	}
+}
+
+func TestScanMultiRowsKeepsExactBudgetResultComplete(t *testing.T) {
+	counter := &rowBudgetFakeCounter{}
+	rows := openRowBudgetFakeRows(t, openRowBudgetFakeDB(t, counter, 50), "SELECT n")
+
+	results, err := scanMultiRowsForDialectContext(budgetContext(50), rows, "")
+	if err != nil {
+		t.Fatalf("scanMultiRowsForDialectContext: %v", err)
+	}
+	if len(results) != 1 || len(results[0].Rows) != 50 {
+		t.Fatalf("expected complete 50-row result set, got %#v", results)
+	}
+	if results[0].Truncated {
+		t.Fatalf("result set with exactly the budget row count must not be marked truncated")
+	}
+}
+
+func TestScanMultiRowsWithoutBudgetMaterializesAllRows(t *testing.T) {
+	counter := &rowBudgetFakeCounter{}
+	rows := openRowBudgetFakeRows(t, openRowBudgetFakeDB(t, counter, 300), "SELECT n")
+
+	results, err := scanMultiRowsForDialectContext(context.Background(), rows, "")
+	if err != nil {
+		t.Fatalf("scanMultiRowsForDialectContext: %v", err)
+	}
+	if len(results) != 1 || len(results[0].Rows) != 300 || results[0].Truncated {
+		t.Fatalf("expected complete 300-row result set, got %#v", results)
+	}
+}
+
+func TestScanMultiRowsBudgetStopsAfterTruncatedResultSet(t *testing.T) {
+	counter := &rowBudgetFakeCounter{}
+	rows := openRowBudgetFakeRows(t, openRowBudgetFakeDB(t, counter, 10, 100), "SELECT n; SELECT n")
+
+	results, err := scanMultiRowsForDialectContext(budgetContext(50), rows, "")
+	if err != nil {
+		t.Fatalf("scanMultiRowsForDialectContext: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 result sets, got %d", len(results))
+	}
+	if len(results[0].Rows) != 10 || results[0].Truncated {
+		t.Fatalf("expected first result set complete with 10 rows, got %#v", results[0])
+	}
+	if len(results[1].Rows) != 50 || !results[1].Truncated {
+		t.Fatalf("expected second result set truncated at 50 rows, got %#v", results[1])
+	}
+	// 第一个结果集耗尽需要 10 次 Next + 1 次 EOF；第二个结果集在读取
+	// 50 行后通过 1 次溢出探测确认截断，之后不再读取。
+	if counter.nextCalls.Load() != 62 {
+		t.Fatalf("expected 62 Next calls, got %d", counter.nextCalls.Load())
+	}
+}
+
+func TestScanRowsContextMarksRowBudgetOnSingleResultSet(t *testing.T) {
+	counter := &rowBudgetFakeCounter{}
+	rows := openRowBudgetFakeRows(t, openRowBudgetFakeDB(t, counter, 300), "SELECT n")
+
+	budget := NewRowBudget(50)
+	ctx := ContextWithRowBudget(context.Background(), budget)
+	data, _, err := scanRowsContext(ctx, rows)
+	if err != nil {
+		t.Fatalf("scanRowsContext: %v", err)
+	}
+	if len(data) != 50 {
+		t.Fatalf("expected 50 rows, got %d", len(data))
+	}
+	if !budget.Truncated() {
+		t.Fatalf("expected budget to be marked truncated")
+	}
+	if err := rows.Close(); err != nil {
+		t.Fatalf("close rows: %v", err)
+	}
+	if counter.closeCalls.Load() != 1 {
+		t.Fatalf("expected rows closed once, got %d", counter.closeCalls.Load())
+	}
+}

--- a/internal/db/row_budget_test.go
+++ b/internal/db/row_budget_test.go
@@ -123,9 +123,6 @@ func TestScanMultiRowsStopsReadingAtRowBudget(t *testing.T) {
 	if !counter.nextCalls.CompareAndSwap(51, 51) {
 		t.Fatalf("expected 51 Next calls (50 rows + 1 overflow probe), got %d", counter.nextCalls.Load())
 	}
-	if counter.closeCalls.Load() != 0 {
-		// Rows 由方言层的 defer rows.Close 释放；此处通过显式 Close 模拟并断言可释放。
-	}
 	if err := rows.Close(); err != nil {
 		t.Fatalf("close rows: %v", err)
 	}

--- a/internal/db/scan_rows.go
+++ b/internal/db/scan_rows.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"runtime"
@@ -28,6 +29,10 @@ func scanRows(rows *sql.Rows) ([]map[string]interface{}, []string, error) {
 	return scanRowsForDialect(rows, "")
 }
 
+func scanRowsContext(ctx context.Context, rows *sql.Rows) ([]map[string]interface{}, []string, error) {
+	return scanRowsForDialectContext(ctx, rows, "")
+}
+
 func streamRows(rows *sql.Rows, consumer QueryStreamConsumer) error {
 	return streamRowsForDialect(rows, "", consumer)
 }
@@ -48,17 +53,24 @@ type queryRowsScanner interface {
 }
 
 func scanRowsForDialect(rows *sql.Rows, dialect string) ([]map[string]interface{}, []string, error) {
-	return scanRowsForDialectWithPreview(rows, dialect, true)
+	data, columns, _, err := scanRowsForDialectWithPreview(rows, dialect, true, nil)
+	return data, columns, err
+}
+
+func scanRowsForDialectContext(ctx context.Context, rows *sql.Rows, dialect string) ([]map[string]interface{}, []string, error) {
+	data, columns, _, err := scanRowsForDialectWithPreview(rows, dialect, true, RowBudgetFromContext(ctx))
+	return data, columns, err
 }
 
 func scanRowsUnboundedForDialect(rows *sql.Rows, dialect string) ([]map[string]interface{}, []string, error) {
-	return scanRowsForDialectWithPreview(rows, dialect, false)
+	data, columns, _, err := scanRowsForDialectWithPreview(rows, dialect, false, nil)
+	return data, columns, err
 }
 
-func scanRowsForDialectWithPreview(rows *sql.Rows, dialect string, boundOracleLargeObjects bool) ([]map[string]interface{}, []string, error) {
+func scanRowsForDialectWithPreview(rows *sql.Rows, dialect string, boundOracleLargeObjects bool, budget *RowBudget) ([]map[string]interface{}, []string, bool, error) {
 	columns, err := rows.Columns()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, false, err
 	}
 	columns = ensureUniqueQueryColumnNames(columns)
 
@@ -68,14 +80,25 @@ func scanRowsForDialectWithPreview(rows *sql.Rows, dialect string, boundOracleLa
 	}
 
 	scanner := newQueryRowScanner(columns, colTypes, dialect)
-	return scanRowsWithScanner(rows, columns, scanner, boundOracleLargeObjects)
+	return scanRowsWithScanner(rows, columns, scanner, boundOracleLargeObjects, budget)
 }
 
-func scanRowsWithScanner(rows *sql.Rows, columns []string, scanner queryRowsScanner, boundOracleLargeObjects bool) ([]map[string]interface{}, []string, error) {
+func scanRowsWithScanner(rows *sql.Rows, columns []string, scanner queryRowsScanner, boundOracleLargeObjects bool, budget *RowBudget) ([]map[string]interface{}, []string, bool, error) {
 	resultData := make([]map[string]interface{}, 0)
 
+	// maxRows 为每个结果集的行数上限。达到上限后再观察到一次 rows.Next()==true
+	// 才判定截断，保证行数恰好等于上限的完整结果集不被误标。
+	maxRows := budget.MaxRowsPerResult()
 	var rowNumber int64
+	truncated := false
 	for rows.Next() {
+		if maxRows > 0 && rowNumber >= int64(maxRows) {
+			// 结果集仍有更多行：停止读取（不排空、不推进结果集），
+			// 由调用方既有的 rows.Close 释放 Rows 与连接。
+			truncated = true
+			budget.MarkTruncated()
+			break
+		}
 		rowNumber++
 		var (
 			entry map[string]interface{}
@@ -87,15 +110,18 @@ func scanRowsWithScanner(rows *sql.Rows, columns []string, scanner queryRowsScan
 			entry, err = scanner.scanCurrentRow(rows)
 		}
 		if err != nil {
-			return resultData, columns, newQueryRowScanError(rowNumber, columns, err)
+			return resultData, columns, false, newQueryRowScanError(rowNumber, columns, err)
 		}
 		resultData = append(resultData, entry)
 	}
 
-	if err := rows.Err(); err != nil {
-		return resultData, columns, err
+	if truncated {
+		return resultData, columns, true, nil
 	}
-	return resultData, columns, nil
+	if err := rows.Err(); err != nil {
+		return resultData, columns, false, err
+	}
+	return resultData, columns, false, nil
 }
 
 func streamRowsForDialect(rows *sql.Rows, dialect string, consumer QueryStreamConsumer) error {
@@ -343,13 +369,25 @@ func ensureUniqueQueryColumnNames(columns []string) []string {
 // scanMultiRows 遍历 sql.Rows 中的所有结果集，将每个结果集作为 ResultSetData 返回。
 // 利用 rows.NextResultSet() 支持一次 query 返回多个结果集的场景。
 func scanMultiRows(rows *sql.Rows) ([]connection.ResultSetData, error) {
-	return scanMultiRowsForDialect(rows, "")
+	return scanMultiRowsWithBudget(rows, "", nil)
+}
+
+func scanMultiRowsContext(ctx context.Context, rows *sql.Rows) ([]connection.ResultSetData, error) {
+	return scanMultiRowsWithBudget(rows, "", RowBudgetFromContext(ctx))
 }
 
 func scanMultiRowsForDialect(rows *sql.Rows, dialect string) ([]connection.ResultSetData, error) {
+	return scanMultiRowsWithBudget(rows, dialect, nil)
+}
+
+func scanMultiRowsForDialectContext(ctx context.Context, rows *sql.Rows, dialect string) ([]connection.ResultSetData, error) {
+	return scanMultiRowsWithBudget(rows, dialect, RowBudgetFromContext(ctx))
+}
+
+func scanMultiRowsWithBudget(rows *sql.Rows, dialect string, budget *RowBudget) ([]connection.ResultSetData, error) {
 	var results []connection.ResultSetData
 	for {
-		data, cols, err := scanRowsForDialect(rows, dialect)
+		data, cols, truncated, err := scanRowsForDialectWithPreview(rows, dialect, true, budget)
 		if err != nil {
 			return results, err
 		}
@@ -360,9 +398,15 @@ func scanMultiRowsForDialect(rows *sql.Rows, dialect string) ([]connection.Resul
 			cols = []string{}
 		}
 		results = append(results, connection.ResultSetData{
-			Rows:    data,
-			Columns: cols,
+			Rows:      data,
+			Columns:   cols,
+			Truncated: truncated,
 		})
+		if truncated {
+			// 达到行预算：不再调用 NextResultSet（database/sql 会先排空当前
+			// 结果集的剩余行），剩余结果集与行一并放弃。
+			break
+		}
 		if !rows.NextResultSet() {
 			break
 		}

--- a/internal/db/scan_rows_test.go
+++ b/internal/db/scan_rows_test.go
@@ -425,7 +425,7 @@ func (r *scanRowsDuplicateRows) Next(dest []driver.Value) error {
 func TestScanRowsReturnsSecondRowScanErrorWithPartialResults(t *testing.T) {
 	rows := openScanRowsErrorRows(t)
 
-	data, columns, err := scanRowsWithScanner(rows, []string{"id"}, &scanRowsErrorScanner{failAt: 2}, false)
+	data, columns, _, err := scanRowsWithScanner(rows, []string{"id"}, &scanRowsErrorScanner{failAt: 2}, false, nil)
 	if !errors.Is(err, errScanRowsTest) {
 		t.Fatalf("scanRows error = %v, want wrapped scan error", err)
 	}

--- a/internal/db/sqlite_impl.go
+++ b/internal/db/sqlite_impl.go
@@ -213,7 +213,7 @@ func (s *SQLiteDB) QueryContext(ctx context.Context, query string) ([]map[string
 	}
 	defer rows.Close()
 
-	return scanRows(rows)
+	return scanRowsContext(ctx, rows)
 }
 
 func (s *SQLiteDB) Query(query string) ([]map[string]interface{}, []string, error) {

--- a/internal/db/sqlserver_impl.go
+++ b/internal/db/sqlserver_impl.go
@@ -55,7 +55,7 @@ func scanSQLServerRowsWithMessages(ctx context.Context, rows *sql.Rows, retmsg *
 				allMessages = append(allMessages, text)
 			}
 		case sqlexp.MsgNext:
-			data, cols, err := scanRows(rows)
+			data, cols, truncated, err := scanRowsForDialectWithPreview(rows, "", true, RowBudgetFromContext(ctx))
 			if err != nil {
 				return resultSets, messages, err
 			}
@@ -66,10 +66,15 @@ func scanSQLServerRowsWithMessages(ctx context.Context, rows *sql.Rows, retmsg *
 				cols = []string{}
 			}
 			resultSets = append(resultSets, connection.ResultSetData{
-				Rows:     data,
-				Columns:  cols,
-				Messages: append([]string(nil), messages...),
+				Rows:      data,
+				Columns:   cols,
+				Messages:  append([]string(nil), messages...),
+				Truncated: truncated,
 			})
+			if truncated {
+				// 达到行预算：停止读取，剩余结果集与消息不再消费。
+				return resultSets, allMessages, nil
+			}
 			messages = nil
 		case sqlexp.MsgRowsAffected:
 			resultSets = append(resultSets, connection.ResultSetData{

--- a/internal/db/tdengine_impl.go
+++ b/internal/db/tdengine_impl.go
@@ -392,7 +392,7 @@ func (t *TDengineDB) QueryContext(ctx context.Context, query string) ([]map[stri
 	}
 	defer rows.Close()
 
-	return scanRows(rows)
+	return scanRowsContext(ctx, rows)
 }
 
 func (t *TDengineDB) Query(query string) ([]map[string]interface{}, []string, error) {

--- a/internal/db/trino_impl.go
+++ b/internal/db/trino_impl.go
@@ -422,7 +422,7 @@ func (t *TrinoDB) QueryContext(ctx context.Context, query string) ([]map[string]
 		return nil, nil, err
 	}
 	defer rows.Close()
-	return scanRows(rows)
+	return scanRowsContext(ctx, rows)
 }
 
 func (t *TrinoDB) Query(query string) ([]map[string]interface{}, []string, error) {

--- a/internal/db/vastbase_impl.go
+++ b/internal/db/vastbase_impl.go
@@ -156,7 +156,7 @@ func (v *VastbaseDB) QueryContext(ctx context.Context, query string) ([]map[stri
 	}
 	defer rows.Close()
 
-	return scanRows(rows)
+	return scanRowsContext(ctx, rows)
 }
 
 func (v *VastbaseDB) Query(query string) ([]map[string]interface{}, []string, error) {

--- a/internal/mcpserver/backend.go
+++ b/internal/mcpserver/backend.go
@@ -29,7 +29,7 @@ type Backend interface {
 	DBGetForeignKeys(context.Context, connection.ConnectionConfig, string, string) connection.QueryResult
 	DBGetTriggers(context.Context, connection.ConnectionConfig, string, string) connection.QueryResult
 	DBShowCreateTable(context.Context, connection.ConnectionConfig, string, string) connection.QueryResult
-	ExecuteSQLFromMCP(context.Context, connection.ConnectionConfig, string, string) connection.QueryResult
+	ExecuteSQLFromMCP(context.Context, connection.ConnectionConfig, string, string, int) connection.QueryResult
 	InspectSQL(dbType string, sql string) appcore.SQLInspection
 	GetSQLSafetyLevel() ai.SQLPermissionLevel
 	AuthorizeSQLConnection(config connection.ConnectionConfig, sql string) error
@@ -39,7 +39,7 @@ type Backend interface {
 // implementations. Production AppBackend uses it to close the gap between the
 // service's presentation-time policy check and database dispatch.
 type executionAuthorizingBackend interface {
-	ExecuteAuthorizedSQLFromMCP(context.Context, string, connection.ConnectionConfig, string, string, bool) connection.QueryResult
+	ExecuteAuthorizedSQLFromMCP(context.Context, string, connection.ConnectionConfig, string, string, bool, int) connection.QueryResult
 }
 
 // AppBackend 基于现有 internal/app.App 暴露 MCP 所需数据库能力。
@@ -158,18 +158,19 @@ func (b *AppBackend) DBShowCreateTable(ctx context.Context, config connection.Co
 // ExecuteAuthorizedSQLFromMCP resolves the saved connection and checks its
 // current protections immediately before dispatching SQL. The service's
 // earlier display snapshot is not trusted for this authorization boundary.
-func (b *AppBackend) ExecuteSQLFromMCP(ctx context.Context, config connection.ConnectionConfig, dbName string, query string) connection.QueryResult {
-	return b.executeAuthorizedSQLFromMCP(ctx, strings.TrimSpace(config.ID), config, dbName, query, true)
+// maxRowsPerResult 限制每个结果集的物化行数（0 表示不限制）。
+func (b *AppBackend) ExecuteSQLFromMCP(ctx context.Context, config connection.ConnectionConfig, dbName string, query string, maxRowsPerResult int) connection.QueryResult {
+	return b.executeAuthorizedSQLFromMCP(ctx, strings.TrimSpace(config.ID), config, dbName, query, true, maxRowsPerResult)
 }
 
 // ExecuteAuthorizedSQLFromMCP is the explicit authorization-bound entry point
 // used by Service. It re-reads the saved connection immediately before SQL is
 // dispatched, closing the stale-view TOCTOU window.
-func (b *AppBackend) ExecuteAuthorizedSQLFromMCP(ctx context.Context, connectionID string, config connection.ConnectionConfig, dbName string, query string, allowMutating bool) connection.QueryResult {
-	return b.executeAuthorizedSQLFromMCP(ctx, strings.TrimSpace(connectionID), config, dbName, query, allowMutating)
+func (b *AppBackend) ExecuteAuthorizedSQLFromMCP(ctx context.Context, connectionID string, config connection.ConnectionConfig, dbName string, query string, allowMutating bool, maxRowsPerResult int) connection.QueryResult {
+	return b.executeAuthorizedSQLFromMCP(ctx, strings.TrimSpace(connectionID), config, dbName, query, allowMutating, maxRowsPerResult)
 }
 
-func (b *AppBackend) executeAuthorizedSQLFromMCP(ctx context.Context, connectionID string, config connection.ConnectionConfig, dbName string, query string, allowMutating bool) connection.QueryResult {
+func (b *AppBackend) executeAuthorizedSQLFromMCP(ctx context.Context, connectionID string, config connection.ConnectionConfig, dbName string, query string, allowMutating bool, maxRowsPerResult int) connection.QueryResult {
 	if b == nil || b.mcpQueryExecutor == nil {
 		return connection.QueryResult{Success: false, Message: "MCP backend is unavailable"}
 	}
@@ -178,7 +179,7 @@ func (b *AppBackend) executeAuthorizedSQLFromMCP(ctx context.Context, connection
 		return connection.QueryResult{Success: false, Message: "MCP saved connection ID is required"}
 	}
 	config.ID = connectionID
-	return b.mcpQueryExecutor.DBQueryMultiAuthorizedContext(ctx, config, dbName, query, allowMutating)
+	return b.mcpQueryExecutor.DBQueryMultiAuthorizedContext(ctx, config, dbName, query, allowMutating, maxRowsPerResult)
 }
 
 func (b *AppBackend) InspectSQL(dbType string, sql string) appcore.SQLInspection {

--- a/internal/mcpserver/service.go
+++ b/internal/mcpserver/service.go
@@ -622,8 +622,11 @@ func (s *Service) ExecuteSQL(ctx context.Context, req *mcp.CallToolRequest, args
 		return toolError("连接写保护拒绝 SQL 执行: %s", strings.TrimSpace(err.Error())), executeSQLResult{}, nil
 	}
 
+	// 行预算在执行前下传到 db 层：达到上限后停止读取行并释放连接，
+	// 而不是把完整结果物化后再截断。
+	maxRowsPerResult := normalizeMaxRowsPerResult(args.MaxRowsPerResult)
 	dbName := effectiveDBName(args.DBName, view.Config)
-	queryResult := s.executeAuthorizedSQL(ctx, view, dbName, sqlText, args.AllowMutating)
+	queryResult := s.executeAuthorizedSQL(ctx, view, dbName, sqlText, args.AllowMutating, maxRowsPerResult)
 	if !queryResult.Success {
 		failure := executeSQLResult{
 			RequestID:         mcpRequestID(ctx),
@@ -648,7 +651,7 @@ func (s *Service) ExecuteSQL(ctx context.Context, req *mcp.CallToolRequest, args
 		return toolError("解析 SQL 执行结果失败: %v", err), executeSQLResult{}, nil
 	}
 
-	normalizedResults, truncated := normalizeResultSets(resultSets, normalizeMaxRowsPerResult(args.MaxRowsPerResult))
+	normalizedResults, truncated := normalizeResultSets(resultSets, maxRowsPerResult)
 	output := executeSQLResult{
 		RequestID:         mcpRequestID(ctx),
 		ConnectionID:      view.ID,
@@ -666,11 +669,11 @@ func (s *Service) ExecuteSQL(ctx context.Context, req *mcp.CallToolRequest, args
 	return textResult(formatExecuteSQLResultContent(output)), output, nil
 }
 
-func (s *Service) executeAuthorizedSQL(ctx context.Context, view connection.SavedConnectionView, dbName string, sqlText string, allowMutating bool) connection.QueryResult {
+func (s *Service) executeAuthorizedSQL(ctx context.Context, view connection.SavedConnectionView, dbName string, sqlText string, allowMutating bool, maxRowsPerResult int) connection.QueryResult {
 	if backend, ok := s.backend.(executionAuthorizingBackend); ok {
-		return backend.ExecuteAuthorizedSQLFromMCP(ctx, view.ID, view.Config, dbName, sqlText, allowMutating)
+		return backend.ExecuteAuthorizedSQLFromMCP(ctx, view.ID, view.Config, dbName, sqlText, allowMutating, maxRowsPerResult)
 	}
-	return s.backend.ExecuteSQLFromMCP(ctx, view.Config, dbName, sqlText)
+	return s.backend.ExecuteSQLFromMCP(ctx, view.Config, dbName, sqlText, maxRowsPerResult)
 }
 
 func successResult() *mcp.CallToolResult {
@@ -1017,17 +1020,26 @@ func normalizeResultSets(resultSets []connection.ResultSetData, maxRows int) ([]
 	for _, resultSet := range resultSets {
 		rows := ensureNonNilRows(resultSet.Rows)
 		rowCount := len(rows)
-		truncated := false
+		// Truncated 为 true 表示 db 层达到行预算后停止读取，返回的行是
+		// 服务器端数据的下界；否则只在超出 maxRows 时做响应侧裁剪。
+		truncatedByBudget := resultSet.Truncated
+		truncated := truncatedByBudget
 		if maxRows > 0 && len(rows) > maxRows {
 			rows = append([]map[string]interface{}(nil), rows[:maxRows]...)
 			truncated = true
+		}
+		if truncated {
 			truncatedAny = true
+		}
+		messages := ensureNonNilStrings(append([]string(nil), resultSet.Messages...))
+		if truncatedByBudget {
+			messages = append(messages, fmt.Sprintf("结果集达到每结果集行数上限 %d，剩余行未读取", maxRows))
 		}
 		normalized = append(normalized, sqlResultSet{
 			StatementIndex: resultSet.StatementIndex,
 			Columns:        ensureNonNilStrings(append([]string(nil), resultSet.Columns...)),
 			Rows:           rows,
-			Messages:       ensureNonNilStrings(append([]string(nil), resultSet.Messages...)),
+			Messages:       messages,
 			RowCount:       rowCount,
 			Truncated:      truncated,
 		})
@@ -1068,7 +1080,7 @@ func formatExecuteSQLResultContent(result executeSQLResult) string {
 		}
 		builder.WriteString(fmt.Sprintf("：%d 行", resultSet.RowCount))
 		if resultSet.Truncated {
-			builder.WriteString(fmt.Sprintf("，仅显示前 %d 行", len(resultSet.Rows)))
+			builder.WriteString(fmt.Sprintf("，已达每结果集行数上限（返回前 %d 行），其余行未返回", len(resultSet.Rows)))
 		}
 		if len(resultSet.Messages) > 0 {
 			builder.WriteString("\n消息：")

--- a/internal/mcpserver/service.go
+++ b/internal/mcpserver/service.go
@@ -652,6 +652,21 @@ func (s *Service) ExecuteSQL(ctx context.Context, req *mcp.CallToolRequest, args
 	}
 
 	normalizedResults, truncated := normalizeResultSets(resultSets, maxRowsPerResult)
+	message := strings.TrimSpace(queryResult.Message)
+	// 逐条执行路径达到行预算后停止读取并不再执行剩余语句；原生多语句批次
+	// 的语句已在服务端全部执行（ExecutedCount 等于语句总数），不产生该说明。
+	if truncated && queryResult.ExecutedCount > 0 && queryResult.ExecutedCount < inspection.StatementCount {
+		budgetNote := fmt.Sprintf(
+			"已达到每结果集行数上限 %d，剩余 %d 条语句未执行",
+			maxRowsPerResult,
+			inspection.StatementCount-queryResult.ExecutedCount,
+		)
+		if message != "" {
+			message += "；" + budgetNote
+		} else {
+			message = budgetNote
+		}
+	}
 	output := executeSQLResult{
 		RequestID:         mcpRequestID(ctx),
 		ConnectionID:      view.ID,
@@ -660,7 +675,7 @@ func (s *Service) ExecuteSQL(ctx context.Context, req *mcp.CallToolRequest, args
 		ReadOnly:          inspection.ReadOnly,
 		QueryID:           strings.TrimSpace(queryResult.QueryID),
 		CancellationState: strings.TrimSpace(queryResult.CancellationState),
-		Message:           strings.TrimSpace(queryResult.Message),
+		Message:           message,
 		OutcomeUnknown:    queryResult.OutcomeUnknown,
 		Truncated:         truncated,
 		Statements:        toStatementSummaries(inspection.Statements),

--- a/internal/mcpserver/service.go
+++ b/internal/mcpserver/service.go
@@ -57,7 +57,7 @@ type executeSQLArgs struct {
 	DBName           string `json:"dbName,omitempty" jsonschema:"可选数据库/Schema 名称。为空时优先使用保存连接里的默认数据库"`
 	SQL              string `json:"sql" jsonschema:"待执行的 SQL 文本，可以包含多条语句"`
 	AllowMutating    bool   `json:"allowMutating,omitempty" jsonschema:"当 SQL 包含当前 AI 安全控制允许范围内的 DDL/DML 等非只读语句时，必须显式设为 true"`
-	MaxRowsPerResult int    `json:"maxRowsPerResult,omitempty" jsonschema:"每个结果集最多返回多少行。默认 50，最大 200（少量数据探查）"`
+	MaxRowsPerResult int    `json:"maxRowsPerResult,omitempty" jsonschema:"每个结果集最多返回多少行。默认 50，最大 200（少量数据探查）。达到上限后立即停止读取，剩余行不返回；多语句查询中某条语句达到上限时，后续语句将不执行"`
 }
 
 type connectionDescriptor struct {

--- a/internal/mcpserver/service.go
+++ b/internal/mcpserver/service.go
@@ -57,7 +57,7 @@ type executeSQLArgs struct {
 	DBName           string `json:"dbName,omitempty" jsonschema:"可选数据库/Schema 名称。为空时优先使用保存连接里的默认数据库"`
 	SQL              string `json:"sql" jsonschema:"待执行的 SQL 文本，可以包含多条语句"`
 	AllowMutating    bool   `json:"allowMutating,omitempty" jsonschema:"当 SQL 包含当前 AI 安全控制允许范围内的 DDL/DML 等非只读语句时，必须显式设为 true"`
-	MaxRowsPerResult int    `json:"maxRowsPerResult,omitempty" jsonschema:"每个结果集最多返回多少行。默认 50，最大 200（少量数据探查）。达到上限后立即停止读取，剩余行不返回；多语句查询中某条语句达到上限时，后续语句将不执行"`
+	MaxRowsPerResult int    `json:"maxRowsPerResult,omitempty" jsonschema:"每个结果集最多返回多少行。默认 50，最大 200（少量数据探查）。达到上限后立即停止读取，剩余行不返回；多语句查询中某条语句达到上限时，后续语句不再返回结果（逐条执行路径中后续语句将不执行；原生多语句批次中的语句仍会在服务端全部执行）"`
 }
 
 type connectionDescriptor struct {

--- a/internal/mcpserver/service_test.go
+++ b/internal/mcpserver/service_test.go
@@ -1488,8 +1488,9 @@ func TestExecuteSQLSurfacesBudgetTruncation(t *testing.T) {
 			Statements:     []appcore.SQLStatementInspection{{Index: 1, Keyword: "select", ReadOnly: true}},
 		},
 		queryResult: connection.QueryResult{
-			Success: true,
-			QueryID: "query-budget",
+			Success:       true,
+			QueryID:       "query-budget",
+			ExecutedCount: 1,
 			Data: []connection.ResultSetData{{
 				StatementIndex: 1,
 				Columns:        []string{"id"},
@@ -1527,5 +1528,59 @@ func TestExecuteSQLSurfacesBudgetTruncation(t *testing.T) {
 	}
 	if text := firstTextContent(result); !strings.Contains(text, "已达每结果集行数上限") {
 		t.Fatalf("expected budget truncation wording in content: %q", text)
+	}
+}
+
+func TestExecuteSQLNotesStatementsSkippedByRowBudget(t *testing.T) {
+	rows := make([]map[string]interface{}, 0, 50)
+	for i := 1; i <= 50; i++ {
+		rows = append(rows, map[string]interface{}{"id": int64(i)})
+	}
+	backend := &fakeBackend{
+		editableConnection: connection.SavedConnectionView{
+			ID:     "mysql-main",
+			Config: connection.ConnectionConfig{Type: "mysql", Database: "app"},
+		},
+		inspection: appcore.SQLInspection{
+			StatementCount: 3,
+			ReadOnly:       true,
+			Statements: []appcore.SQLStatementInspection{
+				{Index: 1, Keyword: "select", ReadOnly: true},
+				{Index: 2, Keyword: "select", ReadOnly: true},
+				{Index: 3, Keyword: "select", ReadOnly: true},
+			},
+		},
+		queryResult: connection.QueryResult{
+			Success:       true,
+			QueryID:       "query-skip",
+			ExecutedCount: 1,
+			Data: []connection.ResultSetData{{
+				StatementIndex: 1,
+				Columns:        []string{"id"},
+				Rows:           rows,
+				Truncated:      true,
+			}},
+		},
+	}
+
+	service := NewService(backend)
+	result, out, err := service.ExecuteSQL(context.Background(), nil, executeSQLArgs{
+		ConnectionID: "mysql-main",
+		SQL:          "select id from users; select id from orders; select id from items",
+	})
+	if err != nil {
+		t.Fatalf("ExecuteSQL returned error: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("expected success result, got %#v", result)
+	}
+	if !out.Truncated {
+		t.Fatalf("expected truncated output, got %#v", out)
+	}
+	if !strings.Contains(out.Message, "剩余 2 条语句未执行") {
+		t.Fatalf("expected skipped-statement note in message: %q", out.Message)
+	}
+	if text := firstTextContent(result); !strings.Contains(text, "剩余 2 条语句未执行") {
+		t.Fatalf("expected skipped-statement note in content: %q", text)
 	}
 }

--- a/internal/mcpserver/service_test.go
+++ b/internal/mcpserver/service_test.go
@@ -15,30 +15,31 @@ import (
 )
 
 type fakeBackend struct {
-	savedConnections    []connection.SavedConnectionView
-	savedConnectionsErr error
-	editableConnection  connection.SavedConnectionView
-	editableErr         error
-	databasesResult     connection.QueryResult
-	tablesResult        connection.QueryResult
-	viewsResult         connection.QueryResult
-	objectsResult       connection.QueryResult
-	allColumnsResult    connection.QueryResult
-	columnsResult       connection.QueryResult
-	indexesResult       connection.QueryResult
-	foreignKeysResult   connection.QueryResult
-	triggersResult      connection.QueryResult
-	ddlResult           connection.QueryResult
-	queryResult         connection.QueryResult
-	inspection          appcore.SQLInspection
-	safetyLevel         ai.SQLPermissionLevel
-	queryCalled         bool
-	queryContext        context.Context
-	authorizeErr        error
-	authorizeCalls      int
-	authorizedConfig    connection.ConnectionConfig
-	authorizedSQL       string
-	events              []string
+	savedConnections      []connection.SavedConnectionView
+	savedConnectionsErr   error
+	editableConnection    connection.SavedConnectionView
+	editableErr           error
+	databasesResult       connection.QueryResult
+	tablesResult          connection.QueryResult
+	viewsResult           connection.QueryResult
+	objectsResult         connection.QueryResult
+	allColumnsResult      connection.QueryResult
+	columnsResult         connection.QueryResult
+	indexesResult         connection.QueryResult
+	foreignKeysResult     connection.QueryResult
+	triggersResult        connection.QueryResult
+	ddlResult             connection.QueryResult
+	queryResult           connection.QueryResult
+	inspection            appcore.SQLInspection
+	safetyLevel           ai.SQLPermissionLevel
+	queryCalled           bool
+	queryContext          context.Context
+	queryMaxRowsPerResult int
+	authorizeErr          error
+	authorizeCalls        int
+	authorizedConfig      connection.ConnectionConfig
+	authorizedSQL         string
+	events                []string
 }
 
 type cancellableTablesBackend struct {
@@ -139,9 +140,10 @@ func (f *fakeBackend) DBShowCreateTable(context.Context, connection.ConnectionCo
 	return f.ddlResult
 }
 
-func (f *fakeBackend) ExecuteSQLFromMCP(ctx context.Context, config connection.ConnectionConfig, dbName string, query string) connection.QueryResult {
+func (f *fakeBackend) ExecuteSQLFromMCP(ctx context.Context, config connection.ConnectionConfig, dbName string, query string, maxRowsPerResult int) connection.QueryResult {
 	f.queryCalled = true
 	f.queryContext = ctx
+	f.queryMaxRowsPerResult = maxRowsPerResult
 	f.events = append(f.events, "query")
 	return f.queryResult
 }
@@ -1425,4 +1427,105 @@ func firstTextContent(result *mcp.CallToolResult) string {
 		return ""
 	}
 	return text.Text
+}
+
+func TestExecuteSQLForwardsNormalizedMaxRowsPerResult(t *testing.T) {
+	cases := []struct {
+		name string
+		arg  int
+		want int
+	}{
+		{name: "unset falls back to default", arg: 0, want: defaultMaxRowsPerResult},
+		{name: "above limit clamps to limit", arg: 5000, want: maxRowsPerResultLimit},
+		{name: "explicit value passes through", arg: 120, want: 120},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := &fakeBackend{
+				editableConnection: connection.SavedConnectionView{
+					ID:     "mysql-main",
+					Config: connection.ConnectionConfig{Type: "mysql", Database: "app"},
+				},
+				inspection: appcore.SQLInspection{
+					StatementCount: 1,
+					ReadOnly:       true,
+					Statements:     []appcore.SQLStatementInspection{{Index: 1, Keyword: "select", ReadOnly: true}},
+				},
+				queryResult: connection.QueryResult{Success: true, Data: []connection.ResultSetData{}},
+			}
+			service := NewService(backend)
+			result, _, err := service.ExecuteSQL(context.Background(), nil, executeSQLArgs{
+				ConnectionID:     "mysql-main",
+				SQL:              "select 1",
+				MaxRowsPerResult: tc.arg,
+			})
+			if err != nil {
+				t.Fatalf("ExecuteSQL returned error: %v", err)
+			}
+			if result == nil || result.IsError {
+				t.Fatalf("expected success result, got %#v", result)
+			}
+			if backend.queryMaxRowsPerResult != tc.want {
+				t.Fatalf("backend received maxRowsPerResult=%d, want %d", backend.queryMaxRowsPerResult, tc.want)
+			}
+		})
+	}
+}
+
+func TestExecuteSQLSurfacesBudgetTruncation(t *testing.T) {
+	rows := make([]map[string]interface{}, 0, 50)
+	for i := 1; i <= 50; i++ {
+		rows = append(rows, map[string]interface{}{"id": int64(i)})
+	}
+	backend := &fakeBackend{
+		editableConnection: connection.SavedConnectionView{
+			ID:     "mysql-main",
+			Config: connection.ConnectionConfig{Type: "mysql", Database: "app"},
+		},
+		inspection: appcore.SQLInspection{
+			StatementCount: 1,
+			ReadOnly:       true,
+			Statements:     []appcore.SQLStatementInspection{{Index: 1, Keyword: "select", ReadOnly: true}},
+		},
+		queryResult: connection.QueryResult{
+			Success: true,
+			QueryID: "query-budget",
+			Data: []connection.ResultSetData{{
+				StatementIndex: 1,
+				Columns:        []string{"id"},
+				Rows:           rows,
+				Truncated:      true,
+			}},
+		},
+	}
+
+	service := NewService(backend)
+	result, out, err := service.ExecuteSQL(context.Background(), nil, executeSQLArgs{
+		ConnectionID: "mysql-main",
+		SQL:          "select id from users",
+	})
+	if err != nil {
+		t.Fatalf("ExecuteSQL returned error: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("expected success result, got %#v", result)
+	}
+	if !out.Truncated || len(out.Results) != 1 || !out.Results[0].Truncated {
+		t.Fatalf("expected truncated output, got %#v", out)
+	}
+	if out.Results[0].RowCount != 50 || len(out.Results[0].Rows) != 50 {
+		t.Fatalf("unexpected row counts: rowCount=%d rows=%d", out.Results[0].RowCount, len(out.Results[0].Rows))
+	}
+	foundBudgetNote := false
+	for _, message := range out.Results[0].Messages {
+		if strings.Contains(message, "剩余行未读取") {
+			foundBudgetNote = true
+		}
+	}
+	if !foundBudgetNote {
+		t.Fatalf("expected budget truncation note in messages: %#v", out.Results[0].Messages)
+	}
+	if text := firstTextContent(result); !strings.Contains(text, "已达每结果集行数上限") {
+		t.Fatalf("expected budget truncation wording in content: %q", text)
+	}
 }


### PR DESCRIPTION
## 问题背景

MCP `execute_sql` 工具声称每个结果集默认返回 50 行、最多 200 行，但该上限只在 `dbQueryMulti` 完整物化全部行之后才由 `normalizeResultSets` 截断。已授权的 MCP 客户端一条大查询即可占用应用内存、数据库连接和服务端读取资源，导致工作台及其他请求退化。

## 修复内容

- db 层新增 `RowBudget`（每结果集行数上限 + 截断标记），经 context 下传到扫描层；`scanRowsWithScanner` 读满预算后再观察一次 `rows.Next` 确认确有更多行才判定截断，避免恰好等于预算的完整结果集被误标；判定后停止读取、不推进 `NextResultSet`（避免 database/sql 排空当前结果集剩余行），由方言层既有 `rows.Close` 释放 Rows 与连接
- 全部 SQL 方言的 ctx 变体查询（MySQL/MariaDB/PostgreSQL 系/Oracle/SQL Server/达梦/瀚高/人大金仓/Iris/DuckDB/ClickHouse/TDengine/SQLite/Trino/Vastbase 及 session/事务执行器）接入预算感知扫描；SQL Server 消息循环与 ClickHouse legacy HTTP 流式解码在截断处提前退出
- `dbQueryMulti` 仅在 MCP 路径注入预算；逐条执行路径预算耗尽后不再执行剩余语句，原生多语句批次不产生误导性的"未执行"说明
- MCP `Backend`/`MCPQueryExecutor` 接口传递 `maxRowsPerResult`；`ResultSetData` 新增 `Truncated` 字段；响应附带截断说明（顶部 Truncated、结果集消息、多语句跳过说明）；`normalizeResultSets` 保留为响应侧兜底
- `maxRowsPerResult` 工具 schema 披露预算行为；UI/CLI 路径不注入预算，行为不变

## 验证方式

- `go test ./internal/db/ ./internal/connection/ ./internal/mcpserver/` 全量通过；`go test ./internal/app/` 全量通过；`go vet` 通过
- 计数 fake driver 断言：300 行结果集在预算 50 时恰好读取 51 次 `Next`（50 行 + 1 次溢出探测）后停止，`rows.Close` 恰好一次；行数恰好等于预算的完整结果集不误标；多结果集场景首个小结果集完整、第二个超限截断
- app 层断言 MCP 查询 ctx 携带行预算、UI 查询 ctx 不携带；MCP 层断言 `maxRowsPerResult` 归一化下传（0→50、>200→200、显式值透传）与截断/跳过语句说明输出
- 四轮独立子 agent 代码审查通过

## 影响与风险

- 预算截断的结果集 `RowCount` 从"服务器端全量行数"变为"已读取行数"，配合 `Truncated` 标记与结果集消息说明
- 原生多语句批次中的语句已在服务端全部执行，预算只能停止结果读取，无法撤销服务端执行（只读批次/写批次门控与现状一致）
- IoTDB/Elasticsearch/MongoDB/MySQLAgent/OptionalDriverAgent 等拥有独立物化路径的方言本次未接入预算，响应侧 `normalizeResultSets` 兜底仍生效，可作后续跟进
- `ResultSetData` 新增可选 JSON 字段 `truncated`，向后兼容

## 关联 Issue

Closes #1142
