### PR TITLE
fix(sqlite): mark all composite primary key columns as PRI

### DIFF
--- a/internal/db/sqlite_autoincrement_test.go
+++ b/internal/db/sqlite_autoincrement_test.go
@@ -44,6 +44,24 @@ func TestApplySQLiteAutoIncrement(t *testing.T) {
 		}
 	}
 
+	// 即便 DDL 文本碰巧匹配 AUTOINCREMENT，只要 PRI 列多于 1 列就不得打自增标记。
+	guarded := []connection.ColumnDefinition{
+		{Name: "a", Type: "INTEGER", Key: "PRI"},
+		{Name: "b", Type: "INTEGER", Key: "PRI"},
+	}
+	applySQLiteAutoIncrement(guarded, "CREATE TABLE t (a INTEGER PRIMARY KEY AUTOINCREMENT, b INTEGER)")
+	for _, col := range guarded {
+		if col.Extra != "" {
+			t.Fatalf("复合主键列数守卫失效: %s=%q", col.Name, col.Extra)
+		}
+	}
+
+	noPK := []connection.ColumnDefinition{{Name: "id", Type: "INTEGER"}}
+	applySQLiteAutoIncrement(noPK, "CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT)")
+	if noPK[0].Extra != "" {
+		t.Fatalf("无 PRI 列不应标记自增: %q", noPK[0].Extra)
+	}
+
 	// 空 DDL（虚拟表等拿不到建表 SQL 的场景）必须原样返回。
 	untouched := []connection.ColumnDefinition{{Name: "id", Type: "INTEGER", Key: "PRI"}}
 	applySQLiteAutoIncrement(untouched, "")

--- a/internal/db/sqlite_columns_test.go
+++ b/internal/db/sqlite_columns_test.go
@@ -1,0 +1,394 @@
+//go:build gonavi_full_drivers || gonavi_sqlite_driver
+
+package db
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"GoNavi-Wails/internal/connection"
+)
+
+func TestSQLiteGetColumnsMarksCompositePrimaryKeyMembers(t *testing.T) {
+	client := &SQLiteDB{}
+	if err := client.Connect(connection.ConnectionConfig{Type: "sqlite", Host: ":memory:"}); err != nil {
+		t.Fatalf("连接 SQLite 失败: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	if _, err := client.conn.Exec(`CREATE TABLE composite_pk (a INTEGER NOT NULL, b INTEGER NOT NULL, c TEXT, PRIMARY KEY(a, b))`); err != nil {
+		t.Fatalf("创建复合主键表失败: %v", err)
+	}
+
+	columns, err := client.GetColumns("main", "composite_pk")
+	if err != nil {
+		t.Fatalf("GetColumns 失败: %v", err)
+	}
+	got := map[string]string{}
+	for _, col := range columns {
+		got[col.Name] = col.Key
+		if col.Extra != "" {
+			t.Fatalf("复合主键列不应标记自增: %+v", col)
+		}
+	}
+	if got["a"] != "PRI" || got["b"] != "PRI" {
+		t.Fatalf("PRIMARY KEY(a,b) 两列均应标记 PRI，实际=%v", got)
+	}
+	if got["c"] != "" {
+		t.Fatalf("非主键列不应标记 PRI: %q", got["c"])
+	}
+}
+
+func TestSQLiteGetColumnsPreservesPrimaryKeyOrdinal(t *testing.T) {
+	client := &SQLiteDB{}
+	if err := client.Connect(connection.ConnectionConfig{Type: "sqlite", Host: ":memory:"}); err != nil {
+		t.Fatalf("连接 SQLite 失败: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	// 列声明顺序与主键序号不同：b 在前但 PRIMARY KEY(a,b)。
+	if _, err := client.conn.Exec(`CREATE TABLE ordinal_pk (b INTEGER NOT NULL, a INTEGER NOT NULL, PRIMARY KEY(a, b))`); err != nil {
+		t.Fatalf("创建错序复合主键表失败: %v", err)
+	}
+
+	columns, err := client.GetColumns("main", "ordinal_pk")
+	if err != nil {
+		t.Fatalf("GetColumns 失败: %v", err)
+	}
+	if len(columns) != 2 || columns[0].Name != "b" || columns[1].Name != "a" {
+		t.Fatalf("列顺序应保持声明顺序，实际=%#v", columns)
+	}
+	if columns[0].Key != "PRI" || columns[1].Key != "PRI" {
+		t.Fatalf("错序复合主键两列均应标记 PRI: %#v", columns)
+	}
+
+	data, _, err := client.Query("PRAGMA table_info('ordinal_pk')")
+	if err != nil {
+		t.Fatalf("PRAGMA table_info 失败: %v", err)
+	}
+	_, pkNames := sqliteTableInfoColumns(data)
+	if !reflect.DeepEqual(pkNames, []string{"a", "b"}) {
+		t.Fatalf("主键序号应为 [a b]，实际=%#v", pkNames)
+	}
+}
+
+func TestSQLiteGetColumnsMarksSingleColumnPrimaryAndAutoIncrement(t *testing.T) {
+	client := &SQLiteDB{}
+	if err := client.Connect(connection.ConnectionConfig{Type: "sqlite", Host: ":memory:"}); err != nil {
+		t.Fatalf("连接 SQLite 失败: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	if _, err := client.conn.Exec(`CREATE TABLE plain_pk (id INTEGER PRIMARY KEY, name TEXT)`); err != nil {
+		t.Fatalf("创建单列主键表失败: %v", err)
+	}
+	if _, err := client.conn.Exec(`CREATE TABLE auto_pk (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)`); err != nil {
+		t.Fatalf("创建 AUTOINCREMENT 表失败: %v", err)
+	}
+
+	plain, err := client.GetColumns("main", "plain_pk")
+	if err != nil {
+		t.Fatalf("GetColumns(plain_pk) 失败: %v", err)
+	}
+	if len(plain) != 2 || plain[0].Name != "id" || plain[0].Key != "PRI" || plain[0].Extra != "" {
+		t.Fatalf("单列主键应标记 PRI 且无自增: %#v", plain)
+	}
+	if plain[1].Key != "" || plain[1].Extra != "" {
+		t.Fatalf("非主键列不应带 PRI/自增: %#v", plain[1])
+	}
+
+	autoCols, err := client.GetColumnsContext(nil, "main", "auto_pk")
+	if err != nil {
+		t.Fatalf("GetColumnsContext(auto_pk) 失败: %v", err)
+	}
+	if len(autoCols) != 2 || autoCols[0].Name != "id" || autoCols[0].Key != "PRI" || autoCols[0].Extra != "auto_increment" {
+		t.Fatalf("AUTOINCREMENT 主键应标记 PRI+auto_increment: %#v", autoCols)
+	}
+	if autoCols[1].Extra != "" {
+		t.Fatalf("非主键列不应标记自增: %#v", autoCols[1])
+	}
+}
+
+func TestSQLiteTableInfoColumnsCoversPragmaValueShapes(t *testing.T) {
+	t.Parallel()
+
+	columns, pkNames := sqliteTableInfoColumns([]map[string]interface{}{
+		{
+			"name":       "b",
+			"type":       "INTEGER",
+			"notnull":    int(1),
+			"pk":         int64(2),
+			"dflt_value": nil,
+		},
+		{
+			"NAME":       "a",
+			"TYPE":       "INTEGER",
+			"NOTNULL":    "1",
+			"PK":         " 1 ",
+			"DFLT_VALUE": 0,
+		},
+		{
+			"name":       "note",
+			"type":       "TEXT",
+			"notnull":    float64(0),
+			"pk":         uint(0),
+			"dflt_value": "x",
+		},
+		{
+			"name": "orphan",
+		},
+	})
+
+	if len(columns) != 4 {
+		t.Fatalf("unexpected column count: %d", len(columns))
+	}
+	if columns[0].Name != "b" || columns[0].Type != "INTEGER" || columns[0].Nullable != "NO" || columns[0].Key != "PRI" {
+		t.Fatalf("first PK member = %+v", columns[0])
+	}
+	if columns[1].Name != "a" || columns[1].Type != "INTEGER" || columns[1].Nullable != "NO" || columns[1].Key != "PRI" {
+		t.Fatalf("second PK member = %+v", columns[1])
+	}
+	if columns[1].Default == nil || *columns[1].Default != "0" {
+		t.Fatalf("uppercase default = %#v", columns[1].Default)
+	}
+	if columns[2].Name != "note" || columns[2].Nullable != "YES" || columns[2].Key != "" {
+		t.Fatalf("non-key column = %+v", columns[2])
+	}
+	if columns[2].Default == nil || *columns[2].Default != "x" {
+		t.Fatalf("lowercase default = %#v", columns[2].Default)
+	}
+	if columns[3].Name != "orphan" || columns[3].Type != "" || columns[3].Nullable != "YES" || columns[3].Key != "" || columns[3].Default != nil {
+		t.Fatalf("missing-field column = %+v", columns[3])
+	}
+	if !reflect.DeepEqual(pkNames, []string{"a", "b"}) {
+		t.Fatalf("pk ordinal names = %#v, want [a b]", pkNames)
+	}
+	if columns[0].Default != nil {
+		t.Fatalf("nil default should stay unset, got %v", *columns[0].Default)
+	}
+}
+
+func TestSQLiteGetColumnsRequiresOpenConnection(t *testing.T) {
+	_, err := (&SQLiteDB{}).GetColumns("main", "orders")
+	if err == nil || !strings.Contains(err.Error(), "连接未打开") {
+		t.Fatalf("未打开连接应失败，实际=%v", err)
+	}
+}
+
+type sqliteColumnsScenarioDriver struct{}
+
+type sqliteColumnsScenarioConn struct {
+	scenario string
+}
+
+type sqliteColumnsScenarioStmt struct {
+	scenario string
+	query    string
+}
+
+type sqliteColumnsScenarioRows struct {
+	columns []string
+	values  [][]driver.Value
+	index   int
+}
+
+var registerSQLiteColumnsScenarioDriverOnce sync.Once
+
+func (sqliteColumnsScenarioDriver) Open(name string) (driver.Conn, error) {
+	return sqliteColumnsScenarioConn{scenario: name}, nil
+}
+
+func (c sqliteColumnsScenarioConn) Prepare(query string) (driver.Stmt, error) {
+	return sqliteColumnsScenarioStmt{scenario: c.scenario, query: query}, nil
+}
+
+func (sqliteColumnsScenarioConn) Close() error { return nil }
+
+func (sqliteColumnsScenarioConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("not supported")
+}
+
+func (sqliteColumnsScenarioStmt) Close() error { return nil }
+
+func (sqliteColumnsScenarioStmt) NumInput() int { return -1 }
+
+func (sqliteColumnsScenarioStmt) Exec(args []driver.Value) (driver.Result, error) {
+	return driver.RowsAffected(0), nil
+}
+
+func (s sqliteColumnsScenarioStmt) Query(args []driver.Value) (driver.Rows, error) {
+	isTableInfo := strings.Contains(s.query, "table_info(")
+	isDDL := strings.Contains(s.query, "sqlite_master")
+	switch s.scenario {
+	case "pragma_error":
+		if isTableInfo {
+			return nil, errors.New("pragma failed")
+		}
+	case "ddl_error":
+		if isTableInfo {
+			return sqliteCompositeTableInfoRows(), nil
+		}
+		if isDDL {
+			return nil, errors.New("sqlite_master failed")
+		}
+	case "ddl_empty":
+		if isTableInfo {
+			return sqliteCompositeTableInfoRows(), nil
+		}
+		if isDDL {
+			return &sqliteColumnsScenarioRows{columns: []string{"sql"}}, nil
+		}
+	case "ddl_nil_sql":
+		if isTableInfo {
+			return sqliteCompositeTableInfoRows(), nil
+		}
+		if isDDL {
+			return &sqliteColumnsScenarioRows{
+				columns: []string{"sql"},
+				values:  [][]driver.Value{{nil}},
+			}, nil
+		}
+	case "ddl_missing_sql":
+		if isTableInfo {
+			return sqliteCompositeTableInfoRows(), nil
+		}
+		if isDDL {
+			return &sqliteColumnsScenarioRows{
+				columns: []string{"name"},
+				values:  [][]driver.Value{{"composite_pk"}},
+			}, nil
+		}
+	case "uppercase_composite":
+		if isTableInfo {
+			return &sqliteColumnsScenarioRows{
+				columns: []string{"CID", "NAME", "TYPE", "NOTNULL", "DFLT_VALUE", "PK"},
+				values: [][]driver.Value{
+					{int64(0), "a", "INTEGER", int64(1), nil, int64(1)},
+					{int64(1), "b", "INTEGER", int64(1), "7", int64(2)},
+				},
+			}, nil
+		}
+		if isDDL {
+			return &sqliteColumnsScenarioRows{
+				columns: []string{"sql"},
+				values:  [][]driver.Value{{"CREATE TABLE composite_pk (a INTEGER, b INTEGER, PRIMARY KEY(a, b))"}},
+			}, nil
+		}
+	default:
+		return nil, errors.New("unexpected columns scenario")
+	}
+	return nil, errors.New("unexpected metadata query")
+}
+
+func sqliteCompositeTableInfoRows() *sqliteColumnsScenarioRows {
+	return &sqliteColumnsScenarioRows{
+		columns: []string{"cid", "name", "type", "notnull", "dflt_value", "pk"},
+		values: [][]driver.Value{
+			{int64(0), "a", "INTEGER", int64(1), nil, int64(1)},
+			{int64(1), "b", "INTEGER", int64(1), nil, int64(2)},
+		},
+	}
+}
+
+func (r *sqliteColumnsScenarioRows) Columns() []string { return r.columns }
+
+func (r *sqliteColumnsScenarioRows) Close() error { return nil }
+
+func (r *sqliteColumnsScenarioRows) Next(dest []driver.Value) error {
+	if r.index >= len(r.values) {
+		return io.EOF
+	}
+	copy(dest, r.values[r.index])
+	r.index++
+	return nil
+}
+
+func openSQLiteColumnsScenarioDB(t *testing.T, scenario string) *sql.DB {
+	t.Helper()
+	registerSQLiteColumnsScenarioDriverOnce.Do(func() {
+		sql.Register("sqlite_columns_scenario", sqliteColumnsScenarioDriver{})
+	})
+	conn, err := sql.Open("sqlite_columns_scenario", scenario)
+	if err != nil {
+		t.Fatalf("open sqlite_columns_scenario %s: %v", scenario, err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func TestSQLiteGetColumnsContextHandlesTableInfoAndDDLLookups(t *testing.T) {
+	t.Run("pragma error", func(t *testing.T) {
+		database := &SQLiteDB{conn: openSQLiteColumnsScenarioDB(t, "pragma_error")}
+		_, err := database.GetColumns("main", "composite_pk")
+		if err == nil || !strings.Contains(err.Error(), "pragma failed") {
+			t.Fatalf("expected pragma error, got %v", err)
+		}
+	})
+
+	t.Run("ddl lookup error keeps columns", func(t *testing.T) {
+		database := &SQLiteDB{conn: openSQLiteColumnsScenarioDB(t, "ddl_error")}
+		columns, err := database.GetColumns("main", "composite_pk")
+		if err != nil {
+			t.Fatalf("DDL 失败应跳过，实际=%v", err)
+		}
+		assertCompositePRI(t, columns)
+	})
+
+	t.Run("empty ddl rows", func(t *testing.T) {
+		database := &SQLiteDB{conn: openSQLiteColumnsScenarioDB(t, "ddl_empty")}
+		columns, err := database.GetColumns("main", "composite_pk")
+		if err != nil {
+			t.Fatalf("空 DDL 应跳过，实际=%v", err)
+		}
+		assertCompositePRI(t, columns)
+	})
+
+	t.Run("nil ddl sql", func(t *testing.T) {
+		database := &SQLiteDB{conn: openSQLiteColumnsScenarioDB(t, "ddl_nil_sql")}
+		columns, err := database.GetColumns("main", "composite_pk")
+		if err != nil {
+			t.Fatalf("nil DDL 应跳过，实际=%v", err)
+		}
+		assertCompositePRI(t, columns)
+	})
+
+	t.Run("missing ddl sql column", func(t *testing.T) {
+		database := &SQLiteDB{conn: openSQLiteColumnsScenarioDB(t, "ddl_missing_sql")}
+		columns, err := database.GetColumns("main", "composite_pk")
+		if err != nil {
+			t.Fatalf("缺少 sql 列应跳过，实际=%v", err)
+		}
+		assertCompositePRI(t, columns)
+	})
+
+	t.Run("uppercase pragma keys", func(t *testing.T) {
+		database := &SQLiteDB{conn: openSQLiteColumnsScenarioDB(t, "uppercase_composite")}
+		columns, err := database.GetColumnsContext(context.Background(), "main", "composite_pk")
+		if err != nil {
+			t.Fatalf("uppercase GetColumnsContext 失败: %v", err)
+		}
+		assertCompositePRI(t, columns)
+		if columns[1].Default == nil || *columns[1].Default != "7" {
+			t.Fatalf("uppercase default 未保留: %#v", columns[1].Default)
+		}
+	})
+}
+
+func assertCompositePRI(t *testing.T, columns []connection.ColumnDefinition) {
+	t.Helper()
+	if len(columns) != 2 || columns[0].Name != "a" || columns[0].Key != "PRI" || columns[1].Name != "b" || columns[1].Key != "PRI" {
+		t.Fatalf("expected composite PRI columns, got %#v", columns)
+	}
+	for _, col := range columns {
+		if col.Extra != "" {
+			t.Fatalf("composite PK must not be auto_increment: %+v", col)
+		}
+	}
+}

--- a/internal/db/sqlite_impl.go
+++ b/internal/db/sqlite_impl.go
@@ -340,49 +340,74 @@ func (s *SQLiteDB) getColumnsContext(ctx context.Context, dbName, tableName stri
 		return nil, err
 	}
 
-	parseInt := func(v interface{}) int {
-		switch val := v.(type) {
-		case int:
-			return val
-		case int64:
-			return int(val)
-		case float64:
-			return int(val)
-		case string:
-			var n int
-			_, _ = fmt.Sscanf(strings.TrimSpace(val), "%d", &n)
-			return n
-		default:
-			var n int
-			_, _ = fmt.Sscanf(strings.TrimSpace(fmt.Sprintf("%v", v)), "%d", &n)
-			return n
+	columns, _ := sqliteTableInfoColumns(data)
+
+	// PRAGMA table_info 不回显 AUTOINCREMENT，只能从建表 SQL 识别；
+	// 拿不到 DDL（虚拟表/异常）时静默跳过，不影响其余元数据。
+	tableDDL := ""
+	ddlRows, _, ddlErr := s.QueryContext(ctx, fmt.Sprintf("SELECT sql FROM sqlite_master WHERE type='table' AND name='%s'", escapeSQLiteStringLiteral(table)))
+	if ddlErr == nil && len(ddlRows) > 0 {
+		if val, ok := ddlRows[0]["sql"]; ok && val != nil {
+			tableDDL = fmt.Sprintf("%v", val)
 		}
 	}
+	return applySQLiteAutoIncrement(columns, tableDDL), nil
+}
 
-	getStr := func(row map[string]interface{}, key string) string {
-		if v, ok := row[key]; ok && v != nil {
-			return fmt.Sprintf("%v", v)
-		}
-		if v, ok := row[strings.ToUpper(key)]; ok && v != nil {
-			return fmt.Sprintf("%v", v)
-		}
-		return ""
+func sqliteTableInfoParseInt(v interface{}) int {
+	switch val := v.(type) {
+	case int:
+		return val
+	case int64:
+		return int(val)
+	case float64:
+		return int(val)
+	case string:
+		var n int
+		_, _ = fmt.Sscanf(strings.TrimSpace(val), "%d", &n)
+		return n
+	default:
+		var n int
+		_, _ = fmt.Sscanf(strings.TrimSpace(fmt.Sprintf("%v", v)), "%d", &n)
+		return n
 	}
+}
 
-	var columns []connection.ColumnDefinition
+func sqliteTableInfoRowString(row map[string]interface{}, key string) string {
+	if v, ok := row[key]; ok && v != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	if v, ok := row[strings.ToUpper(key)]; ok && v != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return ""
+}
+
+// sqliteTableInfoColumns 把 PRAGMA table_info 行转成列定义。
+// pk 是主键内 1-based 序号（非主键为 0），复合主键后续列为 2、3…，
+// 必须按 pk>0 标记 PRI，而不能把 pk==1 当成布尔值。
+// 返回的列保持 table_info 的 cid 顺序；pkNames 按主键序号排列，
+// 供需要 PRIMARY KEY(a,b) 列顺序的调用方使用。
+func sqliteTableInfoColumns(data []map[string]interface{}) (columns []connection.ColumnDefinition, pkNames []string) {
+	type columnWithPK struct {
+		col connection.ColumnDefinition
+		pk  int
+	}
+	parsed := make([]columnWithPK, 0, len(data))
+	maxPK := 0
 	for _, row := range data {
 		notnull := 0
 		if v, ok := row["notnull"]; ok && v != nil {
-			notnull = parseInt(v)
+			notnull = sqliteTableInfoParseInt(v)
 		} else if v, ok := row["NOTNULL"]; ok && v != nil {
-			notnull = parseInt(v)
+			notnull = sqliteTableInfoParseInt(v)
 		}
 
 		pk := 0
 		if v, ok := row["pk"]; ok && v != nil {
-			pk = parseInt(v)
+			pk = sqliteTableInfoParseInt(v)
 		} else if v, ok := row["PK"]; ok && v != nil {
-			pk = parseInt(v)
+			pk = sqliteTableInfoParseInt(v)
 		}
 
 		nullable := "YES"
@@ -391,13 +416,13 @@ func (s *SQLiteDB) getColumnsContext(ctx context.Context, dbName, tableName stri
 		}
 
 		key := ""
-		if pk == 1 {
+		if pk > 0 {
 			key = "PRI"
 		}
 
 		col := connection.ColumnDefinition{
-			Name:     getStr(row, "name"),
-			Type:     getStr(row, "type"),
+			Name:     sqliteTableInfoRowString(row, "name"),
+			Type:     sqliteTableInfoRowString(row, "type"),
 			Nullable: nullable,
 			Key:      key,
 			Extra:    "",
@@ -412,19 +437,21 @@ func (s *SQLiteDB) getColumnsContext(ctx context.Context, dbName, tableName stri
 			col.Default = &def
 		}
 
-		columns = append(columns, col)
-	}
-
-	// PRAGMA table_info 不回显 AUTOINCREMENT，只能从建表 SQL 识别；
-	// 拿不到 DDL（虚拟表/异常）时静默跳过，不影响其余元数据。
-	tableDDL := ""
-	ddlRows, _, ddlErr := s.QueryContext(ctx, fmt.Sprintf("SELECT sql FROM sqlite_master WHERE type='table' AND name='%s'", escapeSQLiteStringLiteral(table)))
-	if ddlErr == nil && len(ddlRows) > 0 {
-		if val, ok := ddlRows[0]["sql"]; ok && val != nil {
-			tableDDL = fmt.Sprintf("%v", val)
+		parsed = append(parsed, columnWithPK{col: col, pk: pk})
+		if pk > maxPK {
+			maxPK = pk
 		}
 	}
-	return applySQLiteAutoIncrement(columns, tableDDL), nil
+
+	columns = make([]connection.ColumnDefinition, len(parsed))
+	pkNames = make([]string, maxPK)
+	for i, item := range parsed {
+		columns[i] = item.col
+		if item.pk > 0 {
+			pkNames[item.pk-1] = item.col.Name
+		}
+	}
+	return columns, pkNames
 }
 
 // applySQLiteAutoIncrement 给 AUTOINCREMENT 主键列打上 auto_increment 标记，

--- a/internal/sync/source_query_sync_test.go
+++ b/internal/sync/source_query_sync_test.go
@@ -310,6 +310,36 @@ func TestResolvePKColumnsUsesCurrentLanguageForQueryDiffErrors(t *testing.T) {
 			t.Fatalf("resolvePKColumns() = %#v, want %#v", keys, want)
 		}
 	})
+
+	t.Run("sqlite composite primary key includes every PRI member", func(t *testing.T) {
+		// Mirrors SQLite GetColumns for PRIMARY KEY(a,b): every pk>0 column is PRI.
+		keys, err := resolvePKColumns([]connection.ColumnDefinition{
+			{Name: "name", Type: "TEXT"},
+			{Name: "a", Type: "INTEGER", Nullable: "NO", Key: "PRI"},
+			{Name: "b", Type: "INTEGER", Nullable: "NO", Key: "PRI"},
+		})
+		if err != nil {
+			t.Fatalf("resolvePKColumns() error = %v", err)
+		}
+		want := []string{"a", "b"}
+		if !reflect.DeepEqual(keys, want) {
+			t.Fatalf("resolvePKColumns() = %#v, want %#v", keys, want)
+		}
+	})
+
+	t.Run("PK key alias is treated as primary", func(t *testing.T) {
+		keys, err := resolvePKColumns([]connection.ColumnDefinition{
+			{Name: "a", Type: "INTEGER", Key: "PK"},
+			{Name: "b", Type: "INTEGER", Key: "PRI"},
+		})
+		if err != nil {
+			t.Fatalf("resolvePKColumns() error = %v", err)
+		}
+		want := []string{"a", "b"}
+		if !reflect.DeepEqual(keys, want) {
+			t.Fatalf("resolvePKColumns() = %#v, want %#v", keys, want)
+		}
+	})
 }
 
 func TestLoadSourceQuerySyncContextUsesCurrentLanguageForStructuredErrors(t *testing.T) {


### PR DESCRIPTION
Fixes Syngnat/GoNavi#1194

## What changed

SQLite `PRAGMA table_info` exposes `pk` as a 1-based ordinal within the primary key (0 = not a key member). `getColumnsContext` treated it as a boolean and only marked `pk == 1` as `PRI`, so `PRIMARY KEY(a,b)` returned `a=PRI` and `b` empty.

- Mark every column with `pk > 0` as `PRI`.
- Keep table/cid order for `GetColumns`; return PK member names ordered by that ordinal for callers that need `PRIMARY KEY(a,b)` column order.
- Leave the AUTOINCREMENT guard unchanged: `auto_increment` is applied only when the DDL has a real single-column `PRIMARY KEY … AUTOINCREMENT` sequence **and** exactly one `PRI` column.

Sync key resolution (`resolvePKColumns`) already collected every `PRI`/`PK` column; with GetColumns fixed it now sees the full composite key.

## Test results

```
go test -tags gonavi_sqlite_driver ./internal/db -run 'SQLite' -count=1
ok  	GoNavi-Wails/internal/db	0.266s

go test ./internal/sync -run 'ResolvePKColumns' -count=1
ok  	GoNavi-Wails/internal/sync	0.177s
```

## Coverage of changed code

`go test -tags gonavi_sqlite_driver ./internal/db -run 'SQLite' -count=1 -coverprofile=... -covermode=count`

| Function | Coverage |
| --- | --- |
| `sqlite_impl.go:GetColumns` | 100.0% |
| `sqlite_impl.go:GetColumnsContext` | 100.0% |
| `sqlite_impl.go:getColumnsContext` | 100.0% |
| `sqlite_impl.go:sqliteTableInfoParseInt` | 100.0% |
| `sqlite_impl.go:sqliteTableInfoRowString` | 100.0% |
| `sqlite_impl.go:sqliteTableInfoColumns` | 100.0% |
| `sqlite_impl.go:applySQLiteAutoIncrement` | 100.0% |

`go test ./internal/sync -run 'ResolvePKColumns' -count=1 -coverprofile=...`

| Function | Coverage |
| --- | --- |
| `source_query_sync.go:resolvePKColumns` | 100.0% |
