### PR TITLE
fix(data-grid): 保留只读 JSON 格式化能力

### DIFF
--- a/frontend/src/components/DataGrid.ddl.test.tsx
+++ b/frontend/src/components/DataGrid.ddl.test.tsx
@@ -2597,6 +2597,58 @@ describe('DataGrid DDL interactions', () => {
     renderer!.unmount();
   });
 
+  it('formats JSON in a protected read-only cell viewer without enabling save', async () => {
+    const compactJson = '{"billType":"YDApp","data":{"items":[{"count":100}]}}';
+    const formattedJson = JSON.stringify(JSON.parse(compactJson), null, 2);
+    const rows = [{ __gonavi_row_key__: 'row-1', id: 1, payload: compactJson }];
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <DataGrid
+          data={rows}
+          columnNames={['id', 'payload']}
+          loading={false}
+          tableName="orders"
+          dbName="main"
+          connectionId="conn-1"
+          pkColumns={['id']}
+          readOnly
+        />,
+      );
+    });
+    await waitForEffects();
+
+    const doubleClickSurface = renderer!.root.findAll(
+      (node) => typeof node.props.onDoubleClickCapture === 'function',
+    )[0];
+    await act(async () => {
+      doubleClickSurface.props.onDoubleClickCapture({
+        target: createRenderedCellTarget('row-1', 'payload'),
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      });
+    });
+
+    const viewer = renderer!.root.findByProps({
+      'data-modal-title': t('data_grid.cell_viewer.title_with_column', { column: 'payload' }),
+    });
+    const formatButton = viewer.findByProps({ 'data-grid-cell-editor-format': 'true' });
+    expect(viewer.findByProps({ 'data-monaco-editor': 'true' }).props['data-read-only']).toBe('true');
+    expect(viewer.findByProps({ 'data-grid-cell-editor-compact-json': 'true' })).toBeTruthy();
+    expect(viewer.findAllByProps({ 'data-grid-cell-editor-escape': 'true' })).toHaveLength(0);
+    expect(viewer.findAllByProps({ 'data-grid-cell-editor-unescape': 'true' })).toHaveLength(0);
+    expect(viewer.findAll((node) => node.type === 'button' && textContent(node).includes(t('common.save')))).toHaveLength(0);
+
+    await act(async () => {
+      formatButton.props.onClick();
+    });
+
+    expect(textContent(viewer.findByProps({ 'data-monaco-editor': 'true' }))).toBe(formattedJson);
+    expect(testRenderState.latestTableProps.dataSource[0].payload).toBe(compactJson);
+    renderer!.unmount();
+  });
+
   it('formats a writable JSON cell from the toolbar before saving the draft', async () => {
 
     const compactJson = '{"billType":"YDApp","data":{"items":[{"count":100}]}}';

--- a/frontend/src/components/DataGridModals.tsx
+++ b/frontend/src/components/DataGridModals.tsx
@@ -242,36 +242,36 @@ const DataGridModals: React.FC<DataGridModalsProps> = ({
           {cellEditorMeta ? `${tableName || ''}${tableName ? '.' : ''}${cellEditorMeta.dataIndex}` : ''}
         </span>
         <span style={{ flex: 1 }} />
+        {cellEditorIsJson && (
+          <>
+            <Tooltip title={translate('data_grid.json_editor.format')}>
+              <Button
+                data-grid-cell-editor-format="true"
+                size="small"
+                icon={<FormatPainterOutlined aria-hidden="true" />}
+                aria-label={translate('data_grid.json_editor.format')}
+                disabled={cellEditorEscapeApplied}
+                onClick={onFormatJsonInEditor}
+              >
+                {translate('data_grid.json_editor.format')}
+              </Button>
+            </Tooltip>
+            <Tooltip title={translate('data_grid.json_editor.compact')}>
+              <Button
+                data-grid-cell-editor-compact-json="true"
+                size="small"
+                icon={<CompressOutlined aria-hidden="true" />}
+                aria-label={translate('data_grid.json_editor.compact')}
+                disabled={cellEditorEscapeApplied}
+                onClick={onCompactJsonInEditor}
+              >
+                {translate('data_grid.json_editor.compact')}
+              </Button>
+            </Tooltip>
+          </>
+        )}
         {!cellEditorReadOnly && (
           <>
-            {cellEditorIsJson && (
-              <>
-                <Tooltip title={translate('data_grid.json_editor.format')}>
-                  <Button
-                    data-grid-cell-editor-format="true"
-                    size="small"
-                    icon={<FormatPainterOutlined aria-hidden="true" />}
-                    aria-label={translate('data_grid.json_editor.format')}
-                    disabled={cellEditorEscapeApplied}
-                    onClick={onFormatJsonInEditor}
-                  >
-                    {translate('data_grid.json_editor.format')}
-                  </Button>
-                </Tooltip>
-                <Tooltip title={translate('data_grid.json_editor.compact')}>
-                  <Button
-                    data-grid-cell-editor-compact-json="true"
-                    size="small"
-                    icon={<CompressOutlined aria-hidden="true" />}
-                    aria-label={translate('data_grid.json_editor.compact')}
-                    disabled={cellEditorEscapeApplied}
-                    onClick={onCompactJsonInEditor}
-                  >
-                    {translate('data_grid.json_editor.compact')}
-                  </Button>
-                </Tooltip>
-              </>
-            )}
             <Tooltip title={translate('data_grid.cell_editor.escape')}>
               <Button
                 data-grid-cell-editor-escape="true"


### PR DESCRIPTION
## 背景

Fixes #1201

MySQL JSON 单元格已支持格式化查看，但启用生产环境保护后，结果集进入只读模式，JSON 格式化和压缩按钮也被写权限条件一并隐藏。生产保护应阻止数据保存，不应限制只读查看时的展示优化。

## 变更

- 只读 JSON 单元格查看器保留格式化与压缩按钮。
- JSON 展示变换仅更新弹窗内文本，不修改结果行数据。
- 生产环境保护下继续保持 Monaco 只读并隐藏保存入口。
- 转义、反转义等编辑操作仍仅对可写单元格开放。
- 增加生产保护等价的只读 JSON 交互回归测试。

## 影响范围

- DataGrid JSON 单元格查看器工具栏。
- 生产环境保护、只读查询结果及不可写字段的查看体验。

## 验证

- DataGrid、布局与生产保护能力相关 Vitest：181 项通过。
- rebase 最新 dev 后 DataGrid 核心 Vitest：93 项通过。
- `npm exec tsc -- --noEmit`：通过。
- Vite 完整构建：通过。
- `git diff --check origin/dev...HEAD`：通过。

## 风险与回滚

改动只开放本地 JSON 展示格式化，不改变 DataGrid 写权限、保存处理器或数据库请求。若出现查看器行为异常，可直接回滚本 PR 的 squash commit。