### PR TITLE
🐛 fix(database-search): 修复限定表名搜索引用

### DIFF
--- a/frontend/src/components/FindInDatabaseModal.test.tsx
+++ b/frontend/src/components/FindInDatabaseModal.test.tsx
@@ -147,6 +147,7 @@ const renderFindModal = () => {
 
 describe("FindInDatabaseModal i18n", () => {
   beforeEach(() => {
+    mocks.storeState.connections[0].config.type = "mysql";
     mocks.dbQuery.mockReset();
     mocks.dbGetTables.mockReset();
     mocks.dbGetAllColumns.mockReset();
@@ -263,5 +264,71 @@ describe("FindInDatabaseModal i18n", () => {
     expect(mocks.message.error).toHaveBeenCalledWith("Failed to get column summary: metadata permission denied");
     expect(mocks.message.info).not.toHaveBeenCalledWith("No matching data found");
     expect(mocks.dbQuery).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["public.users", "public.users", "FROM public.users"],
+    ['public."audit.log"', "public.audit.log", 'FROM public."audit.log"'],
+    ['public."User""s"', 'public.User"s', 'FROM public."User""s"'],
+    ["Sales.User Accounts", "Sales.User Accounts", 'FROM "Sales"."User Accounts"'],
+  ])("quotes schema-qualified table %s by segment and matches its column metadata", async (tableName, columnTableName, expectedFrom) => {
+    mocks.storeState.connections[0].config.type = "postgres";
+    mocks.dbGetTables.mockResolvedValue({ success: true, data: [{ Table: tableName }] });
+    mocks.dbGetAllColumns.mockResolvedValue({
+      success: true,
+      data: [{ tableName: columnTableName, name: "name", type: "text" }],
+    });
+    mocks.dbQuery.mockResolvedValue({ success: true, data: [] });
+    const renderer = renderFindModal();
+
+    const input = renderer.root.findByType("input");
+    await act(async () => {
+      input.props.onChange({ target: { value: "alice" } });
+    });
+    const searchButton = renderer.root.findAllByType("button").find((button) => textContent(button).includes("Search"));
+
+    await act(async () => {
+      searchButton?.props.onClick();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.dbQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      "app_db",
+      expect.stringContaining(expectedFrom),
+    );
+    if (tableName === "public.users") {
+      expect(mocks.dbQuery.mock.calls[0][2]).not.toContain('FROM "public.users"');
+    }
+  });
+
+  it("keeps dots inside a MySQL single-part table name", async () => {
+    mocks.storeState.connections[0].config.type = "mysql";
+    mocks.dbGetTables.mockResolvedValue({ success: true, data: [{ Table: "audit.log" }] });
+    mocks.dbGetAllColumns.mockResolvedValue({
+      success: true,
+      data: [{ tableName: "audit.log", name: "name", type: "varchar(255)" }],
+    });
+    mocks.dbQuery.mockResolvedValue({ success: true, data: [] });
+    const renderer = renderFindModal();
+
+    const input = renderer.root.findByType("input");
+    await act(async () => {
+      input.props.onChange({ target: { value: "alice" } });
+    });
+    const searchButton = renderer.root.findAllByType("button").find((button) => textContent(button).includes("Search"));
+
+    await act(async () => {
+      searchButton?.props.onClick();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.dbQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      "app_db",
+      expect.stringContaining("FROM `audit.log`"),
+    );
   });
 });

--- a/frontend/src/components/FindInDatabaseModal.tsx
+++ b/frontend/src/components/FindInDatabaseModal.tsx
@@ -3,7 +3,7 @@ import React, { useState, useRef, useCallback, useMemo } from 'react';
 import { Input, Button, Table, Progress, Space, Tag, message, Tooltip, Select, Empty } from 'antd';
 import { SearchOutlined, StopOutlined, EyeOutlined, DatabaseOutlined } from '@ant-design/icons';
 import { DBQuery, DBGetTables, DBGetAllColumns } from '../../wailsjs/go/app/App';
-import { quoteIdentPart, escapeLiteral } from '../utils/sql';
+import { quoteIdentPart, quoteQualifiedIdent, escapeLiteral } from '../utils/sql';
 import { useStore } from '../store';
 import { buildOverlayWorkbenchTheme } from '../utils/overlayWorkbenchTheme';
 import { buildRpcConnectionConfig } from '../utils/connectionRpcConfig';
@@ -11,6 +11,7 @@ import { isMacLikePlatform } from '../utils/appearance';
 import { useI18n } from '../i18n/provider';
 import { normalizeTableNamesFromMetadataRows } from '../utils/tableMetadataRows';
 import { getTableMetadataIssueDetail, isTableMetadataIncomplete } from '../utils/tableMetadataResult';
+import { splitQualifiedNameSegments } from '../utils/qualifiedName';
 
 interface FindInDatabaseModalProps {
     open: boolean;
@@ -60,6 +61,10 @@ const buildLimitedSelectSQL = (dbType: string, baseSql: string, limit: number): 
 };
 
 const MAX_MATCH_ROWS_PER_TABLE = 100;
+
+const getTableMetadataIdentity = (dbType: string, tableName: string): string => (
+    splitQualifiedNameSegments(String(tableName || ''), dbType).join('.')
+);
 
 const FindInDatabaseModal: React.FC<FindInDatabaseModalProps> = ({ open, onClose, connectionId, dbName }) => {
     const { t } = useI18n();
@@ -145,7 +150,7 @@ const FindInDatabaseModal: React.FC<FindInDatabaseModalProps> = ({ open, onClose
 
             const columnsByTable: Record<string, Array<{ name: string; type: string }>> = {};
             allColumns.forEach((col: any) => {
-                const tbl = col.tableName || '';
+                const tbl = getTableMetadataIdentity(dbType, col.tableName || '');
                 if (!columnsByTable[tbl]) columnsByTable[tbl] = [];
                 columnsByTable[tbl].push({ name: col.name, type: col.type || '' });
             });
@@ -159,7 +164,7 @@ const FindInDatabaseModal: React.FC<FindInDatabaseModalProps> = ({ open, onClose
                 const tableName = tableNames[i];
                 setProgress({ current: i + 1, total: tableNames.length, tableName });
 
-                const tableCols = columnsByTable[tableName] || [];
+                const tableCols = columnsByTable[getTableMetadataIdentity(dbType, tableName)] || [];
                 const textCols = tableCols.filter(c => isTextColumnType(c.type));
 
                 if (textCols.length === 0) continue;
@@ -173,7 +178,12 @@ const FindInDatabaseModal: React.FC<FindInDatabaseModalProps> = ({ open, onClose
                     return `CAST(${quotedCol} AS ${castType}) LIKE '%${escapedKeyword}%'`;
                 });
 
-                const quotedTable = quoteIdentPart(dbType, tableName);
+                // MySQL permits a literal dot in an unqualified table name. Keep
+                // the legacy whole-name quoting there; PostgreSQL and other
+                // qualified-name dialects need segment-aware quoting.
+                const quotedTable = dbType.toLowerCase() === 'mysql'
+                    ? quoteIdentPart(dbType, tableName)
+                    : quoteQualifiedIdent(dbType, tableName);
                 const baseSql = `SELECT * FROM ${quotedTable} WHERE ${whereConditions.join(' OR ')}`;
                 const sql = buildLimitedSelectSQL(dbType, baseSql, MAX_MATCH_ROWS_PER_TABLE);
 

--- a/frontend/src/utils/sql.test.ts
+++ b/frontend/src/utils/sql.test.ts
@@ -97,6 +97,15 @@ describe('reverseOrderBySQL', () => {
 });
 
 describe('quoteQualifiedIdent', () => {
+  it.each([
+    ['public.users', 'public.users'],
+    ['"Sales"."User Accounts"', '"Sales"."User Accounts"'],
+    ['"audit.log"', '"audit.log"'],
+    ['"Orders"."User""s"', '"Orders"."User""s"'],
+  ])('quotes PostgreSQL metadata name %s without changing its segments', (input, expected) => {
+    expect(quoteQualifiedIdent('postgres', input)).toBe(expected);
+  });
+
   it('keeps the Apache IoTDB root node bare while quoting child path segments', () => {
     expect(quoteQualifiedIdent('iotdb', 'root.sg.d1'))
       .toBe('root.`sg`.`d1`');


### PR DESCRIPTION
## 问题背景

数据库全库搜索将 PostgreSQL 的 `schema.table` 作为单一标识符引用，生成的 SQL 会把限定表名错误地整体加引号，导致无法查询目标表。特殊表名经表元数据编码后还可能与列元数据无法匹配，从而跳过搜索。

## 修复内容

- 对 PostgreSQL 等限定名场景按标识符段引用表名，并保持列名的单段引用。
- 统一表列表与列元数据的限定名身份键，支持字面点号、双引号、大小写和空格表名。
- 保留 MySQL 单段表名（包括字面点号）的整体引用行为。
- 新增组件和 SQL 工具的回归测试。

## 验证方式

- `npm --prefix frontend test -- --run src/components/FindInDatabaseModal.test.tsx src/utils/sql.test.ts`（41/41 通过）
- `npm --prefix frontend run build`（通过）
- `git diff --check`（通过）
- 子 agent 复审：未发现 Issue #1181 范围内有效 P0/P1/P2 问题。

## 影响与风险

- 仅影响“全库搜索”生成的表名引用及其元数据匹配。
- PostgreSQL 限定表名将按 schema 和表名分别引用；MySQL 保持原有单段表名行为。
- 若需回滚，回退本 PR 的单个提交即可恢复原引用逻辑。

## 关联 Issue

Closes #1181
