### PR TITLE
🐛 fix(query): 修复多方言自动限流与分页解析

### DIFF
--- a/frontend/src/components/QueryEditor.results-and-drop.test.tsx
+++ b/frontend/src/components/QueryEditor.results-and-drop.test.tsx
@@ -1099,6 +1099,45 @@ describe('QueryEditor external SQL save', () => {
     renderer.unmount();
   });
 
+  it('places the Dameng row limit before a trailing WITH UR clause', async () => {
+    storeState.connections[0].config.type = 'dameng';
+    storeState.connections[0].config.database = 'GXCM';
+    storeState.queryOptions.maxRows = 500;
+    const sql = [
+      'SELECT DISTINCT v.emp_id, v.emp_name, s.stru_order',
+      'FROM pub_stru s, pub_emp_view_all v',
+      'WHERE s.organ_id = v.emp_id',
+      '  AND v.emp_id IN (',
+      '    SELECT b.organ_id',
+      '    FROM pub_organ_view a, pub_organ_role b',
+      "    WHERE locate(',' || a.organ_id || ',', ',' || b.range_ids || ',') > 0",
+      '  )',
+      'ORDER BY s.stru_order WITH ur;',
+    ].join('\n');
+    editorState.value = sql;
+    backendApp.DBQueryMulti.mockResolvedValueOnce({
+      success: true,
+      data: [{ columns: ['emp_id'], rows: [{ emp_id: '1' }] }],
+    });
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<QueryEditor tab={createTab({ dbName: 'GXCM', query: sql })} />);
+    });
+    await act(async () => {
+      await findButton(renderer, '运行').props.onClick();
+      for (let i = 0; i < 8; i += 1) await Promise.resolve();
+    });
+
+    expect(backendApp.DBQueryMulti).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'dameng' }),
+      'GXCM',
+      sql.replace(' WITH ur;', ' LIMIT 500 OFFSET 0 WITH ur'),
+      'query-1',
+    );
+    renderer.unmount();
+  });
+
   it('executes a long commented Oracle anonymous block without blocking the UI thread', async () => {
     storeState.appearance.uiVersion = 'v2';
     storeState.connections[0].config.type = 'oracle';

--- a/frontend/src/components/QueryEditor.tsx
+++ b/frontend/src/components/QueryEditor.tsx
@@ -9835,8 +9835,6 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
       if (!conn) return;
       const executionDbName = target?.executionDbName ?? currentDb;
       if (!target?.page?.baseSql || !canUseQueryEditorDatabaseContext(conn, executionDbName) || resultTotalCountRequestsRef.current[resultKey]) return;
-      const countSql = buildQueryResultCountSql(target.page.baseSql);
-      if (!countSql) return;
       const config = {
           ...conn.config,
           port: Number(conn.config.port),
@@ -9851,6 +9849,8 @@ const QueryEditor: React.FC<{ tab: TabData; isActive?: boolean }> = ({ tab, isAc
           String((config as any).driver || ''),
           { oceanBaseProtocol: String((config as any).oceanBaseProtocol || '') },
       )).toLowerCase();
+      const countSql = buildQueryResultCountSql(target.page.baseSql, normalizedDbType);
+      if (!countSql) return;
       const sequence = ++resultTotalCountSeqRef.current;
       resultTotalCountRequestsRef.current[resultKey] = { sequence, queryId: '' };
       setResultSets(prev => prev.map(rs =>

--- a/frontend/src/utils/aiSqlLimit.test.ts
+++ b/frontend/src/utils/aiSqlLimit.test.ts
@@ -46,9 +46,27 @@ describe('buildAIReadonlyPreviewSQL', () => {
       .toBe('SELECT * FROM events LIMIT 50 OFFSET 0');
   });
 
+  it('ignores apparent limits inside SQL comments', () => {
+    expect(buildAIReadonlyPreviewSQL('postgres', 'SELECT id FROM users /* LIMIT 10 */', 50))
+      .toBe('SELECT id FROM users LIMIT 50 OFFSET 0 /* LIMIT 10 */');
+    expect(buildAIReadonlyPreviewSQL('postgres', 'SELECT id FROM users --LIMIT 10', 50))
+      .toBe('SELECT id FROM users LIMIT 50 OFFSET 0 --LIMIT 10');
+  });
+
+  it('adds a limit before an existing OFFSET on grouped SQL', () => {
+    const sql = 'SELECT dept_id, COUNT(*) total FROM users GROUP BY dept_id HAVING COUNT(*) > 1 ORDER BY total DESC OFFSET 40';
+    expect(buildAIReadonlyPreviewSQL('postgres', sql, 50))
+      .toBe('SELECT dept_id, COUNT(*) total FROM users GROUP BY dept_id HAVING COUNT(*) > 1 ORDER BY total DESC LIMIT 50 OFFSET 40');
+  });
+
   it('limits Dameng readonly SQL with native LIMIT syntax', () => {
     expect(buildAIReadonlyPreviewSQL('dameng', 'SELECT 1 FROM DUAL;', 50))
       .toBe('SELECT 1 FROM DUAL LIMIT 50 OFFSET 0');
+  });
+
+  it('places the Dameng readonly limit before WITH UR', () => {
+    expect(buildAIReadonlyPreviewSQL('dameng', 'SELECT 1 FROM DUAL WITH ur;', 50))
+      .toBe('SELECT 1 FROM DUAL LIMIT 50 OFFSET 0 WITH ur');
   });
 
   it('does not limit non-readonly SQL', () => {

--- a/frontend/src/utils/aiSqlLimit.ts
+++ b/frontend/src/utils/aiSqlLimit.ts
@@ -1,23 +1,37 @@
 import { buildPaginatedSelectSQL } from './sql';
 import { resolveSqlDialect } from './sqlDialect';
+import { applyQueryAutoLimit, findTopLevelKeyword, getLeadingKeyword, splitSqlTail } from './queryAutoLimit';
 
 const AI_READONLY_SQL_KEYWORDS = new Set(['select', 'show', 'describe', 'desc', 'explain', 'with', 'pragma', 'values']);
 
 const trimSQLStatement = (sql: string): string => String(sql || '').trim().replace(/;\s*$/, '').trim();
 
-const isAIReadonlySQL = (sql: string): boolean => {
-  const firstWord = trimSQLStatement(sql).trimStart().split(/\s+/)[0]?.toLowerCase() || '';
+const isAIReadonlySQL = (sql: string, dialect: string): boolean => {
+  const firstWord = getLeadingKeyword(trimSQLStatement(sql), dialect);
   return AI_READONLY_SQL_KEYWORDS.has(firstWord);
 };
 
 const hasExistingRowLimit = (dialect: string, sql: string): boolean => {
-  const text = trimSQLStatement(sql).toLowerCase();
+  const text = splitSqlTail(trimSQLStatement(sql), dialect).main;
   if (!text) return false;
-  if (/\blimit\s+\d+\b/.test(text)) return true;
-  if (/\bfetch\s+(first|next)\s+\d+\s+rows?\b/.test(text)) return true;
-  if (/\btop\s*\(?\s*\d+\s*\)?\b/.test(text)) return true;
+  if (findTopLevelKeyword(text, 'limit', dialect) >= 0) return true;
+  if (findTopLevelKeyword(text, 'fetch', dialect) >= 0) return true;
+  if (findTopLevelKeyword(text, 'top', dialect) >= 0) return true;
+  return (dialect === 'oracle' || dialect === 'dameng')
+    && findTopLevelKeyword(text, 'rownum', dialect) >= 0;
+};
 
-  return (dialect === 'oracle' || dialect === 'dameng') && /\brownum\b/.test(text);
+const preserveAIExplicitZeroOffset = (dialect: string, sql: string): string => {
+  if (dialect === 'oracle' || dialect === 'dameng' || dialect === 'sqlserver' || dialect === 'mssql') {
+    return sql;
+  }
+  const { main, tail } = splitSqlTail(sql, dialect);
+  const limitPos = findTopLevelKeyword(main, 'limit', dialect);
+  if (limitPos < 0 || findTopLevelKeyword(main, 'offset', dialect) >= 0) return sql;
+  const limitMatch = main.slice(limitPos).match(/^limit\s+\d+/i);
+  if (!limitMatch) return sql;
+  const insertAt = limitPos + limitMatch[0].length;
+  return `${main.slice(0, insertAt)} OFFSET 0${main.slice(insertAt)}${tail}`;
 };
 
 export const buildAIReadonlyPreviewSQL = (
@@ -30,8 +44,12 @@ export const buildAIReadonlyPreviewSQL = (
   const baseSQL = trimSQLStatement(sql);
   const safeLimit = Math.max(0, Math.floor(Number(limit) || 0));
   const dialect = resolveSqlDialect(dbType, driver, options);
-  if (!baseSQL || safeLimit <= 0 || !isAIReadonlySQL(baseSQL) || hasExistingRowLimit(dialect, baseSQL)) {
+  if (!baseSQL || safeLimit <= 0 || !isAIReadonlySQL(baseSQL, dialect) || hasExistingRowLimit(dialect, baseSQL)) {
     return baseSQL;
+  }
+  if (getLeadingKeyword(baseSQL, dialect) === 'select') {
+    const result = applyQueryAutoLimit(baseSQL, dialect, safeLimit);
+    return result.applied ? preserveAIExplicitZeroOffset(dialect, result.sql) : result.sql;
   }
   return buildPaginatedSelectSQL(dialect, baseSQL, '', safeLimit, 0);
 };

--- a/frontend/src/utils/queryAutoLimit.test.ts
+++ b/frontend/src/utils/queryAutoLimit.test.ts
@@ -56,6 +56,29 @@ describe('applyQueryAutoLimit', () => {
     });
   });
 
+  it('places the Dameng limit before a trailing WITH UR clause', () => {
+    const sql = `SELECT DISTINCT
+  v.emp_id,
+  v.emp_name,
+  s.stru_order
+FROM pub_stru s, pub_emp_view_all v
+WHERE s.organ_id = v.emp_id
+  AND v.emp_id IN (
+    SELECT b.organ_id
+    FROM pub_organ_view a, pub_organ_role b
+    WHERE locate(',' || a.organ_id || ',', ',' || b.range_ids || ',') > 0
+  )
+ORDER BY s.stru_order WITH ur;`;
+
+    for (const [dbType, driver] of [['dameng', ''], ['custom', 'dm8']]) {
+      expect(applyQueryAutoLimit(sql, dbType, 500, driver)).toEqual({
+        sql: sql.replace(' WITH ur;', ' LIMIT 500 OFFSET 0 WITH ur;'),
+        applied: true,
+        maxRows: 500,
+      });
+    }
+  });
+
   it.each([
     ['sqlserver'],
     ['mssql'],
@@ -112,6 +135,35 @@ describe('applyQueryAutoLimit', () => {
       .toBe('SELECT * FROM (SELECT * FROM users LIMIT 10) t LIMIT 500');
   });
 
+  it('preserves an existing ORDER BY LIMIT OFFSET clause', () => {
+    const sql = 'SELECT id FROM users ORDER BY id LIMIT 20 OFFSET 40';
+    expect(applyQueryAutoLimit(sql, 'postgres', 500)).toEqual({
+      sql,
+      applied: false,
+      maxRows: 500,
+    });
+  });
+
+  it('limits GROUP BY and HAVING after the complete query', () => {
+    const sql = 'SELECT dept_id, COUNT(*) total FROM users GROUP BY dept_id HAVING COUNT(*) > 1 ORDER BY total DESC';
+    expect(applyQueryAutoLimit(sql, 'postgres', 500).sql)
+      .toBe(`${sql} LIMIT 500`);
+  });
+
+  it('ignores LIMIT text in block comments and compact PostgreSQL line comments', () => {
+    expect(applyQueryAutoLimit('SELECT id FROM users /* LIMIT 10 */ ORDER BY id', 'postgres', 500).sql)
+      .toBe('SELECT id FROM users /* LIMIT 10 */ ORDER BY id LIMIT 500');
+    expect(applyQueryAutoLimit('SELECT id FROM users --LIMIT 10', 'postgres', 500).sql)
+      .toBe('SELECT id FROM users LIMIT 500 --LIMIT 10');
+    expect(applyQueryAutoLimit('--preview\nSELECT id FROM users', 'postgres', 500).sql)
+      .toBe('--preview\nSELECT id FROM users LIMIT 500');
+  });
+
+  it('keeps compact double-minus expressions executable for MySQL', () => {
+    expect(applyQueryAutoLimit('SELECT 1--2 AS value', 'mysql', 500).sql)
+      .toBe('SELECT 1--2 AS value LIMIT 500');
+  });
+
   it('does not add another Oracle limit when Oracle SQL already limits rows', () => {
     expect(applyQueryAutoLimit('SELECT * FROM users WHERE ROWNUM <= 10', 'oracle', 500).applied)
       .toBe(false);
@@ -124,6 +176,14 @@ describe('applyQueryAutoLimit', () => {
 
     expect(applyQueryAutoLimit(sql, 'dameng', 5000)).toEqual({
       sql,
+      applied: false,
+      maxRows: 5000,
+    });
+  });
+
+  it('keeps WITH UR after an existing Dameng limit', () => {
+    expect(applyQueryAutoLimit('SELECT ID FROM USERS LIMIT 25 WITH UR;', 'dameng', 5000)).toEqual({
+      sql: 'SELECT ID FROM USERS LIMIT 25 WITH UR;',
       applied: false,
       maxRows: 5000,
     });

--- a/frontend/src/utils/queryAutoLimit.ts
+++ b/frontend/src/utils/queryAutoLimit.ts
@@ -1,10 +1,11 @@
 import { resolveSqlDialect } from './sqlDialect';
-import { buildPaginatedSelectSQL } from './sql';
+import { buildPaginatedSelectSQL, splitTrailingIsolationClause } from './sql';
+import { isSqlDashLineCommentStart } from './sqlStatementSelection';
 
 const isWS = (ch: string) => ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r';
 const isWord = (ch: string) => /[A-Za-z0-9_]/.test(ch);
 
-export const getLeadingKeyword = (sql: string): string => {
+export const getLeadingKeyword = (sql: string, dbType = ''): string => {
   const text = (sql || '').replace(/\r\n/g, '\n');
   let inSingle = false;
   let inDouble = false;
@@ -17,7 +18,6 @@ export const getLeadingKeyword = (sql: string): string => {
   for (let i = 0; i < text.length; i++) {
     const ch = text[i];
     const next = i + 1 < text.length ? text[i + 1] : '';
-    const prev = i > 0 ? text[i - 1] : '';
     const next2 = i + 2 < text.length ? text[i + 2] : '';
 
     if (!inSingle && !inDouble && !inBacktick) {
@@ -41,7 +41,7 @@ export const getLeadingKeyword = (sql: string): string => {
         inLineComment = true;
         continue;
       }
-      if (ch === '-' && next === '-' && (i === 0 || isWS(prev)) && (next2 === '' || isWS(next2))) {
+      if (ch === '-' && next === '-' && isSqlDashLineCommentStart(dbType, next2)) {
         i++;
         inLineComment = true;
         continue;
@@ -95,7 +95,7 @@ export const getLeadingKeyword = (sql: string): string => {
   return '';
 };
 
-export const splitSqlTail = (sql: string): { main: string; tail: string } => {
+export const splitSqlTail = (sql: string, dbType = ''): { main: string; tail: string } => {
   const text = (sql || '').replace(/\r\n/g, '\n');
   let inSingle = false;
   let inDouble = false;
@@ -109,7 +109,6 @@ export const splitSqlTail = (sql: string): { main: string; tail: string } => {
   for (let i = 0; i < text.length; i++) {
     const ch = text[i];
     const next = i + 1 < text.length ? text[i + 1] : '';
-    const prev = i > 0 ? text[i - 1] : '';
     const next2 = i + 2 < text.length ? text[i + 2] : '';
 
     if (!inSingle && !inDouble && !inBacktick) {
@@ -143,7 +142,7 @@ export const splitSqlTail = (sql: string): { main: string; tail: string } => {
         inLineComment = true;
         continue;
       }
-      if (ch === '-' && next === '-' && (i === 0 || isWS(prev)) && (next2 === '' || isWS(next2))) {
+      if (ch === '-' && next === '-' && isSqlDashLineCommentStart(dbType, next2)) {
         i++;
         inLineComment = true;
         continue;
@@ -182,7 +181,7 @@ export const splitSqlTail = (sql: string): { main: string; tail: string } => {
   return { main: text.slice(0, mainEnd), tail: text.slice(mainEnd) };
 };
 
-export const findTopLevelKeyword = (sql: string, keyword: string): number => {
+export const findTopLevelKeyword = (sql: string, keyword: string, dbType = ''): number => {
   const text = sql;
   const kw = keyword.toLowerCase();
   let inSingle = false;
@@ -197,7 +196,6 @@ export const findTopLevelKeyword = (sql: string, keyword: string): number => {
   for (let i = 0; i < text.length; i++) {
     const ch = text[i];
     const next = i + 1 < text.length ? text[i + 1] : '';
-    const prev = i > 0 ? text[i - 1] : '';
     const next2 = i + 2 < text.length ? text[i + 2] : '';
 
     if (!inSingle && !inDouble && !inBacktick) {
@@ -221,7 +219,7 @@ export const findTopLevelKeyword = (sql: string, keyword: string): number => {
         inLineComment = true;
         continue;
       }
-      if (ch === '-' && next === '-' && (i === 0 || isWS(prev)) && (next2 === '' || isWS(next2))) {
+      if (ch === '-' && next === '-' && isSqlDashLineCommentStart(dbType, next2)) {
         i++;
         inLineComment = true;
         continue;
@@ -360,52 +358,57 @@ export const applyQueryAutoLimit = (
 ): { sql: string; applied: boolean; maxRows: number } => {
   if (!Number.isFinite(maxRows) || maxRows <= 0) return { sql, applied: false, maxRows };
   const normalizedType = String(resolveSqlDialect(dbType || 'mysql', driver)).toLowerCase();
-  const keyword = getLeadingKeyword(sql);
+  const keyword = getLeadingKeyword(sql, normalizedType);
   if (keyword !== 'select') return { sql, applied: false, maxRows };
 
-  const { main, tail } = splitSqlTail(sql);
+  const { main, tail } = splitSqlTail(sql, normalizedType);
   if (!main.trim()) return { sql, applied: false, maxRows };
+  const isolationStatement = normalizedType === 'dameng'
+    ? splitTrailingIsolationClause(main)
+    : { main, tail: '' };
+  const executableMain = isolationStatement.main;
+  const executableSql = `${executableMain}${isolationStatement.tail}${tail}`;
 
-  const fromPos = findTopLevelKeyword(main, 'from');
-  const limitPos = findTopLevelKeyword(main, 'limit');
-  if (limitPos >= 0 && (fromPos < 0 || limitPos > fromPos)) return { sql, applied: false, maxRows };
-  const fetchPos = findTopLevelKeyword(main, 'fetch');
-  if (fetchPos >= 0 && (fromPos < 0 || fetchPos > fromPos)) return { sql, applied: false, maxRows };
+  const fromPos = findTopLevelKeyword(executableMain, 'from', normalizedType);
+  const limitPos = findTopLevelKeyword(executableMain, 'limit', normalizedType);
+  if (limitPos >= 0 && (fromPos < 0 || limitPos > fromPos)) return { sql: executableSql, applied: false, maxRows };
+  const fetchPos = findTopLevelKeyword(executableMain, 'fetch', normalizedType);
+  if (fetchPos >= 0 && (fromPos < 0 || fetchPos > fromPos)) return { sql: executableSql, applied: false, maxRows };
 
   if (normalizedType === 'sqlserver' || normalizedType === 'mssql') {
-    const topPos = findTopLevelKeyword(main, 'top');
+    const topPos = findTopLevelKeyword(executableMain, 'top', normalizedType);
     if (topPos >= 0) return { sql, applied: false, maxRows };
-    const selectPos = findTopLevelKeyword(main, 'select');
+    const selectPos = findTopLevelKeyword(executableMain, 'select', normalizedType);
     if (selectPos < 0) return { sql, applied: false, maxRows };
     const afterSelect = selectPos + 'SELECT'.length;
-    const restAfterSelect = main.slice(afterSelect);
+    const restAfterSelect = executableMain.slice(afterSelect);
     const distinctMatch = restAfterSelect.match(/^(\s+DISTINCT\b)/i);
     const insertOffset = distinctMatch ? afterSelect + distinctMatch[1].length : afterSelect;
-    const nextMain = main.slice(0, insertOffset) + ` TOP ${maxRows}` + main.slice(insertOffset);
+    const nextMain = executableMain.slice(0, insertOffset) + ` TOP ${maxRows}` + executableMain.slice(insertOffset);
     return { sql: nextMain + tail, applied: true, maxRows };
   }
 
   if (normalizedType === 'oracle' || normalizedType === 'dameng') {
-    const rownumPos = findTopLevelKeyword(main, 'rownum');
-    if (rownumPos >= 0) return { sql, applied: false, maxRows };
-    const offsetPos = findTopLevelKeyword(main, 'offset');
-    if (offsetPos >= 0 && (fromPos < 0 || offsetPos > fromPos)) return { sql, applied: false, maxRows };
-    const forPos = findTopLevelKeyword(main, 'for');
-    if (forPos >= 0 && (fromPos < 0 || forPos > fromPos)) return { sql, applied: false, maxRows };
+    const rownumPos = findTopLevelKeyword(executableMain, 'rownum', normalizedType);
+    if (rownumPos >= 0) return { sql: executableSql, applied: false, maxRows };
+    const offsetPos = findTopLevelKeyword(executableMain, 'offset', normalizedType);
+    if (offsetPos >= 0 && (fromPos < 0 || offsetPos > fromPos)) return { sql: executableSql, applied: false, maxRows };
+    const forPos = findTopLevelKeyword(executableMain, 'for', normalizedType);
+    if (forPos >= 0 && (fromPos < 0 || forPos > fromPos)) return { sql: executableSql, applied: false, maxRows };
     // Oracle-compatible databases reject NEXTVAL/CURRVAL when the ROWNUM cap
     // moves the original SELECT into a subquery.
-    if (hasOracleSequencePseudoColumn(main)) return { sql, applied: false, maxRows };
+    if (hasOracleSequencePseudoColumn(executableMain)) return { sql: executableSql, applied: false, maxRows };
     return { sql: `${buildPaginatedSelectSQL(normalizedType, main, '', maxRows, 0)}${tail}`, applied: true, maxRows };
   }
 
-  const offsetPos = findTopLevelKeyword(main, 'offset');
-  const forPos = findTopLevelKeyword(main, 'for');
-  const lockPos = findTopLevelKeyword(main, 'lock');
+  const offsetPos = findTopLevelKeyword(executableMain, 'offset', normalizedType);
+  const forPos = findTopLevelKeyword(executableMain, 'for', normalizedType);
+  const lockPos = findTopLevelKeyword(executableMain, 'lock', normalizedType);
   const candidates = [offsetPos, forPos, lockPos]
     .filter(pos => pos >= 0 && (fromPos < 0 || pos > fromPos));
-  const insertAt = candidates.length > 0 ? Math.min(...candidates) : main.length;
-  const before = main.slice(0, insertAt).trimEnd();
-  const after = main.slice(insertAt).trimStart();
+  const insertAt = candidates.length > 0 ? Math.min(...candidates) : executableMain.length;
+  const before = executableMain.slice(0, insertAt).trimEnd();
+  const after = executableMain.slice(insertAt).trimStart();
   const nextMain = [before, `LIMIT ${maxRows}`, after].filter(Boolean).join(' ').trim();
   return { sql: nextMain + tail, applied: true, maxRows };
 };

--- a/frontend/src/utils/queryResultPagination.test.ts
+++ b/frontend/src/utils/queryResultPagination.test.ts
@@ -47,6 +47,23 @@ describe('queryResultPagination', () => {
     });
   });
 
+  it('recognizes a Dameng limit placed before WITH UR as editor pagination', () => {
+    const page = createInitialQueryResultPagination({
+      executedSql: 'SELECT id FROM users LIMIT 500 OFFSET 0 WITH UR;',
+      exportSql: 'SELECT id FROM users WITH UR;',
+      dbType: 'dameng',
+      returnedRowCount: 500,
+      fallbackPageSize: 500,
+    });
+
+    expect(page).toMatchObject({
+      current: 1,
+      pageSize: 500,
+      baseSql: 'SELECT id FROM users WITH UR',
+      exportAllSql: 'SELECT id FROM users WITH UR',
+    });
+  });
+
   it('keeps query-editor injected Oracle ROWNUM wrapper pageable', () => {
     const page = createInitialQueryResultPagination({
       executedSql: 'SELECT * FROM (SELECT id, name FROM users ORDER BY created_at DESC) WHERE ROWNUM <= 500',
@@ -74,6 +91,23 @@ describe('queryResultPagination', () => {
       pageSize: 500,
       lookahead: true,
     })).toBe('SELECT * FROM (SELECT id FROM users) AS __gonavi_query_page__ LIMIT 501 OFFSET 500');
+  });
+
+  it('keeps Dameng WITH UR outside the paginated derived table', () => {
+    expect(buildQueryResultPageSql({
+      baseSql: 'SELECT id FROM users WITH UR',
+      dbType: 'dameng',
+      page: 2,
+      pageSize: 500,
+      lookahead: true,
+    })).toBe(
+      'SELECT * FROM (SELECT id FROM users) "__gonavi_query_page__" LIMIT 501 OFFSET 500 WITH UR',
+    );
+  });
+
+  it('moves a trailing isolation clause outside the total-count subquery', () => {
+    expect(buildQueryResultCountSql('SELECT id FROM users WITH UR;'))
+      .toBe('SELECT COUNT(*) AS __gonavi_total__ FROM (SELECT id FROM users) __gonavi_query_count__ WITH UR');
   });
 
   it('sorts the wrapped MySQL result before applying pagination', () => {
@@ -113,6 +147,43 @@ describe('queryResultPagination', () => {
       rowCount: 500,
       hasNext: false,
     })).toEqual({ total: 1000, totalKnown: true });
+  });
+
+  it('returns an exact zero total for an empty first page', () => {
+    expect(resolveQueryResultPaginationTotal({
+      current: 1,
+      pageSize: 500,
+      rowCount: 0,
+      hasNext: false,
+    })).toEqual({ total: 0, totalKnown: true });
+  });
+
+  it('counts GROUP BY and HAVING results without the top-level ordering', () => {
+    expect(buildQueryResultCountSql(
+      'SELECT dept_id, COUNT(*) total FROM users GROUP BY dept_id HAVING COUNT(*) > 1 ORDER BY total DESC',
+      'postgres',
+    )).toBe(
+      'SELECT COUNT(*) AS __gonavi_total__ FROM (SELECT dept_id, COUNT(*) total FROM users GROUP BY dept_id HAVING COUNT(*) > 1) __gonavi_query_count__',
+    );
+  });
+
+  it('ignores compact line-comment keywords when building a count query', () => {
+    expect(buildQueryResultCountSql('SELECT id FROM users --ORDER BY ignored', 'postgres'))
+      .toBe('SELECT COUNT(*) AS __gonavi_total__ FROM (SELECT id FROM users) __gonavi_query_count__');
+  });
+
+  it('keeps a compact-commented PostgreSQL query pageable', () => {
+    expect(createInitialQueryResultPagination({
+      executedSql: '--preview\nSELECT id FROM users LIMIT 500',
+      exportSql: '--preview\nSELECT id FROM users',
+      dbType: 'postgres',
+      returnedRowCount: 500,
+      fallbackPageSize: 500,
+    })).toMatchObject({
+      current: 1,
+      pageSize: 500,
+      baseSql: '--preview\nSELECT id FROM users',
+    });
   });
 
   it('builds a portable total-count query and removes only the top-level ordering', () => {

--- a/frontend/src/utils/queryResultPagination.ts
+++ b/frontend/src/utils/queryResultPagination.ts
@@ -1,4 +1,4 @@
-import { buildOrderBySQL, buildPaginatedSelectSQL } from './sql';
+import { buildOrderBySQL, buildPaginatedSelectSQL, splitTrailingIsolationClause } from './sql';
 import { findTopLevelKeyword, getLeadingKeyword, splitSqlTail } from './queryAutoLimit';
 import { resolveSqlDialect } from './sqlDialect';
 
@@ -52,42 +52,50 @@ const normalizeSqlForComparison = (sql: string): string => (
     .toLowerCase()
 );
 
-const parseTopLevelLimit = (sql: string): LimitInfo | null => {
-  const { main } = splitSqlTail(sql);
-  const limitPos = findTopLevelKeyword(main, 'limit');
+const normalizePaginationStatement = (sql: string, dialect = ''): string => {
+  const main = splitSqlTail(sql, dialect).main.trim();
+  return main;
+};
+
+const parseTopLevelLimit = (sql: string, dialect = ''): LimitInfo | null => {
+  const main = normalizePaginationStatement(sql, dialect);
+  const statement = dialect === 'dameng'
+    ? splitTrailingIsolationClause(main)
+    : { main, tail: '' };
+  const limitPos = findTopLevelKeyword(statement.main, 'limit', dialect);
   if (limitPos < 0) return null;
-  const fromPos = findTopLevelKeyword(main, 'from');
+  const fromPos = findTopLevelKeyword(statement.main, 'from', dialect);
   if (fromPos >= 0 && limitPos < fromPos) return null;
 
-  const beforeLimit = main.slice(0, limitPos).trimEnd();
-  const limitClause = main.slice(limitPos).trim();
+  const baseSql = `${statement.main.slice(0, limitPos).trimEnd()}${statement.tail}`;
+  const limitClause = statement.main.slice(limitPos).trim();
   const mysqlOffsetLimit = limitClause.match(/^limit\s+(\d+)\s*,\s*(\d+)$/i);
   if (mysqlOffsetLimit) {
     const offset = normalizePositiveInteger(mysqlOffsetLimit[1]);
     const limit = normalizePositiveInteger(mysqlOffsetLimit[2]);
-    return limit > 0 ? { baseSql: beforeLimit, limit, offset } : null;
+    return limit > 0 ? { baseSql, limit, offset } : null;
   }
 
   const limitOffset = limitClause.match(/^limit\s+(\d+)\s+offset\s+(\d+)$/i);
   if (limitOffset) {
     const limit = normalizePositiveInteger(limitOffset[1]);
     const offset = normalizePositiveInteger(limitOffset[2]);
-    return limit > 0 ? { baseSql: beforeLimit, limit, offset } : null;
+    return limit > 0 ? { baseSql, limit, offset } : null;
   }
 
   const simpleLimit = limitClause.match(/^limit\s+(\d+)$/i);
   if (simpleLimit) {
     const limit = normalizePositiveInteger(simpleLimit[1]);
-    return limit > 0 ? { baseSql: beforeLimit, limit, offset: 0 } : null;
+    return limit > 0 ? { baseSql, limit, offset: 0 } : null;
   }
 
   return null;
 };
 
-const stripExplicitLimitForExport = (sql: string): string => {
-  const parsed = parseTopLevelLimit(sql);
+const stripExplicitLimitForExport = (sql: string, dialect = ''): string => {
+  const parsed = parseTopLevelLimit(sql, dialect);
   if (parsed?.baseSql) return parsed.baseSql;
-  return splitSqlTail(sql).main.trim();
+  return normalizePaginationStatement(sql, dialect);
 };
 
 const wasLimitAppliedByQueryEditorCap = (
@@ -102,15 +110,15 @@ const wasLimitAppliedByQueryEditorCap = (
   if (!executed || !exportable) return false;
   if (normalizeSqlForComparison(executed) === normalizeSqlForComparison(exportable)) return false;
 
-  const exportBaseSql = stripExplicitLimitForExport(exportable);
-  if (normalizeSqlForComparison(stripExplicitLimitForExport(executed)) === normalizeSqlForComparison(exportBaseSql)) {
+  const dialect = resolveSqlDialect(dbType || 'mysql', driver || '');
+  const exportBaseSql = stripExplicitLimitForExport(exportable, dialect);
+  if (normalizeSqlForComparison(stripExplicitLimitForExport(executed, dialect)) === normalizeSqlForComparison(exportBaseSql)) {
     return true;
   }
 
   const pageSize = normalizePositiveInteger(fallbackPageSize);
-  if (pageSize <= 0 || getLeadingKeyword(exportBaseSql) !== 'select') return false;
+  if (pageSize <= 0 || getLeadingKeyword(exportBaseSql, dialect) !== 'select') return false;
 
-  const dialect = resolveSqlDialect(dbType || 'mysql', driver || '');
   const queryEditorCappedSql = buildPaginatedSelectSQL(dialect, exportBaseSql, '', pageSize, 0);
   return normalizeSqlForComparison(executed) === normalizeSqlForComparison(queryEditorCappedSql);
 };
@@ -124,13 +132,15 @@ const resolveWrappedBaseSql = (dbType: string, baseSql: string): string => {
   return `SELECT * FROM (${base}) AS __gonavi_query_page__`;
 };
 
-export const buildQueryResultCountSql = (baseSql: string): string => {
-  const mainSql = splitSqlTail(String(baseSql || '')).main.trim();
+export const buildQueryResultCountSql = (baseSql: string, dbType = ''): string => {
+  const dialect = resolveSqlDialect(dbType || '');
+  const mainSql = splitSqlTail(String(baseSql || ''), dialect).main.trim();
   if (!mainSql) return '';
-  const orderByPos = findTopLevelKeyword(mainSql, 'order by');
-  const countBaseSql = (orderByPos >= 0 ? mainSql.slice(0, orderByPos) : mainSql).trim();
+  const statement = splitTrailingIsolationClause(mainSql);
+  const orderByPos = findTopLevelKeyword(statement.main, 'order by', dialect);
+  const countBaseSql = (orderByPos >= 0 ? statement.main.slice(0, orderByPos) : statement.main).trim();
   if (!countBaseSql) return '';
-  return `SELECT COUNT(*) AS __gonavi_total__ FROM (${countBaseSql}) __gonavi_query_count__`;
+  return `SELECT COUNT(*) AS __gonavi_total__ FROM (${countBaseSql}) __gonavi_query_count__${statement.tail}`;
 };
 
 export const parseQueryResultTotalCount = (row: unknown): number | null => {
@@ -171,13 +181,16 @@ export const buildQueryResultPageSql = (params: {
     oceanBaseProtocol: params.oceanBaseProtocol || '',
   });
   const orderBySql = buildOrderBySQL(dialect, params.sortInfo || []);
+  const statement = dialect === 'dameng'
+    ? splitTrailingIsolationClause(params.baseSql)
+    : { main: params.baseSql, tail: '' };
   return buildPaginatedSelectSQL(
     dialect,
-    resolveWrappedBaseSql(dialect, params.baseSql),
+    resolveWrappedBaseSql(dialect, statement.main),
     orderBySql,
     limit,
     offset,
-  );
+  ) + statement.tail;
 };
 
 export const resolveQueryResultPaginationTotal = (params: {
@@ -213,10 +226,10 @@ export const createInitialQueryResultPagination = (params: {
   fallbackPageSize?: number;
 }): QueryResultPaginationState | undefined => {
   const executedSql = String(params.executedSql || '').trim();
-  if (!executedSql || getLeadingKeyword(executedSql) !== 'select') return undefined;
-
-  const explicitLimit = parseTopLevelLimit(executedSql);
-  const mainSql = splitSqlTail(executedSql).main.trim();
+  const dialect = resolveSqlDialect(params.dbType || 'mysql', params.driver || '');
+  if (!executedSql || getLeadingKeyword(executedSql, dialect) !== 'select') return undefined;
+  const explicitLimit = parseTopLevelLimit(executedSql, dialect);
+  const mainSql = normalizePaginationStatement(executedSql, dialect);
   const fallbackPageSize = normalizePositiveInteger(params.fallbackPageSize);
   const returnedRowCount = Math.max(0, Math.floor(Number(params.returnedRowCount) || 0));
   const pageSize = explicitLimit?.limit || fallbackPageSize || returnedRowCount;
@@ -228,9 +241,9 @@ export const createInitialQueryResultPagination = (params: {
   if (current <= 1 && returnedRowCount < pageSize) return undefined;
 
   const exportSql = String(params.exportSql || '').trim();
-  const exportAllSql = exportSql && getLeadingKeyword(exportSql) === 'select'
-    ? stripExplicitLimitForExport(exportSql)
-    : stripExplicitLimitForExport(executedSql);
+  const exportAllSql = exportSql && getLeadingKeyword(exportSql, dialect) === 'select'
+    ? stripExplicitLimitForExport(exportSql, dialect)
+    : stripExplicitLimitForExport(executedSql, dialect);
   const autoLimitCap = current === 1 && wasLimitAppliedByQueryEditorCap(
     executedSql,
     exportSql,

--- a/frontend/src/utils/sql.test.ts
+++ b/frontend/src/utils/sql.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildOrderBySQL, buildPaginatedSelectSQL, buildWhereSQL, quoteIdentPart, quoteQualifiedIdent, reverseOrderBySQL } from './sql';
+import { buildOrderBySQL, buildPaginatedSelectSQL, buildWhereSQL, quoteIdentPart, quoteQualifiedIdent, reverseOrderBySQL, splitTrailingIsolationClause } from './sql';
 
 describe('buildOrderBySQL', () => {
   it('does not sort Elasticsearch table previews by the _id fallback column', () => {
@@ -39,6 +39,16 @@ describe('buildPaginatedSelectSQL', () => {
 
     expect(buildPaginatedSelectSQL('dameng', baseSql, '', 5000, 0))
       .toBe(`${baseSql} LIMIT 5000 OFFSET 0`);
+  });
+
+  it.each(['UR', 'CS', 'RS', 'RR'])('keeps Dameng WITH %s after native pagination', (isolation) => {
+    expect(buildPaginatedSelectSQL('dameng', `SELECT * FROM users WITH ${isolation}`, '', 500, 0))
+      .toBe(`SELECT * FROM users LIMIT 500 OFFSET 0 WITH ${isolation}`);
+  });
+
+  it('does not treat trailing line-comment text as a Dameng isolation clause', () => {
+    const sql = 'SELECT * FROM users -- example WITH UR';
+    expect(splitTrailingIsolationClause(sql)).toEqual({ main: sql, tail: '' });
   });
 
   it('keeps the Oracle ROWNUM compatibility wrapper', () => {

--- a/frontend/src/utils/sql.ts
+++ b/frontend/src/utils/sql.ts
@@ -288,6 +288,19 @@ const addSqlServerTopLimit = (sql: string, limit: number): string => {
   );
 };
 
+export const splitTrailingIsolationClause = (sql: string): { main: string; tail: string } => {
+  const text = String(sql || '').trim();
+  const match = text.match(/^(.*?)(\s+WITH\s+(?:UR|CS|RS|RR))\s*$/is);
+  if (!match) return { main: text, tail: '' };
+  const clauseStart = match[1].length;
+  const currentLine = text.slice(text.lastIndexOf('\n', clauseStart - 1) + 1, clauseStart);
+  if (/(?:--|#)[^\r\n]*$/u.test(currentLine)) return { main: text, tail: '' };
+  return {
+    main: match[1].trimEnd(),
+    tail: match[2],
+  };
+};
+
 const buildSqlServerPaginatedSelectSQL = (
   base: string,
   orderBy: string,
@@ -337,6 +350,15 @@ export const buildPaginatedSelectSQL = (
         return `SELECT * FROM (${orderedSql}) WHERE ROWNUM <= ${upperBound}`;
       }
       return `SELECT * FROM (SELECT "__gonavi_page__".*, ROWNUM "__gonavi_rn__" FROM (${orderedSql}) "__gonavi_page__" WHERE ROWNUM <= ${upperBound}) WHERE "__gonavi_rn__" > ${safeOffset}`;
+    }
+    case 'dameng': {
+      // WITH UR/CS/RS/RR is a terminal isolation clause in Dameng DB2
+      // compatibility mode. Keep it after native LIMIT/OFFSET; appending the
+      // limit after WITH UR is rejected. Native pagination also avoids
+      // wrapping JOIN results whose duplicate column names are ambiguous in a
+      // derived table.
+      const statement = splitTrailingIsolationClause(base);
+      return `${statement.main}${orderBy} LIMIT ${safeLimit} OFFSET ${safeOffset}${statement.tail}`;
     }
     case 'sqlserver':
     case 'mssql': {

--- a/frontend/src/utils/sqlStatementSelection.ts
+++ b/frontend/src/utils/sqlStatementSelection.ts
@@ -71,7 +71,7 @@ const supportsSqlHashLineComment = (dbType: string): boolean => {
   return !normalized || normalized === 'clickhouse' || MYSQL_DASH_COMMENT_DIALECTS.has(normalized);
 };
 
-const isSqlDashLineCommentStart = (dbType: string, next2: string): boolean => {
+export const isSqlDashLineCommentStart = (dbType: string, next2: string): boolean => {
   const normalized = normalizeSqlLexicalDbType(dbType);
   return !MYSQL_DASH_COMMENT_DIALECTS.has(normalized) || !next2 || isWhitespace(next2);
 };


### PR DESCRIPTION
## 背景

查询编辑器会根据“结果集最大行数”自动为只读查询追加限制语句。对于达梦 DB2 兼容模式，原 SQL 可能以 `WITH UR`、`WITH CS`、`WITH RS` 或 `WITH RR` 结尾；原实现直接在语句末尾追加 `LIMIT`，会生成错误的子句顺序并导致执行失败。

此外，自动限流、AI 只读预览、结果分页和总数统计分别解析 SQL，其中双横线注释统一要求后接空白。该规则只适用于 MySQL 系，导致 PostgreSQL、SQL Server、Oracle、达梦等方言中的 `--LIMIT`、`--ORDER BY` 紧凑注释被误当成可执行 SQL，进而错误判断已有行数限制或裁剪查询。

## 变更

- 按数据库方言识别双横线注释：MySQL 系保留后接空白要求，其余支持的 SQL 方言按标准行注释处理。
- 复用统一的顶层 SQL 扫描逻辑，覆盖自动限流、AI 只读预览、结果分页、导出和总数统计。
- 达梦 DB2 兼容模式下将 `LIMIT/OFFSET` 放在 `WITH UR/CS/RS/RR` 之前，并在翻页和总数查询时保持隔离级别位于最外层。
- 保留用户已有的顶层 `LIMIT/OFFSET`，避免覆盖偏移量；嵌套查询中的限制不再阻止外层自动限流。
- 补充 `GROUP BY/HAVING`、块注释、紧凑行注释、嵌套查询、空结果和达梦隔离级别等回归测试。

## 影响范围

- 查询编辑器的结果集最大行数限制。
- AI 只读 SQL 预览。
- 查询结果分页、全部导出及总数统计。
- 达梦 DB2 兼容模式的查询执行；Oracle 兼容模式原有行为不变。

## 验证

- `npm exec vitest run src/utils/queryAutoLimit.test.ts src/utils/aiSqlLimit.test.ts src/utils/queryResultPagination.test.ts src/utils/sql.test.ts src/utils/sqlStatementSelection.test.ts src/components/QueryEditor.results-and-drop.test.tsx --reporter=dot`：6 个测试文件、283 项测试通过。
- `npm exec tsc -- --noEmit`：通过。
- `npm run build`：通过。
- `wails build -s -skipbindings -trimpath -clean -o GoNavi.exe`：通过。
- `git diff --check origin/dev...HEAD`：通过。

## 风险与回滚

改动仅调整只读查询的客户端 SQL 解析与分页改写，不改变数据库驱动或后端执行接口。已有顶层限制语句仍保持原样，达梦隔离级别仅在识别到合法尾子句时移动到分页语句之后。若出现兼容问题，可直接回滚本 PR 的单个提交，恢复原有限流行为。