### PR TITLE
🐛 fix(dameng/build): 修复达梦 DDL 获取与前端依赖重装

### DIFF
--- a/frontend/scripts/wails-frontend-install.mjs
+++ b/frontend/scripts/wails-frontend-install.mjs
@@ -167,7 +167,12 @@ if (!forceInstall && existsSync(nodeModulesPath)) {
   }
 }
 
-runNpm(isCI ? 'ci' : 'install');
+// A local `npm install` preserves the existing node_modules tree. That is
+// unsafe for patch-package: after an interrupted install, a package may be
+// left partially patched and the next postinstall applies the same patch a
+// second time. The lockfile-driven CI path rebuilds the tree before running
+// postinstall, so use it for every real reinstall as well.
+runNpm(existsSync(packageLockPath) ? 'ci' : 'install');
 const missingAfterInstall = missingBuildBinaries();
 if (missingAfterInstall.length > 0) {
   fail(`frontend dependencies installed without required build binaries: ${missingAfterInstall.join(', ')}`);

--- a/internal/app/methods_db.go
+++ b/internal/app/methods_db.go
@@ -3292,7 +3292,7 @@ func tryGetOceanBaseOracleShowCreateStatement(dbInst db.Database, schemaName str
 
 func supportsCreateStatementFallback(dbType string) bool {
 	switch dbType {
-	case "postgres", "kingbase", "highgo", "vastbase", "opengauss", "gaussdb", "sqlserver":
+	case "postgres", "kingbase", "highgo", "vastbase", "opengauss", "gaussdb", "sqlserver", "dameng":
 		return true
 	default:
 		return false
@@ -3467,7 +3467,7 @@ func buildFallbackCreateStatementWithText(dbType string, schemaName string, tabl
 		colName := quoteIdentByType(dbType, colNameRaw)
 		defParts := []string{fmt.Sprintf("%s %s", colName, colType)}
 
-		if dbType == "sqlserver" && strings.Contains(strings.ToLower(strings.TrimSpace(col.Extra)), "auto_increment") {
+		if supportsFallbackIdentityColumn(dbType, colType, col.Extra) {
 			defParts = append(defParts, "IDENTITY(1,1)")
 		}
 		if strings.EqualFold(strings.TrimSpace(col.Nullable), "NO") {
@@ -3512,6 +3512,28 @@ func buildFallbackCreateStatementWithText(dbType string, schemaName string, tabl
 		ddl.WriteString(strings.Join(columnCommentLines, "\n"))
 	}
 	return ddl.String(), nil
+}
+
+func supportsFallbackIdentityColumn(dbType string, columnType string, extra string) bool {
+	if !strings.Contains(strings.ToLower(strings.TrimSpace(extra)), "auto_increment") {
+		return false
+	}
+	if dbType == "sqlserver" {
+		return true
+	}
+	if dbType != "dameng" {
+		return false
+	}
+
+	// 达梦只允许整数列声明 IDENTITY；NUMBER 等类型强行追加会触发
+	// Error -2713（非法 IDENTITY 列类型）。GetColumns 对真实自增列会返回
+	// SMALLINT、INTEGER 或 BIGINT，因此仅在这些合法类型上还原该属性。
+	switch strings.ToUpper(strings.TrimSpace(columnType)) {
+	case "SMALLINT", "INTEGER", "BIGINT":
+		return true
+	default:
+		return false
+	}
 }
 
 type fallbackIndexGroup struct {

--- a/internal/app/methods_db_create_statement_test.go
+++ b/internal/app/methods_db_create_statement_test.go
@@ -803,3 +803,57 @@ func TestResolveCreateStatementWithFallback_FallbackWhenCreateStatementError(t *
 		t.Fatalf("expected fallback DDL for postgres error path, got: %s", ddl)
 	}
 }
+
+func TestResolveCreateStatementWithFallback_DamengUsesColumnsWhenNativeDDLUnavailable(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		config connection.ConnectionConfig
+	}{
+		{name: "built-in", config: connection.ConnectionConfig{Type: "dameng"}},
+		{name: "custom dm8", config: connection.ConnectionConfig{Type: "custom", Driver: "dm8"}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dbInst := &fakeCreateStatementDB{
+				createErr: errors.New("DBMS_METADATA.GET_DDL is unavailable"),
+				columns: []connection.ColumnDefinition{
+					{Name: "ID", Type: "BIGINT", Nullable: "NO", Key: "PRI", Extra: "auto_increment"},
+					{Name: "STATUS", Type: "VARCHAR2(32)", Nullable: "YES"},
+				},
+			}
+
+			ddl, err := resolveCreateStatementWithFallback(dbInst, tc.config, "GXCM", "SM_CHECK_RESULT_ITEM")
+			if err != nil {
+				t.Fatalf("resolveCreateStatementWithFallback() unexpected error: %v", err)
+			}
+			if !strings.Contains(ddl, `CREATE TABLE "GXCM"."SM_CHECK_RESULT_ITEM"`) {
+				t.Fatalf("expected Dameng fallback DDL with owner and table, got: %s", ddl)
+			}
+			if !strings.Contains(ddl, `"ID" BIGINT IDENTITY(1,1) NOT NULL`) || !strings.Contains(ddl, `PRIMARY KEY ("ID")`) {
+				t.Fatalf("expected Dameng fallback DDL to preserve identity and primary key metadata, got: %s", ddl)
+			}
+			if dbInst.columnsCalls != 1 {
+				t.Fatalf("expected Dameng fallback to load columns once, got %d", dbInst.columnsCalls)
+			}
+		})
+	}
+}
+
+func TestBuildFallbackCreateStatement_DamengDoesNotAddIdentityToNumber(t *testing.T) {
+	t.Parallel()
+
+	ddl, err := buildFallbackCreateStatement("dameng", "GXCM", "LEGACY_ITEMS", []connection.ColumnDefinition{
+		{Name: "ID", Type: "NUMBER(19)", Nullable: "NO", Extra: "auto_increment"},
+	})
+	if err != nil {
+		t.Fatalf("buildFallbackCreateStatement() unexpected error: %v", err)
+	}
+	if strings.Contains(ddl, "IDENTITY") {
+		t.Fatalf("Dameng NUMBER columns must not receive an illegal IDENTITY clause: %s", ddl)
+	}
+}

--- a/internal/db/dameng_impl.go
+++ b/internal/db/dameng_impl.go
@@ -314,8 +314,7 @@ func (d *DamengDB) GetCreateStatement(dbName, tableName string) (string, error) 
 	}
 
 	if len(data) > 0 {
-		if val, ok := data[0]["DDL"]; ok {
-			ddl := fmt.Sprintf("%v", val)
+		if ddl := getDamengRowString(data[0], "DDL"); ddl != "" {
 			commentData, _, commentErr := d.Query(buildDamengTableCommentQuery(dbName, tableName))
 			if commentErr != nil {
 				logger.Warnf("达梦 GetCreateStatement 表注释元数据查询失败，已返回基础 DDL：%v", commentErr)

--- a/internal/db/dameng_metadata_entry_test.go
+++ b/internal/db/dameng_metadata_entry_test.go
@@ -161,3 +161,51 @@ func TestDamengMetadataEntrypointsTreatWhitespaceSchemaAsEmpty(t *testing.T) {
 		t.Fatalf("whitespace schema should use current-schema DDL query, got: %v", capture.queries)
 	}
 }
+
+func TestDamengGetCreateStatementAcceptsDriverConfiguredLowercaseColumnName(t *testing.T) {
+	t.Parallel()
+
+	// The DM Go driver exposes columnNameCase=lower and changes result-set
+	// labels accordingly. DBMS_METADATA.GET_DDL still returns the DDL value,
+	// so metadata lookup must not depend on a literal uppercase map key.
+	db := &DamengDB{conn: sql.OpenDB(damengLowercaseDDLConnector{})}
+	t.Cleanup(func() { _ = db.conn.Close() })
+
+	ddl, err := db.GetCreateStatement("GXCM", "SM_CHECK_RESULT_ITEM")
+	if err != nil {
+		t.Fatalf("GetCreateStatement returned error for lowercase DDL label: %v", err)
+	}
+	if ddl != `CREATE TABLE "GXCM"."SM_CHECK_RESULT_ITEM" ("ID" BIGINT)` {
+		t.Fatalf("unexpected DDL: %q", ddl)
+	}
+}
+
+type damengLowercaseDDLConnector struct{}
+
+func (damengLowercaseDDLConnector) Connect(context.Context) (driver.Conn, error) {
+	return damengLowercaseDDLConn{}, nil
+}
+
+func (damengLowercaseDDLConnector) Driver() driver.Driver { return damengMetadataDriver{} }
+
+type damengLowercaseDDLConn struct{}
+
+func (damengLowercaseDDLConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepared statements are not supported by this test driver")
+}
+
+func (damengLowercaseDDLConn) Close() error { return nil }
+
+func (damengLowercaseDDLConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("transactions are not supported by this test driver")
+}
+
+func (damengLowercaseDDLConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	if strings.Contains(query, "DBMS_METADATA.GET_DDL") {
+		return &damengMetadataRows{
+			columns: []string{"ddl"},
+			values:  [][]driver.Value{{`CREATE TABLE "GXCM"."SM_CHECK_RESULT_ITEM" ("ID" BIGINT)`}},
+		}, nil
+	}
+	return &damengMetadataRows{columns: []string{"table_comment"}}, nil
+}

--- a/internal/db/driver_agent_revisions_gen.go
+++ b/internal/db/driver_agent_revisions_gen.go
@@ -12,7 +12,7 @@ func init() {
 		"sqlserver":     "src-e03b09a949e349d1",
 		"sqlite":        "src-fc840ce80a56ec0f",
 		"duckdb":        "src-54d0eef604419ec4",
-		"dameng":        "src-13c5d36606f618ab",
+		"dameng":        "src-8da626e801953020",
 		"kingbase":      "src-1ccfbf6694ce620f",
 		"highgo":        "src-e826dd90d87903f3",
 		"vastbase":      "src-dd4a53092e3dface",


### PR DESCRIPTION
## 背景

达梦连接可以正常读取表字段，但查看部分表的 DDL 时会提示“未找到 CREATE TABLE 语句”。原因包括达梦驱动按连接参数返回小写结果列名，以及 `DBMS_METADATA.GET_DDL` 在受限账号或特定版本中不可用时，主程序没有启用达梦字段元数据兜底。

此外，本地 Wails 构建在依赖安装中断后可能保留已部分打补丁的 `node_modules`，下一次 `npm install` 会让 `patch-package` 重复应用补丁并失败。

## 变更

- 达梦 DDL 结果列改为大小写不敏感读取，兼容 `columnNameCase=lower`。
- 将达梦加入建表语句 fallback；原生 DDL 不可用时，根据字段、主键和索引元数据生成 `CREATE TABLE`。
- 兜底生成时仅为达梦合法整数类型恢复 `IDENTITY(1,1)`，避免 `NUMBER` 触发非法 Identity 类型错误。
- 同时覆盖内置 `dameng` 与 `custom + dm8` 配置，并更新达梦 driver-agent revision。
- 有 lockfile 时统一使用 `npm ci` 重新安装前端依赖，避免残留目录导致 `patch-package` 重复应用。

## 影响范围

- 达梦表 DDL 查看及依赖该建表语句的元数据能力。
- 达梦 driver-agent 版本指纹与发布构建。
- Wails 本地及 CI 的前端依赖安装流程。

## 验证

- `go test ./internal/app -run '^(TestResolveCreateStatementWithFallback|TestDBShowCreateTable|TestBuildFallbackCreateStatement)' -count=1`：通过。
- `go test -tags gonavi_dameng_driver ./internal/db -run '^TestDameng' -count=1`：通过。
- `go test -tags gonavi_dameng_driver ./cmd/optional-driver-agent -run '^$'`：通过。
- `node --check scripts/wails-frontend-install.mjs`：通过。
- `npm exec tsc -- --noEmit`：通过。
- `node scripts/wails-frontend-install.mjs`：干净安装及三个 `patch-package` 补丁应用通过。
- `git diff --check origin/dev...HEAD`：通过。

## 风险与回滚

原生达梦 DDL 可用时仍优先返回原结果；fallback 仅在原生获取失败或内容不可用时启用。前端安装改为基于 lockfile 的可复现安装，不改变依赖版本。若出现兼容问题，可按提交分别回滚构建脚本或达梦元数据修复。
