### PR TITLE
🐛 fix(webserver): 关闭时追踪活跃请求并强制取消，避免 App 资源销毁竞态

### DIFF
--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -15,6 +15,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	aiservice "GoNavi-Wails/internal/ai/service"
@@ -36,6 +37,16 @@ const (
 	// closed and must reconnect instead of retaining an unbounded queue.
 	eventSubscriberReliableQueueLimit = eventSubscriberQueueLimit * 2
 	eventStreamDataChunkBytes         = 256 << 10
+)
+
+// Shutdown deadlines are package variables so tests can shorten them.
+var (
+	// shutdownGraceTimeout bounds the graceful phase after the listener is
+	// closed: in-flight handlers may still finish normally within this window.
+	shutdownGraceTimeout = 5 * time.Second
+	// shutdownDrainTimeout bounds how long force-cancelled handlers may take
+	// to unwind before the deferred App resource teardown starts.
+	shutdownDrainTimeout = 5 * time.Second
 )
 
 var errorType = reflect.TypeOf((*error)(nil)).Elem()
@@ -543,6 +554,89 @@ func unpackResults(results []reflect.Value) (any, error) {
 	}
 }
 
+// requestTracker counts in-flight HTTP handlers so Server.runHTTP can keep the
+// deferred App resource teardown ordered after the last handler has returned.
+type requestTracker struct {
+	mu      sync.Mutex
+	count   int
+	drained chan struct{}
+}
+
+func newRequestTracker() *requestTracker {
+	drained := make(chan struct{})
+	close(drained)
+	return &requestTracker{drained: drained}
+}
+
+func (t *requestTracker) begin() {
+	t.mu.Lock()
+	if t.count == 0 {
+		t.drained = make(chan struct{})
+	}
+	t.count++
+	t.mu.Unlock()
+}
+
+func (t *requestTracker) done() {
+	t.mu.Lock()
+	t.count--
+	if t.count == 0 {
+		close(t.drained)
+	}
+	t.mu.Unlock()
+}
+
+func (t *requestTracker) active() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.count
+}
+
+// wait blocks until every in-flight handler has returned or ctx expires and
+// reports how many handlers were still running. The re-check loop matters
+// because a handler can still begin after http.Server.Shutdown for a request
+// that was already being read, so a drained signal must never be trusted
+// without re-reading the counter.
+func (t *requestTracker) wait(ctx context.Context) int {
+	for {
+		t.mu.Lock()
+		count := t.count
+		drained := t.drained
+		t.mu.Unlock()
+		if count == 0 {
+			return 0
+		}
+		select {
+		case <-drained:
+		case <-ctx.Done():
+			return t.active()
+		}
+	}
+}
+
+func (t *requestTracker) waitDrain(timeout time.Duration) int {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return t.wait(ctx)
+}
+
+// withRequestLifecycle tracks each request as in-flight and derives its
+// context from the request's own context (so client disconnects still cancel
+// long-lived streams) while linking server-level cancellation into it, so a
+// shutdown can force handlers to unwind through r.Context() even when
+// http.Server.Shutdown no longer waits for them.
+func withRequestLifecycle(serveCtx context.Context, tracker *requestTracker, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		stopServerCancel := context.AfterFunc(serveCtx, cancel)
+		defer stopServerCancel()
+		tracker.begin()
+		defer tracker.done()
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
 type Server struct {
 	options       Options
 	assets        fs.FS
@@ -552,6 +646,9 @@ type Server struct {
 	events        *eventHub
 	invoker       *methodInvoker
 	auditHeavySem chan struct{}
+	// boundAddr records the actual listener address once runHTTP has bound
+	// the socket, which is observable by tests when Addr uses port zero.
+	boundAddr atomic.Value
 }
 
 // SharedRuntimeOptions configures the authenticated loopback runtime used by
@@ -773,13 +870,23 @@ func (s *Server) Run(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	return s.runHTTP(ctx, s.routes())
+}
 
-	defer s.ai.Shutdown()
-	defer s.app.Shutdown()
+// runHTTP owns the HTTP server lifecycle. The deferred resource teardown must
+// only start once every in-flight handler has returned or was explicitly
+// cancelled, otherwise live requests race closed databases and already
+// shut-down services.
+func (s *Server) runHTTP(ctx context.Context, handler http.Handler) error {
+	defer s.shutdownTeardown()
 
+	serveCtx, serveCancel := context.WithCancel(ctx)
+	defer serveCancel()
+
+	tracker := newRequestTracker()
 	httpServer := &http.Server{
 		Addr:              s.options.Addr,
-		Handler:           s.routes(),
+		Handler:           withRequestLifecycle(serveCtx, tracker, handler),
 		ReadHeaderTimeout: httpserverlimits.ReadHeaderTimeout,
 		ReadTimeout:       httpserverlimits.ReadTimeout,
 		WriteTimeout:      httpserverlimits.WriteTimeout,
@@ -790,7 +897,8 @@ func (s *Server) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	logger.Infof("GoNavi Web Server 启动：addr=%s", listener.Addr().String())
+	s.boundAddr.Store(listener.Addr().String())
+	logger.Infof("GoNavi Web Server 启动：addr=%s", listener.Addr())
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -802,19 +910,56 @@ func (s *Server) Run(ctx context.Context) error {
 		if errors.Is(err, http.ErrServerClosed) {
 			return nil
 		}
+		// Serve stopped accepting connections, but handlers already in flight
+		// must still be drained before the resources they use are released.
+		serveCancel()
+		if remaining := tracker.waitDrain(shutdownDrainTimeout); remaining > 0 {
+			logger.Warnf("Web Server 监听异常退出后仍有 %d 个请求未能在等待期内退出", remaining)
+		}
 		return err
 	case <-ctx.Done():
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		shutdownErr := httpServer.Shutdown(shutdownCtx)
-		serveErr := <-errCh
-		if shutdownErr != nil && !errors.Is(shutdownErr, http.ErrServerClosed) {
-			return shutdownErr
-		}
-		if serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
-			return serveErr
-		}
-		return nil
+		return s.shutdownHTTP(serveCtx, serveCancel, tracker, httpServer, errCh)
+	}
+}
+
+// shutdownHTTP stops the listener, gives in-flight handlers a bounded grace
+// period to finish normally, then force-cancels the survivors through their
+// request contexts and waits for them to unwind. It returns only after every
+// handler finished or was explicitly cancelled; the deferred App resource
+// teardown starts the moment this returns.
+func (s *Server) shutdownHTTP(serveCtx context.Context, serveCancel context.CancelFunc, tracker *requestTracker, httpServer *http.Server, errCh <-chan error) error {
+	graceCtx, graceCancel := context.WithTimeout(context.Background(), shutdownGraceTimeout)
+	defer graceCancel()
+	shutdownErr := httpServer.Shutdown(graceCtx)
+	if shutdownErr != nil && !errors.Is(shutdownErr, http.ErrServerClosed) {
+		logger.Warnf("Web Server 优雅关闭等待超时：%v；活跃请求 %d 个，已发送强制取消信号", shutdownErr, tracker.active())
+	}
+
+	// http.Server.Shutdown never cancels active handlers; server-level
+	// cancellation is delivered through each request's derived context.
+	serveCancel()
+	serveErr := <-errCh
+
+	remaining := tracker.waitDrain(shutdownDrainTimeout)
+	if remaining > 0 {
+		return fmt.Errorf("web server shutdown: %d request handler(s) still active after forced cancellation and drain timeout", remaining)
+	}
+	if serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+		return serveErr
+	}
+	// A graceful-phase timeout is already logged above; handlers unwound
+	// after the explicit cancellation, so the shutdown itself succeeded.
+	return nil
+}
+
+// shutdownTeardown releases App-owned resources after the HTTP handlers are
+// done. Run defers it so teardown cannot race live requests.
+func (s *Server) shutdownTeardown() {
+	if s.app != nil {
+		s.app.Shutdown()
+	}
+	if s.ai != nil {
+		s.ai.Shutdown()
 	}
 }
 

--- a/internal/webserver/server_shutdown_test.go
+++ b/internal/webserver/server_shutdown_test.go
@@ -1,0 +1,375 @@
+package webserver
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func setShutdownDeadlines(t *testing.T, grace time.Duration, drain time.Duration) {
+	t.Helper()
+	originalGrace, originalDrain := shutdownGraceTimeout, shutdownDrainTimeout
+	shutdownGraceTimeout, shutdownDrainTimeout = grace, drain
+	t.Cleanup(func() {
+		shutdownGraceTimeout, shutdownDrainTimeout = originalGrace, originalDrain
+	})
+}
+
+// waitForBoundAddr polls until runHTTP has stored the listener address. It
+// returns an empty string when the address never appears, which surfaces as a
+// client dial error in the caller's assertions.
+func waitForBoundAddr(server *Server) string {
+	for range 100 {
+		if addr, ok := server.boundAddr.Load().(string); ok && addr != "" {
+			return addr
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return ""
+}
+
+func TestRequestTrackerWaitDrainsAndReportsRemaining(t *testing.T) {
+	tracker := newRequestTracker()
+	if remaining := tracker.waitDrain(time.Second); remaining != 0 {
+		t.Fatalf("idle tracker reported %d in-flight requests", remaining)
+	}
+
+	tracker.begin()
+	tracker.begin()
+	waitDone := make(chan int, 1)
+	go func() {
+		waitDone <- tracker.waitDrain(2 * time.Second)
+	}()
+	tracker.done()
+	tracker.done()
+	select {
+	case remaining := <-waitDone:
+		if remaining != 0 {
+			t.Fatalf("tracker.wait reported %d remaining requests after all handlers returned", remaining)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("tracker.wait did not drain after handlers finished")
+	}
+
+	// A handler that begins right after a drained signal was observed (a
+	// request that was still being read when Shutdown was called) must still
+	// be awaited instead of being treated as drained.
+	tracker.begin()
+	tracker.done()
+	tracker.begin()
+	if remaining := tracker.waitDrain(50 * time.Millisecond); remaining != 1 {
+		t.Fatalf("tracker.wait reported %d remaining requests, want 1", remaining)
+	}
+	tracker.done()
+	if remaining := tracker.waitDrain(time.Second); remaining != 0 {
+		t.Fatalf("tracker.wait reported %d remaining requests after the last handler returned", remaining)
+	}
+}
+
+func TestWithRequestLifecycleForcesCancellationOnServerShutdown(t *testing.T) {
+	serveCtx, serveCancel := context.WithCancel(context.Background())
+	defer serveCancel()
+	tracker := newRequestTracker()
+	entered := make(chan struct{})
+	cancelled := make(chan struct{})
+	handler := withRequestLifecycle(serveCtx, tracker, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(entered)
+		<-r.Context().Done()
+		close(cancelled)
+	}))
+	testServer := httptest.NewServer(handler)
+	defer testServer.Close()
+
+	clientDone := make(chan error, 1)
+	go func() {
+		response, err := testServer.Client().Get(testServer.URL)
+		if response != nil {
+			_ = response.Body.Close()
+		}
+		clientDone <- err
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("in-flight handler was not entered")
+	}
+	serveCancel()
+	select {
+	case <-cancelled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server-level cancellation did not reach the in-flight handler")
+	}
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer drainCancel()
+	if remaining := tracker.wait(drainCtx); remaining != 0 {
+		t.Fatalf("tracker reported %d in-flight requests after the handler returned", remaining)
+	}
+	select {
+	case <-clientDone:
+		// The handler returned without a response, so the client either sees
+		// an empty reply or a connection error; both prove the request ended.
+	case <-time.After(2 * time.Second):
+		t.Fatal("client request did not return after forced server cancellation")
+	}
+}
+
+func TestWithRequestLifecyclePreservesClientCancellation(t *testing.T) {
+	serveCtx, serveCancel := context.WithCancel(context.Background())
+	defer serveCancel()
+	tracker := newRequestTracker()
+	entered := make(chan struct{})
+	cancelled := make(chan struct{})
+	handler := withRequestLifecycle(serveCtx, tracker, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(entered)
+		<-r.Context().Done()
+		close(cancelled)
+	}))
+	testServer := httptest.NewServer(handler)
+	defer testServer.Close()
+
+	requestCtx, requestCancel := context.WithCancel(context.Background())
+	request, err := http.NewRequestWithContext(requestCtx, http.MethodGet, testServer.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientDone := make(chan error, 1)
+	go func() {
+		response, requestErr := testServer.Client().Do(request)
+		if response != nil {
+			_ = response.Body.Close()
+		}
+		clientDone <- requestErr
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("in-flight handler was not entered")
+	}
+	requestCancel()
+	select {
+	case <-cancelled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("client cancellation did not reach the in-flight handler")
+	}
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer drainCancel()
+	if remaining := tracker.wait(drainCtx); remaining != 0 {
+		t.Fatalf("tracker reported %d in-flight requests after the handler returned", remaining)
+	}
+	select {
+	case <-clientDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancelled client request did not return")
+	}
+}
+
+func TestWithRequestLifecycleKeepsNormalRequestsIntact(t *testing.T) {
+	serveCtx, serveCancel := context.WithCancel(context.Background())
+	defer serveCancel()
+	tracker := newRequestTracker()
+	handlerCtx := make(chan context.Context, 1)
+	handler := withRequestLifecycle(serveCtx, tracker, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.Context().Err(); err != nil {
+			http.Error(w, "request context was cancelled during handling: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		handlerCtx <- r.Context()
+		_, _ = w.Write([]byte("ok"))
+	}))
+	testServer := httptest.NewServer(handler)
+	defer testServer.Close()
+
+	response, err := testServer.Client().Get(testServer.URL)
+	if err != nil {
+		t.Fatalf("normal request failed: %v", err)
+	}
+	body, err := io.ReadAll(response.Body)
+	_ = response.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusOK || string(body) != "ok" {
+		t.Fatalf("status = %d, body = %q; want 200 and %q", response.StatusCode, string(body), "ok")
+	}
+
+	// The per-request context must stay live while the handler runs and be
+	// released once it returns.
+	select {
+	case ctx := <-handlerCtx:
+		if ctx.Err() == nil {
+			t.Fatal("per-request context was not cancelled after the handler returned")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler context was not captured")
+	}
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer drainCancel()
+	if remaining := tracker.wait(drainCtx); remaining != 0 {
+		t.Fatalf("tracker reported %d in-flight requests after the handler returned", remaining)
+	}
+}
+
+func TestServerRunHTTPWaitsForInFlightHandlerBeforeTeardown(t *testing.T) {
+	setShutdownDeadlines(t, 200*time.Millisecond, 3*time.Second)
+	server := &Server{options: Options{Addr: "127.0.0.1:0"}}
+	entered := make(chan struct{})
+	released := make(chan struct{})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(entered)
+		<-r.Context().Done()
+		close(released)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- server.runHTTP(ctx, handler)
+	}()
+	clientDone := make(chan error, 1)
+	go func() {
+		// The URL is only known after runHTTP has bound the listener; wait
+		// for the bound address instead of dialing a guessed port.
+		boundAddr := waitForBoundAddr(server)
+		response, err := http.Get("http://" + boundAddr)
+		if response != nil {
+			_ = response.Body.Close()
+		}
+		clientDone <- err
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("in-flight handler was not entered")
+	}
+	cancel()
+
+	// The graceful phase times out while the handler is still active; runHTTP
+	// must force-cancel it and must not return before the handler unwound,
+	// because the deferred App resource teardown starts on return.
+	select {
+	case err := <-runDone:
+		t.Fatalf("runHTTP returned before the in-flight handler finished: %v", err)
+	case <-released:
+	}
+	select {
+	case err := <-runDone:
+		if err != nil {
+			t.Fatalf("runHTTP returned error after the in-flight handler finished: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runHTTP did not return after the in-flight handler finished")
+	}
+	select {
+	case <-clientDone:
+		// Whatever the client observed, the request ended because the handler
+		// was force-cancelled and the server stopped.
+	case <-time.After(2 * time.Second):
+		t.Fatal("client request did not return after forced server cancellation")
+	}
+}
+
+func TestServerRunHTTPGraceAllowsHandlersToFinish(t *testing.T) {
+	setShutdownDeadlines(t, 3*time.Second, 3*time.Second)
+	server := &Server{options: Options{Addr: "127.0.0.1:0"}}
+	entered := make(chan struct{})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(entered)
+		// Finish within the graceful window without depending on cancellation.
+		time.Sleep(100 * time.Millisecond)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- server.runHTTP(ctx, handler)
+	}()
+	clientDone := make(chan string, 1)
+	go func() {
+		boundAddr := waitForBoundAddr(server)
+		response, err := http.Get("http://" + boundAddr)
+		if err != nil {
+			clientDone <- "request error: " + err.Error()
+			return
+		}
+		body, _ := io.ReadAll(response.Body)
+		_ = response.Body.Close()
+		clientDone <- string(body)
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("in-flight handler was not entered")
+	}
+	cancel()
+
+	// The graceful phase must let the request finish normally and deliver its
+	// response even though the shutdown was already triggered.
+	select {
+	case body := <-clientDone:
+		if body != "ok" {
+			t.Fatalf("request body = %q, want %q", body, "ok")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("graceful request did not complete")
+	}
+	select {
+	case err := <-runDone:
+		if err != nil {
+			t.Fatalf("runHTTP returned error after a graceful shutdown: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runHTTP did not return after the graceful request completed")
+	}
+}
+
+func TestServerRunHTTPReportsHandlersThatSurviveCancellation(t *testing.T) {
+	setShutdownDeadlines(t, 100*time.Millisecond, 100*time.Millisecond)
+	server := &Server{options: Options{Addr: "127.0.0.1:0"}}
+	entered := make(chan struct{})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(entered)
+		// Simulates a handler that never observes cancellation; the drain
+		// timeout must make the shutdown failure diagnosable.
+		select {}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- server.runHTTP(ctx, handler)
+	}()
+	go func() {
+		boundAddr := waitForBoundAddr(server)
+		// The handler never returns, so the outcome of this request is
+		// irrelevant; it only exists to get the handler entered.
+		response, _ := http.Get("http://" + boundAddr)
+		if response != nil {
+			_ = response.Body.Close()
+		}
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("in-flight handler was not entered")
+	}
+	cancel()
+
+	select {
+	case err := <-runDone:
+		if err == nil || !strings.Contains(err.Error(), "1 request handler(s) still active") {
+			t.Fatalf("runHTTP error = %v, want drain timeout mentioning 1 still-active handler", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runHTTP did not return after the drain timeout")
+	}
+}


### PR DESCRIPTION
Fixes #1140

## 问题

`Server.Run`（internal/webserver/server.go）在收到退出信号后调用 `http.Server.Shutdown`（5 秒超时），但 `Shutdown` 只等待连接回到空闲，从不取消活跃 handler。超时后 `Run` 立即返回并触发 `defer s.app.Shutdown()` / `defer s.ai.Shutdown()`，此时慢查询、上传、SSE `/events` 等活跃请求仍在使用 App 资源，导致已关闭的数据库/服务被并发访问。

## 修复方案

与 `internal/mcpserver/run.go` 已有的 `activeRequests.Wait()` 模式对齐，并补齐其缺失的能力：

1. **追踪活跃请求**：新增 `requestTracker` 计数 in-flight handler（带 drained 信号与重检循环，覆盖 "Shutdown 期间仍在读取的请求导致 handler 晚于 Shutdown 开始" 的窗口）。
2. **将服务级取消传入 handler**：新增 `withRequestLifecycle` 中间件，为每个请求派生 context —— 以请求自身 context 为父（保留客户端断连对 SSE 等长连接的取消传播），并通过 `context.AfterFunc` 链接服务级 `serveCtx` 的取消。
3. **三阶段关闭**（`shutdownHTTP`）：
   - 优雅阶段：关闭监听，给活跃请求 `shutdownGraceTimeout`（5s）正常完成；
   - 强制阶段：对仍存留的请求发送服务级取消信号；
   - drain 阶段：有界等待 handler 全部退出（`shutdownDrainTimeout`，5s）后 `Run` 才返回，App 资源销毁（defer）不会早于 handler 结束或被明确终止。
4. **可诊断**：优雅阶段超时输出 Warn 日志（含超时原因与活跃请求数）；drain 仍失败时返回包含剩余 handler 数的错误。此前优雅超时会导致 `Run` 每次都返回 `DeadlineExceeded`（有浏览器标签页时必现），现在 drain 成功即视为关闭成功。

`Serve` 自身异常退出的分支也补了强制取消 + 有界 drain。

## 验收标准对照

- ✅ 活跃 Web handler 在服务停止时收到取消信号（`r.Context()`）或被有界终止
- ✅ `App.Shutdown` 不早于活跃 handler 结束或被明确终止（`runHTTP` 返回前完成 drain）
- ✅ Shutdown 超时结果可诊断（日志/错误），正常请求行为不受影响（中间件仅增加每请求一次 AfterFunc 注册与计数）

## 测试

`internal/webserver/server_shutdown_test.go` 新增 7 个测试：

- `requestTracker`：drain 语义、剩余计数、drained 信号后新开始 handler 的重检
- 中间件：服务级强制取消传播、客户端断连取消保留、正常请求不受影响
- `runHTTP` 端到端：强制取消路径（handler 未退出前 `runHTTP` 不返回）、优雅路径（grace 窗口内请求正常完成）、drain 超时可诊断（handler 无视取消时返回明确错误）

`go test ./internal/webserver/ ./internal/httpserver/ ./internal/mcpserver/ ./internal/nativewindow/` 全部通过；`go vet`、`go build ./...` 通过。