### PR TITLE
🐛 修复 stdio MCP 停止时可能无限等待工具调用并阻塞进程退出

### DIFF
--- a/internal/mcpserver/run.go
+++ b/internal/mcpserver/run.go
@@ -28,6 +28,12 @@ const (
 	// （goroutine 无法强制终止），关闭流程继续推进，保证 Backend.Close
 	// 与进程退出不被无限阻塞。
 	streamableHTTPForceCloseTimeout = 3 * time.Second
+	// stdioShutdownTimeout 是 stdio 服务在父 Context 取消后等待在途工具
+	// 调用自然完成的有界窗口。SDK 的 jsonrpc2 连接层经 notDone 与请求
+	// Context 脱钩，取消无法传播到工具 handler，无法像 Streamable HTTP
+	// 那样强制取消；超时后放弃等待，保证 Backend.Close 与进程退出不被
+	// 无限阻塞。
+	stdioShutdownTimeout = 5 * time.Second
 )
 
 // HTTPServerOptions 描述远程 Streamable HTTP MCP 入口。
@@ -108,14 +114,44 @@ func RunAppStdioServer(ctx context.Context) error {
 	return RunStdioServer(ctx, backend)
 }
 
+// errAbandonedStdioHandlers 标记 stdio 优雅窗口耗尽后仍有在途工具调用未完成。
+var errAbandonedStdioHandlers = errors.New("stdio handlers abandoned after shutdown wait")
+
 // RunStdioServer 使用指定 backend 启动 stdio MCP server。
 func RunStdioServer(ctx context.Context, backend Backend) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	return runStdioServer(ctx, backend, &mcp.StdioTransport{}, stdioShutdownTimeout)
+}
 
+// runStdioServer 包装 Server.Run：ctx 取消后先给在途请求一个优雅窗口
+// 自然完成，超时则放弃等待。SDK 的 Server.Run 在 ctx 取消后调用
+// ss.Close() 并等待 jsonrpc2 连接空闲；工具调用 context 经 notDone 与
+// 父 Context 脱钩，阻塞的 handler 收不到取消信号也无法被强制终止，
+// 原先会让进程永久挂起、Backend.Close 永不执行。放弃契约与 Streamable
+// HTTP（forceCloseActiveRequests）一致：被放弃的工具调用之后可能在
+// 已关闭的 backend 上报错，属于相比进程永久卡死的有意取舍。
+func runStdioServer(ctx context.Context, backend Backend, transport mcp.Transport, shutdownTimeout time.Duration) error {
 	server := NewServer(backend)
-	return server.Run(ctx, &mcp.StdioTransport{})
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- server.Run(ctx, transport)
+	}()
+
+	select {
+	case err := <-runDone:
+		return err
+	case <-ctx.Done():
+	}
+	graceTimer := time.NewTimer(shutdownTimeout)
+	defer graceTimer.Stop()
+	select {
+	case err := <-runDone:
+		return err
+	case <-graceTimer.C:
+		return fmt.Errorf("%w: 优雅窗口 %v 内仍有在途工具调用未完成，已放弃等待", errAbandonedStdioHandlers, shutdownTimeout)
+	}
 }
 
 // StartAppStreamableHTTPServer 启动基于真实 GoNavi App 的 Streamable HTTP MCP server，并立即返回可停止句柄。

--- a/internal/mcpserver/run_test.go
+++ b/internal/mcpserver/run_test.go
@@ -595,6 +595,64 @@ func TestRunStdioServerAbandonsBlockedHandlerAfterGrace(t *testing.T) {
 	}
 }
 
+func TestRunStdioServerDrainsInFlightRequestWithinGrace(t *testing.T) {
+	const grace = 300 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	backend := &blockingConnectionsBackend{
+		closeTrackingBackend: &closeTrackingBackend{fakeBackend: &fakeBackend{}, closed: make(chan struct{})},
+		started:              make(chan struct{}),
+		release:              make(chan struct{}, 1),
+	}
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	runDone := make(chan error, 1)
+	go func() {
+		defer func() { _ = backend.Close(context.Background()) }()
+		runDone <- runStdioServer(ctx, backend, serverTransport, grace)
+	}()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "run-test-client", Version: "v0.0.1"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("connect in-memory client: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	callDone := make(chan error, 1)
+	go func() {
+		_, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "get_connections"})
+		callDone <- err
+	}()
+	select {
+	case <-backend.started:
+	case <-time.After(time.Second):
+		t.Fatal("tool handler did not reach the blocking backend")
+	}
+
+	// 取消后在优雅窗口内释放在途请求：它应当自然完成，stdio 服务正常
+	// 返回而不是报放弃错误——这正是优雅窗口存在的意义。
+	cancel()
+	time.Sleep(30 * time.Millisecond)
+	backend.release <- struct{}{}
+
+	select {
+	case err := <-runDone:
+		if errors.Is(err, errAbandonedStdioHandlers) {
+			t.Fatalf("in-flight request drained within grace must not return abandoned-handler error, got %v", err)
+		}
+	case <-time.After(grace + 2*time.Second):
+		t.Fatal("stdio server did not return after in-flight request drained")
+	}
+	select {
+	case <-backend.closed:
+	case <-time.After(time.Second):
+		t.Fatal("backend did not close after graceful drain")
+	}
+}
+
 func TestRunStdioServerCompletesCleanlyWithoutBlockedHandler(t *testing.T) {
 	const grace = 200 * time.Millisecond
 

--- a/internal/mcpserver/run_test.go
+++ b/internal/mcpserver/run_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"GoNavi-Wails/internal/connection"
 	httpserverlimits "GoNavi-Wails/internal/httpserver"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -516,5 +517,124 @@ func TestBearerTokenAuthHandlerRejectsMissingOrWrongToken(t *testing.T) {
 	}
 	if !called {
 		t.Fatal("next handler should be called with valid token")
+	}
+}
+
+type blockingConnectionsBackend struct {
+	*closeTrackingBackend
+	started chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingConnectionsBackend) GetSavedConnections() ([]connection.SavedConnectionView, error) {
+	close(b.started)
+	<-b.release
+	return nil, nil
+}
+
+func TestRunStdioServerAbandonsBlockedHandlerAfterGrace(t *testing.T) {
+	const grace = 100 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	backend := &blockingConnectionsBackend{
+		closeTrackingBackend: &closeTrackingBackend{fakeBackend: &fakeBackend{}, closed: make(chan struct{})},
+		started:              make(chan struct{}),
+		release:              make(chan struct{}, 1),
+	}
+	t.Cleanup(func() {
+		select {
+		case backend.release <- struct{}{}:
+		default:
+		}
+	})
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	runDone := make(chan error, 1)
+	go func() {
+		// 复刻 RunAppStdioServer 的关闭接线：run 返回后 backend.Close 恰好执行一次。
+		defer func() { _ = backend.Close(context.Background()) }()
+		runDone <- runStdioServer(ctx, backend, serverTransport, grace)
+	}()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "run-test-client", Version: "v0.0.1"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("connect in-memory client: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	callDone := make(chan error, 1)
+	go func() {
+		_, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "get_connections"})
+		callDone <- err
+	}()
+	select {
+	case <-backend.started:
+	case <-time.After(time.Second):
+		t.Fatal("tool handler did not reach the blocking backend")
+	}
+
+	// 父 Context 取消后，阻塞的 handler 收不到取消信号（SDK notDone 脱钩），
+	// stdio 服务必须在优雅窗口耗尽后放弃等待并返回，而不是永久挂起。
+	cancel()
+	start := time.Now()
+	if err := <-runDone; !errors.Is(err, errAbandonedStdioHandlers) {
+		t.Fatalf("run returned %v, want abandoned-handler error", err)
+	}
+	if elapsed := time.Since(start); elapsed > grace+2*time.Second {
+		t.Fatalf("stdio shutdown took %v, want completion within the bounded window", elapsed)
+	}
+
+	// Backend.Close 恰好执行一次（closeTrackingBackend 二次关闭会 panic）。
+	select {
+	case <-backend.closed:
+	case <-time.After(time.Second):
+		t.Fatal("backend did not close after bounded abandon")
+	}
+}
+
+func TestRunStdioServerCompletesCleanlyWithoutBlockedHandler(t *testing.T) {
+	const grace = 200 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	backend := &closeTrackingBackend{fakeBackend: &fakeBackend{}, closed: make(chan struct{})}
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	runDone := make(chan error, 1)
+	go func() {
+		defer func() { _ = backend.Close(context.Background()) }()
+		runDone <- runStdioServer(ctx, backend, serverTransport, grace)
+	}()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "run-test-client", Version: "v0.0.1"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("connect in-memory client: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	if _, err := session.ListTools(ctx, nil); err != nil {
+		t.Fatalf("list tools over in-memory session: %v", err)
+	}
+
+	// 无阻塞 handler 时取消 Context：在途请求自然排空，正常退出，
+	// 不产生放弃错误。
+	cancel()
+	select {
+	case err := <-runDone:
+		if errors.Is(err, errAbandonedStdioHandlers) {
+			t.Fatalf("clean shutdown must not return abandoned-handler error, got %v", err)
+		}
+	case <-time.After(grace + 2*time.Second):
+		t.Fatal("stdio server did not return after context cancellation")
+	}
+	select {
+	case <-backend.closed:
+	case <-time.After(time.Second):
+		t.Fatal("backend did not close after clean shutdown")
 	}
 }

--- a/internal/mcpserver/run_test.go
+++ b/internal/mcpserver/run_test.go
@@ -620,6 +620,12 @@ func TestRunStdioServerDrainsInFlightRequestWithinGrace(t *testing.T) {
 		t.Fatalf("connect in-memory client: %v", err)
 	}
 	t.Cleanup(func() { _ = session.Close() })
+	t.Cleanup(func() {
+		select {
+		case backend.release <- struct{}{}:
+		default:
+		}
+	})
 
 	callDone := make(chan error, 1)
 	go func() {


### PR DESCRIPTION
## 问题背景

stdio MCP 服务存在与 #1139（已由 #1169 修复）同类的无界等待：`Server.Run` 在父 Context 取消后调用 `ss.Close()` 并等待 jsonrpc2 连接空闲（即等所有在途工具 handler 完成）；工具调用 context 经 SDK 的 `notDone` 包装与父 Context 脱钩，阻塞的工具 handler 收不到取消信号也无法被强制终止。SIGTERM 时一个不返回的工具调用会让 mcp-server stdio 进程永久挂起，`defer backend.Close` 永不执行。

## 修复内容

- `RunStdioServer` 拆出可注入的 `runStdioServer`（transport 与优雅窗口参数化）：ctx 取消后先给在途请求一个优雅窗口（生产 5s）自然完成，超时放弃等待并返回 sentinel 错误 `errAbandonedStdioHandlers`，`Backend.Close` 与进程退出不再被阻塞
- 放弃契约与 Streamable HTTP 修复（#1169 `forceCloseActiveRequests`）对齐并写入注释：被放弃的工具调用之后可能在已关闭的 backend 上报错（有意取舍）
- 与 HTTP 修复的关键差异已说明：stdio 无法强制取消（SDK 不暴露中断 handler 的 API），所以是单段等待、无强制取消阶段
- 干净路径不变：无阻塞 handler 时取消 Context，在途请求自然排空，`Server.Run` 返回 `context.Canceled`，main 的 `isNormalServerExit` 仍按正常退出处理（exit 0）

## 验证方式

- `go test ./internal/mcpserver/` 全量通过、count=3/5/20 重跑零抖动，`go vet` 干净
- 测试用 SDK InMemory 传输对驱动真实工具调用链（`get_connections` → `Service.GetConnections` → 阻塞的 fake backend）：
  - 阻塞 handler：取消后有界返回 abandon 错误，`Backend.Close` 恰好执行一次（跟踪 backend 二次关闭即 panic）
  - 优雅窗口排空：取消后释放在途请求 → 正常返回、不误报放弃错误
  - 干净路径：ListTools 完整、取消后自然排空走正常退出
- 两轮独立子 agent 代码审查通过（含 SDK 源码核实的机制确认与时序余量分析：排空实测 ≤10ms vs 窗口 ≥270ms）

## 影响与风险

- 旧行为"handler 不返回就永远等"变更为"优雅 5s 后放弃"，被放弃的工具调用结果丢失且可能在 backend 关闭后报错——这是修复进程永久卡死的有意取舍，与 #1169 契约一致
- abandon 时进程以非零退出码退出（log + exit 1），与 #1169 的 abandon 语义一致
- 改动仅涉及 `internal/mcpserver` 的 stdio 启动包装，`RunStdioServer` 对外签名不变

## 关联 Issue

Closes #1171
