### PR TITLE
🐛 修复 Streamable HTTP MCP 停止时可能无限等待活跃请求

### DIFF
--- a/internal/mcpserver/run.go
+++ b/internal/mcpserver/run.go
@@ -326,13 +326,6 @@ func (t *activeRequestTracker) cancelAll() int {
 	return count
 }
 
-// pending 返回尚未完成的在途请求数。
-func (t *activeRequestTracker) pending() int {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	return len(t.reqs)
-}
-
 // errAbandonedActiveHandlers 标记强制关闭窗口耗尽后仍有活跃 handler 未退出。
 var errAbandonedActiveHandlers = errors.New("active handlers abandoned after force close")
 

--- a/internal/mcpserver/run.go
+++ b/internal/mcpserver/run.go
@@ -192,9 +192,11 @@ func startStreamableHTTPServer(ctx context.Context, options HTTPServerOptions, s
 	var activeRequests sync.WaitGroup
 	inFlight := newActiveRequestTracker()
 	requestHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		// 为每个请求派生可取消 context 并替换进 req：MCP 工具调用从
-		// request context 派生执行 context，强制关闭阶段据此通知活跃
-		// handler 尽快退出，而不是只能等连接被硬切断。
+		// 为每个请求派生可取消 context 并替换进 req：感知 req.Context()
+		// 的 HTTP 层处理代码可在强制关闭阶段立即收到取消信号。注意 MCP
+		// SDK 的工具调用 context 在 jsonrpc2 连接层与请求 context 脱钩，
+		// 不会收到该信号；真正解除阻塞的是 forceCloseActiveRequests 中
+		// 的 httpServer.Close 硬断连接。
 		reqCtx, cancelReq := context.WithCancel(req.Context())
 		defer cancelReq()
 		req = req.Clone(reqCtx)
@@ -243,6 +245,9 @@ func startStreamableHTTPServer(ctx context.Context, options HTTPServerOptions, s
 			// proceed even if a handler ignores cancellation.
 			abandonErr := forceCloseActiveRequests(httpServer, inFlight, &activeRequests, forceCloseTimeout)
 			if abandonErr != nil {
+				if err != nil && !errors.Is(err, http.ErrServerClosed) {
+					abandonErr = errors.Join(abandonErr, err)
+				}
 				handle.complete(abandonErr)
 				return
 			}
@@ -260,14 +265,18 @@ func startStreamableHTTPServer(ctx context.Context, options HTTPServerOptions, s
 			// 连接，在有界窗口内等待。原先这里是无界 activeRequests.Wait()，
 			// 一个不返回的 handler 会永久阻塞 Backend.Close 与进程退出。
 			var abandonErr error
-			if shutdownErr != nil && !errors.Is(shutdownErr, http.ErrServerClosed) {
+			if shutdownErr != nil {
+				// Shutdown 只返回 nil 或 ctx.Err()，到达这里的都是优雅窗口超时。
 				abandonErr = forceCloseActiveRequests(httpServer, inFlight, &activeRequests, forceCloseTimeout)
 			}
 			if abandonErr != nil {
+				if shutdownErr != nil {
+					abandonErr = errors.Join(abandonErr, shutdownErr)
+				}
 				handle.complete(abandonErr)
 				return
 			}
-			if shutdownErr != nil && !errors.Is(shutdownErr, http.ErrServerClosed) {
+			if shutdownErr != nil {
 				handle.complete(shutdownErr)
 				return
 			}
@@ -324,13 +333,22 @@ func (t *activeRequestTracker) pending() int {
 	return len(t.reqs)
 }
 
-// forceCloseActiveRequests 在优雅关闭窗口耗尽后强制终止仍在运行的活跃请求：
-// 先取消其派生 context（协作式 handler 可立即退出），再关闭底层连接，
-// 然后在 forceTimeout 内等待。超时后仍未返回的 handler 将被放弃并计入
-// 返回错误——Go 无法强制杀死 goroutine，但关闭流程必须继续推进，
-// 保证 Backend.Close 与进程退出不被无限阻塞。
+// errAbandonedActiveHandlers 标记强制关闭窗口耗尽后仍有活跃 handler 未退出。
+var errAbandonedActiveHandlers = errors.New("active handlers abandoned after force close")
+
+// forceCloseActiveRequests 在优雅关闭窗口耗尽后强制终止仍在运行的活跃 HTTP
+// 请求：先取消其派生 context（感知 req.Context 的处理代码可立即退出），
+// 再关闭底层连接硬断 SDK 会话等待，然后在 forceTimeout 内等待 HTTP
+// handler 返回。超时后仍未返回的 handler 将被放弃并返回
+// errAbandonedActiveHandlers——Go 无法强制杀死 goroutine，但关闭流程必须
+// 继续推进，保证 Backend.Close 与进程退出不被无限阻塞。
+//
+// 放弃契约：本函数只保证 HTTP handler 层退出；仍在运行的 MCP 工具调用
+// goroutine 不会被终止，可能在 Backend.Close 之后继续访问已关闭的
+// backend 资源（database/sql 并发 Close 安全，通常表现为该调用报错）。
+// 这是相比进程永久卡死的有意取舍。
 func forceCloseActiveRequests(httpServer *http.Server, tracker *activeRequestTracker, activeRequests *sync.WaitGroup, forceTimeout time.Duration) error {
-	tracker.cancelAll()
+	canceled := tracker.cancelAll()
 	_ = httpServer.Close()
 	drained := make(chan struct{})
 	go func() {
@@ -341,7 +359,7 @@ func forceCloseActiveRequests(httpServer *http.Server, tracker *activeRequestTra
 	case <-drained:
 		return nil
 	case <-time.After(forceTimeout):
-		return fmt.Errorf("mcp http 强制关闭后仍有 %d 个活跃 handler 在 %v 内未退出，已放弃等待", tracker.pending(), forceTimeout)
+		return fmt.Errorf("%w: 强制取消 %d 个在途请求后，仍有请求未在 %v 内退出，已放弃等待", errAbandonedActiveHandlers, canceled, forceTimeout)
 	}
 }
 

--- a/internal/mcpserver/run.go
+++ b/internal/mcpserver/run.go
@@ -23,6 +23,11 @@ const (
 	defaultStreamableHTTPAddr     = "127.0.0.1:8765"
 	defaultStreamableHTTPPath     = "/mcp"
 	streamableHTTPShutdownTimeout = 5 * time.Second
+	// streamableHTTPForceCloseTimeout 是优雅关闭超时后，等待活跃 handler
+	// 响应强制取消并退出的有界窗口。超时后仍未返回的 handler 会被放弃
+	// （goroutine 无法强制终止），关闭流程继续推进，保证 Backend.Close
+	// 与进程退出不被无限阻塞。
+	streamableHTTPForceCloseTimeout = 3 * time.Second
 )
 
 // HTTPServerOptions 描述远程 Streamable HTTP MCP 入口。
@@ -180,13 +185,22 @@ func StartStreamableHTTPServer(ctx context.Context, backend Backend, options HTT
 		JSONResponse:   normalized.JSONResponse,
 		SessionTimeout: 30 * time.Minute,
 	})
-	return startStreamableHTTPServer(ctx, normalized, streamableHandler, streamableHTTPShutdownTimeout)
+	return startStreamableHTTPServer(ctx, normalized, streamableHandler, streamableHTTPShutdownTimeout, streamableHTTPForceCloseTimeout)
 }
 
-func startStreamableHTTPServer(ctx context.Context, options HTTPServerOptions, streamableHandler http.Handler, shutdownTimeout time.Duration) (*StreamableHTTPServerHandle, error) {
+func startStreamableHTTPServer(ctx context.Context, options HTTPServerOptions, streamableHandler http.Handler, shutdownTimeout time.Duration, forceCloseTimeout time.Duration) (*StreamableHTTPServerHandle, error) {
 	var activeRequests sync.WaitGroup
+	inFlight := newActiveRequestTracker()
 	requestHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// 为每个请求派生可取消 context 并替换进 req：MCP 工具调用从
+		// request context 派生执行 context，强制关闭阶段据此通知活跃
+		// handler 尽快退出，而不是只能等连接被硬切断。
+		reqCtx, cancelReq := context.WithCancel(req.Context())
+		defer cancelReq()
+		req = req.Clone(reqCtx)
 		activeRequests.Add(1)
+		inFlight.add(req, cancelReq)
+		defer inFlight.remove(req)
 		defer activeRequests.Done()
 		streamableHandler.ServeHTTP(w, req)
 	})
@@ -224,8 +238,14 @@ func startStreamableHTTPServer(ctx context.Context, options HTTPServerOptions, s
 		case err := <-errCh:
 			cancel()
 			// Serve can fail for reasons other than an intentional shutdown while
-			// authenticated handlers are still using the backend.
-			activeRequests.Wait()
+			// authenticated handlers are still using the backend. Force-close the
+			// in-flight requests within a bounded window so the shutdown flow can
+			// proceed even if a handler ignores cancellation.
+			abandonErr := forceCloseActiveRequests(httpServer, inFlight, &activeRequests, forceCloseTimeout)
+			if abandonErr != nil {
+				handle.complete(abandonErr)
+				return
+			}
 			if errors.Is(err, http.ErrServerClosed) {
 				handle.complete(nil)
 				return
@@ -236,8 +256,17 @@ func startStreamableHTTPServer(ctx context.Context, options HTTPServerOptions, s
 			defer shutdownCancel()
 			shutdownErr := httpServer.Shutdown(shutdownCtx)
 			serveErr := <-errCh
-			// A Shutdown timeout does not stop active handlers; keep the backend alive until they return.
-			activeRequests.Wait()
+			// 优雅窗口耗尽仍有活跃 handler：取消其请求 context 并强制关闭
+			// 连接，在有界窗口内等待。原先这里是无界 activeRequests.Wait()，
+			// 一个不返回的 handler 会永久阻塞 Backend.Close 与进程退出。
+			var abandonErr error
+			if shutdownErr != nil && !errors.Is(shutdownErr, http.ErrServerClosed) {
+				abandonErr = forceCloseActiveRequests(httpServer, inFlight, &activeRequests, forceCloseTimeout)
+			}
+			if abandonErr != nil {
+				handle.complete(abandonErr)
+				return
+			}
 			if shutdownErr != nil && !errors.Is(shutdownErr, http.ErrServerClosed) {
 				handle.complete(shutdownErr)
 				return
@@ -251,6 +280,69 @@ func startStreamableHTTPServer(ctx context.Context, options HTTPServerOptions, s
 	}()
 
 	return handle, nil
+}
+
+// activeRequestTracker 跟踪在途 HTTP 请求及其派生 context 的取消函数，
+// 供强制关闭阶段统一取消。
+type activeRequestTracker struct {
+	mu   sync.Mutex
+	reqs map[*http.Request]context.CancelFunc
+}
+
+func newActiveRequestTracker() *activeRequestTracker {
+	return &activeRequestTracker{reqs: make(map[*http.Request]context.CancelFunc)}
+}
+
+func (t *activeRequestTracker) add(req *http.Request, cancel context.CancelFunc) {
+	t.mu.Lock()
+	t.reqs[req] = cancel
+	t.mu.Unlock()
+}
+
+func (t *activeRequestTracker) remove(req *http.Request) {
+	t.mu.Lock()
+	delete(t.reqs, req)
+	t.mu.Unlock()
+}
+
+// cancelAll 取消全部在途请求的派生 context，返回取消数量。
+func (t *activeRequestTracker) cancelAll() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	count := len(t.reqs)
+	for _, cancel := range t.reqs {
+		cancel()
+	}
+	t.reqs = make(map[*http.Request]context.CancelFunc)
+	return count
+}
+
+// pending 返回尚未完成的在途请求数。
+func (t *activeRequestTracker) pending() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.reqs)
+}
+
+// forceCloseActiveRequests 在优雅关闭窗口耗尽后强制终止仍在运行的活跃请求：
+// 先取消其派生 context（协作式 handler 可立即退出），再关闭底层连接，
+// 然后在 forceTimeout 内等待。超时后仍未返回的 handler 将被放弃并计入
+// 返回错误——Go 无法强制杀死 goroutine，但关闭流程必须继续推进，
+// 保证 Backend.Close 与进程退出不被无限阻塞。
+func forceCloseActiveRequests(httpServer *http.Server, tracker *activeRequestTracker, activeRequests *sync.WaitGroup, forceTimeout time.Duration) error {
+	tracker.cancelAll()
+	_ = httpServer.Close()
+	drained := make(chan struct{})
+	go func() {
+		activeRequests.Wait()
+		close(drained)
+	}()
+	select {
+	case <-drained:
+		return nil
+	case <-time.After(forceTimeout):
+		return fmt.Errorf("mcp http 强制关闭后仍有 %d 个活跃 handler 在 %v 内未退出，已放弃等待", tracker.pending(), forceTimeout)
+	}
 }
 
 func streamableHTTPRoutes(options HTTPServerOptions, streamableHandler http.Handler) http.Handler {

--- a/internal/mcpserver/run_test.go
+++ b/internal/mcpserver/run_test.go
@@ -63,7 +63,8 @@ func TestStartStreamableHTTPServerStopsWhenContextIsCanceled(t *testing.T) {
 }
 
 func TestStreamableHTTPServerGracefulShutdownStillWaitsForActiveHandler(t *testing.T) {
-	const shutdownTimeout = 500 * time.Millisecond
+	// 优雅窗口需要覆盖 cancel 与 release 之间的调度延迟，留足余量避免 CI 抖动。
+	const shutdownTimeout = 2 * time.Second
 	const forceCloseTimeout = 500 * time.Millisecond
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -275,9 +276,15 @@ func TestStreamableHTTPServerForceClosesHandlerIgnoringCancellation(t *testing.T
 		t.Fatal("handler did not start")
 	}
 
-	cancel()
+	// Stop 的调用方超时语义：句柄未在有界窗口内完成时返回 DeadlineExceeded，
+	// 同时已在内部触发关闭流程。
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer stopCancel()
+	if err := handle.Stop(stopCtx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Stop returned %v while force close was still running, want deadline exceeded", err)
+	}
 	start := time.Now()
-	if err := handle.Wait(); err == nil || !strings.Contains(err.Error(), "活跃 handler") {
+	if err := handle.Wait(); !errors.Is(err, errAbandonedActiveHandlers) {
 		t.Fatalf("Wait returned %v, want abandoned-handler error", err)
 	}
 	if elapsed := time.Since(start); elapsed > shutdownTimeout+forceCloseTimeout+time.Second {

--- a/internal/mcpserver/run_test.go
+++ b/internal/mcpserver/run_test.go
@@ -62,8 +62,9 @@ func TestStartStreamableHTTPServerStopsWhenContextIsCanceled(t *testing.T) {
 	}
 }
 
-func TestStreamableHTTPServerWaitsForActiveHandlerBeforeClosingBackend(t *testing.T) {
-	const shutdownTimeout = 20 * time.Millisecond
+func TestStreamableHTTPServerGracefulShutdownStillWaitsForActiveHandler(t *testing.T) {
+	const shutdownTimeout = 500 * time.Millisecond
+	const forceCloseTimeout = 500 * time.Millisecond
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -90,7 +91,164 @@ func TestStreamableHTTPServerWaitsForActiveHandlerBeforeClosingBackend(t *testin
 		Addr:  "127.0.0.1:0",
 		Path:  "/mcp",
 		Token: "test-token",
-	}, handler, shutdownTimeout)
+	}, handler, shutdownTimeout, forceCloseTimeout)
+	if err != nil {
+		t.Fatalf("startStreamableHTTPServer returned error: %v", err)
+	}
+	closeBackendAfterServerStops(handle, backend)
+
+	requestDone := make(chan error, 1)
+	go func() {
+		req, err := http.NewRequest(http.MethodPost, "http://"+handle.Addr+handle.Path, nil)
+		if err != nil {
+			requestDone <- err
+			return
+		}
+		req.Header.Set("Authorization", "Bearer test-token")
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+		requestDone <- err
+	}()
+
+	select {
+	case <-handlerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not start")
+	}
+
+	// 优雅窗口内：活跃 handler 仍然占用 backend，关闭流程不会越过它。
+	cancel()
+	select {
+	case <-backend.closed:
+		t.Fatal("backend closed while graceful shutdown window was still waiting for the active handler")
+	default:
+	}
+
+	releaseHandler <- struct{}{}
+	if err := <-requestDone; err != nil {
+		t.Fatalf("request returned error after handler release: %v", err)
+	}
+	if err := handle.Wait(); err != nil {
+		t.Fatalf("Wait returned %v after handler drained within the graceful window, want nil", err)
+	}
+	select {
+	case <-backend.closed:
+	case <-time.After(time.Second):
+		t.Fatal("backend did not close after handler completed")
+	}
+}
+
+func TestStreamableHTTPServerCancelsActiveHandlerRequestContext(t *testing.T) {
+	const shutdownTimeout = 100 * time.Millisecond
+	const forceCloseTimeout = 300 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	backend := &closeTrackingBackend{
+		fakeBackend: &fakeBackend{},
+		closed:      make(chan struct{}),
+	}
+	handlerStarted := make(chan struct{})
+	handlerCanceled := make(chan struct{})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		close(handlerStarted)
+		<-req.Context().Done()
+		close(handlerCanceled)
+	})
+
+	handle, err := startStreamableHTTPServer(ctx, HTTPServerOptions{
+		Addr:  "127.0.0.1:0",
+		Path:  "/mcp",
+		Token: "test-token",
+	}, handler, shutdownTimeout, forceCloseTimeout)
+	if err != nil {
+		t.Fatalf("startStreamableHTTPServer returned error: %v", err)
+	}
+	closeBackendAfterServerStops(handle, backend)
+
+	requestDone := make(chan error, 1)
+	go func() {
+		req, err := http.NewRequest(http.MethodPost, "http://"+handle.Addr+handle.Path, nil)
+		if err != nil {
+			requestDone <- err
+			return
+		}
+		req.Header.Set("Authorization", "Bearer test-token")
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+		requestDone <- err
+	}()
+
+	select {
+	case <-handlerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not start")
+	}
+
+	// 强制关闭阶段必须取消活跃 handler 的请求 context：协作式 handler
+	// 据此立即退出，而不是等优雅窗口耗尽后仍被无界等待。
+	cancel()
+	select {
+	case <-handlerCanceled:
+	case <-time.After(shutdownTimeout + forceCloseTimeout + time.Second):
+		t.Fatal("active handler did not observe request context cancellation")
+	}
+
+	waitErr := make(chan error, 1)
+	go func() {
+		waitErr <- handle.Wait()
+	}()
+	select {
+	case err := <-waitErr:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Wait returned %v after force-canceled handler drained, want graceful deadline exceeded", err)
+		}
+	case <-time.After(forceCloseTimeout + 2*time.Second):
+		t.Fatal("handle did not complete within the bounded shutdown window")
+	}
+	select {
+	case <-backend.closed:
+	case <-time.After(time.Second):
+		t.Fatal("backend did not close after handlers drained")
+	}
+}
+
+func TestStreamableHTTPServerForceClosesHandlerIgnoringCancellation(t *testing.T) {
+	const shutdownTimeout = 50 * time.Millisecond
+	const forceCloseTimeout = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	backend := &closeTrackingBackend{
+		fakeBackend: &fakeBackend{},
+		closed:      make(chan struct{}),
+	}
+	handlerStarted := make(chan struct{})
+	releaseHandler := make(chan struct{}, 1)
+	t.Cleanup(func() {
+		select {
+		case releaseHandler <- struct{}{}:
+		default:
+		}
+	})
+	// 该 handler 完全忽略请求 context 取消，只能被有界放弃。
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(handlerStarted)
+		<-releaseHandler
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	handle, err := startStreamableHTTPServer(ctx, HTTPServerOptions{
+		Addr:  "127.0.0.1:0",
+		Path:  "/mcp",
+		Token: "test-token",
+	}, handler, shutdownTimeout, forceCloseTimeout)
 	if err != nil {
 		t.Fatalf("startStreamableHTTPServer returned error: %v", err)
 	}
@@ -118,28 +276,20 @@ func TestStreamableHTTPServerWaitsForActiveHandlerBeforeClosingBackend(t *testin
 	}
 
 	cancel()
-	stopCtx, stopCancel := context.WithTimeout(context.Background(), 3*shutdownTimeout)
-	defer stopCancel()
-	if err := handle.Stop(stopCtx); !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("Stop returned %v while handler was still active, want deadline exceeded", err)
+	start := time.Now()
+	if err := handle.Wait(); err == nil || !strings.Contains(err.Error(), "活跃 handler") {
+		t.Fatalf("Wait returned %v, want abandoned-handler error", err)
 	}
-	select {
-	case <-backend.closed:
-		t.Fatal("backend closed while handler was still active")
-	default:
+	if elapsed := time.Since(start); elapsed > shutdownTimeout+forceCloseTimeout+time.Second {
+		t.Fatalf("shutdown took %v, want completion within the bounded window", elapsed)
 	}
 
-	releaseHandler <- struct{}{}
-	if err := <-requestDone; err != nil {
-		t.Fatalf("request returned error after handler release: %v", err)
-	}
-	if err := handle.Wait(); !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("Wait returned %v after shutdown timeout, want deadline exceeded", err)
-	}
+	// 核心契约变化：阻塞的 handler 不再挟持关闭流程，Backend.Close 恰好
+	// 执行一次（closeTrackingBackend 二次关闭会 panic）。
 	select {
 	case <-backend.closed:
 	case <-time.After(time.Second):
-		t.Fatal("backend did not close after handler completed")
+		t.Fatal("backend did not close after bounded force close")
 	}
 }
 


### PR DESCRIPTION
## 问题背景

Streamable HTTP MCP 服务在 `Shutdown` 优雅窗口（5s）超时后直接 `activeRequests.Wait()` **无界等待**活跃请求：一个不返回的 handler 会永久阻塞句柄完成、`Backend.Close` 与进程退出——SIGTERM、升级、容器编排停止全部卡死，后端连接和其他资源无法进入关闭流程。`Serve` 意外失败分支存在同样的无界等待。

## 修复内容

- 每个请求派生可取消 context 并替换进 `req`，由 `activeRequestTracker` 跟踪；优雅窗口耗尽仍有活跃请求时：取消全部在途请求 context → `httpServer.Close()` 硬断连接 → 有界窗口（3s）内等待 → 超时则放弃并以 sentinel 错误 `errAbandonedActiveHandlers`（携带真实取消计数，`errors.Join` 保留原始 Serve/Shutdown 错误）完成句柄
- `Serve` 意外失败分支同样改为有界强制关闭
- 优雅窗口内语义保持：活跃 handler 仍会延迟 backend 关闭，正常请求与流式响应不受影响；`Backend.Close` 仍恰好执行一次
- 放弃契约在注释中显式声明：强制关闭只保证 HTTP handler 层退出。经 SDK 源码追踪确认，MCP 工具调用 context 在 jsonrpc2 连接层与请求 context 脱钩，per-request 取消不传播到工具调用层，真正解除阻塞的是 `httpServer.Close()` 硬断连接；被放弃的工具 goroutine 可能在 `Backend.Close` 之后继续访问已关闭资源（database/sql 并发 Close 安全，相比进程永久卡死是有意取舍）

## 验证方式

- `go test ./internal/mcpserver/` 全量通过，关闭相关测试 count=3/5 重跑无抖动，`go vet` 干净
- 协作式 handler：断言父 Context 取消后收到请求 context 取消信号，句柄在优雅+强制窗口内完成
- 完全忽略取消的 handler：断言句柄在有界窗口内完成并返回 abandoned 错误，`Backend.Close` 恰好执行一次（跟踪 backend 二次关闭即 panic）；`handle.Stop` 短超时返回 `DeadlineExceeded` 的调用方语义有测试覆盖
- 优雅窗口语义：活跃 handler 完成前排空期间 backend 不被提前关闭，完成后干净退出（`Wait` 返回 nil）
- 正常请求与流式响应：既有真实 SDK 会话（ListTools）与 SSE 测试无回归
- 两轮独立子 agent 代码审查通过（第一轮借真实 SDK 源码追踪与仓库外实验勘误了机制描述，意见已全部落地）

## 影响与风险

- 旧行为"handler 不返回就永远等"变更为"优雅 5s + 强制 3s 后放弃"，被放弃的 MCP 工具调用结果丢失且可能在 backend 关闭后报错——这是修复进程永久卡死的有意取舍
- 优雅窗口超时但强制排空成功时句柄仍返回 `DeadlineExceeded`（沿用既有语义），容器编排下表现为正常退出码之外的错误退出，可后续单独调整
- stdio 路径存在同类无界等待（`Server.Run` → `Connection.Close` 等 `idle()`），不在本修复范围，建议另开 issue
- 测试改动仅涉及关闭契约，`startStreamableHTTPServer` 为包内函数，签名新增参数不影响外部调用方

## 关联 Issue

Closes #1139
