### PR TITLE
🐛 fix(iotdb): GetObject 错误不再静默写成 NULL

### DIFF
--- a/internal/db/iotdb_impl.go
+++ b/internal/db/iotdb_impl.go
@@ -556,8 +556,7 @@ func scanIoTDBDataSet(ds iotdbDataSet) ([]map[string]interface{}, []string, erro
 			}
 			value, err := ds.GetObject(column)
 			if err != nil {
-				row[column] = nil
-				continue
+				return nil, nil, fmt.Errorf("读取 IoTDB 列 %q 失败：%w", column, err)
 			}
 			row[column] = normalizeIoTDBValue(value)
 		}

--- a/internal/db/iotdb_impl_test.go
+++ b/internal/db/iotdb_impl_test.go
@@ -22,6 +22,9 @@ type fakeIoTDBSession struct {
 	queryResults  map[string][]map[string]interface{}
 	execs         []string
 	queryTimeouts []int64
+	getObjectErrs map[string]error
+	isNullErrs    map[string]error
+	nextErr       error
 }
 
 func (f *fakeIoTDBSession) Close() error { return nil }
@@ -33,7 +36,13 @@ func (f *fakeIoTDBSession) Query(_ context.Context, sql string, timeoutMs *int64
 	}
 	f.queryTimeouts = append(f.queryTimeouts, timeout)
 	rows := f.queryResults[sql]
-	return &fakeIoTDBDataSet{rows: rows, columns: fakeIoTDBColumns(rows)}, nil
+	return &fakeIoTDBDataSet{
+		rows:          rows,
+		columns:       fakeIoTDBColumns(rows),
+		getObjectErrs: f.getObjectErrs,
+		isNullErrs:    f.isNullErrs,
+		nextErr:       f.nextErr,
+	}, nil
 }
 
 func (f *fakeIoTDBSession) Exec(_ context.Context, sql string) error {
@@ -42,12 +51,18 @@ func (f *fakeIoTDBSession) Exec(_ context.Context, sql string) error {
 }
 
 type fakeIoTDBDataSet struct {
-	rows    []map[string]interface{}
-	columns []string
-	index   int
+	rows          []map[string]interface{}
+	columns       []string
+	index         int
+	getObjectErrs map[string]error
+	isNullErrs    map[string]error
+	nextErr       error
 }
 
 func (f *fakeIoTDBDataSet) Next() (bool, error) {
+	if f.nextErr != nil {
+		return false, f.nextErr
+	}
 	if f.index >= len(f.rows) {
 		return false, nil
 	}
@@ -58,11 +73,17 @@ func (f *fakeIoTDBDataSet) Next() (bool, error) {
 func (f *fakeIoTDBDataSet) Close() error { return nil }
 
 func (f *fakeIoTDBDataSet) IsNull(columnName string) (bool, error) {
+	if err := f.isNullErrs[columnName]; err != nil {
+		return false, err
+	}
 	value, ok := f.currentRow()[columnName]
 	return !ok || value == nil, nil
 }
 
 func (f *fakeIoTDBDataSet) GetObject(columnName string) (interface{}, error) {
+	if err := f.getObjectErrs[columnName]; err != nil {
+		return nil, err
+	}
 	return f.currentRow()[columnName], nil
 }
 
@@ -331,5 +352,103 @@ func TestIoTDBLiveSmoke(t *testing.T) {
 	}
 	if got := rows[0]["root.gonavi_smoke.d1.status"]; got != "ok" {
 		t.Fatalf("unexpected status value: %#v rows=%#v columns=%#v", got, rows, columns)
+	}
+}
+
+func TestIoTDBQueryFailsWhenGetObjectReturnsError(t *testing.T) {
+	decodeErr := errors.New("decode failed")
+	session := &fakeIoTDBSession{
+		queryResults: map[string][]map[string]interface{}{
+			"SELECT temperature, status FROM root.sg.d1": {
+				{"temperature": 21.5, "status": "ok"},
+			},
+		},
+		getObjectErrs: map[string]error{
+			"status": decodeErr,
+		},
+	}
+	client := &IoTDBDB{session: session}
+
+	rows, columns, err := client.Query("SELECT temperature, status FROM root.sg.d1")
+	if err == nil {
+		t.Fatalf("expected GetObject error to fail the query, got rows=%#v columns=%#v", rows, columns)
+	}
+	if !errors.Is(err, decodeErr) {
+		t.Fatalf("query error lost GetObject cause: %v", err)
+	}
+	if !strings.Contains(err.Error(), `列 "status"`) {
+		t.Fatalf("query error missing column context: %v", err)
+	}
+	if rows != nil || columns != nil {
+		t.Fatalf("failed query should not return partial rows: rows=%#v columns=%#v", rows, columns)
+	}
+}
+
+func TestIoTDBQueryReturnsRealNullWhenIsNullSucceeds(t *testing.T) {
+	session := &fakeIoTDBSession{
+		queryResults: map[string][]map[string]interface{}{
+			"SELECT temperature, status FROM root.sg.d1": {
+				{"temperature": 21.5, "status": nil},
+			},
+		},
+		getObjectErrs: map[string]error{
+			"status": errors.New("should not read null column"),
+		},
+	}
+	client := &IoTDBDB{session: session}
+
+	rows, columns, err := client.Query("SELECT temperature, status FROM root.sg.d1")
+	if err != nil {
+		t.Fatalf("real NULL should not fail the query: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected one row, got rows=%#v columns=%#v", rows, columns)
+	}
+	if rows[0]["temperature"] != 21.5 {
+		t.Fatalf("unexpected temperature: %#v", rows[0]["temperature"])
+	}
+	if _, exists := rows[0]["status"]; !exists {
+		t.Fatalf("missing status column: %#v", rows[0])
+	}
+	if rows[0]["status"] != nil {
+		t.Fatalf("expected real NULL status, got %#v", rows[0]["status"])
+	}
+}
+
+func TestScanIoTDBDataSetNilDataset(t *testing.T) {
+	rows, columns, err := scanIoTDBDataSet(nil)
+	if err != nil {
+		t.Fatalf("nil dataset should not error: %v", err)
+	}
+	if rows != nil || columns != nil {
+		t.Fatalf("nil dataset should return nil results, got rows=%#v columns=%#v", rows, columns)
+	}
+}
+
+func TestScanIoTDBDataSetNextError(t *testing.T) {
+	nextErr := errors.New("next failed")
+	_, _, err := scanIoTDBDataSet(&fakeIoTDBDataSet{
+		columns: []string{"status"},
+		rows:    []map[string]interface{}{{"status": "ok"}},
+		nextErr: nextErr,
+	})
+	if !errors.Is(err, nextErr) {
+		t.Fatalf("expected Next error, got %v", err)
+	}
+}
+
+func TestScanIoTDBDataSetIsNullErrorFallsBackToGetObject(t *testing.T) {
+	rows, columns, err := scanIoTDBDataSet(&fakeIoTDBDataSet{
+		columns: []string{"status"},
+		rows:    []map[string]interface{}{{"status": "ok"}},
+		isNullErrs: map[string]error{
+			"status": errors.New("isnull failed"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("IsNull error should fall back to GetObject: %v", err)
+	}
+	if len(rows) != 1 || rows[0]["status"] != "ok" {
+		t.Fatalf("unexpected scan result: rows=%#v columns=%#v", rows, columns)
 	}
 }


### PR DESCRIPTION
Fixes Syngnat/GoNavi#1192

## 背景

IoTDB 数据集 `GetObject` 返回错误时，`scanIoTDBDataSet` 写入 `nil` 并继续扫描，查询最终以成功结果返回。调用方无法区分真实 NULL 与字段解码失败。

## 变更

- `GetObject` 错误立即失败查询，错误信息包含列名并保留原始 cause
- 仅在 `IsNull` 成功确认时写入真实空值；`IsNull` 失败则回退到 `GetObject`
- 补充回归测试：GetObject 失败、真实 NULL、Next 错误、IsNull 回退

## 验证

```
go test -tags gonavi_iotdb_driver ./internal/db -run 'IoTDB' -count=1
```

```
ok  	GoNavi-Wails/internal/db	0.026s
```

## 覆盖率（changed code）

`go test -tags gonavi_iotdb_driver ./internal/db -run 'IoTDB' -count=1 -coverprofile=... -covermode=count`

| 函数 | 覆盖率 |
| --- | --- |
| `scanIoTDBDataSet` | 100.0% |

改动行实测命中（`covermode=count`）：

| 行 | 语句 | hits |
| --- | --- | --- |
| 535-536 `ds == nil` 判断 | 1 | 11 |
| 536-538 空数据集返回 | 1 | 1 |
| 539-542 列名与扫描循环 | 4 | 10 |
| 544-546 `Next` 错误 | 1 | 1 |
| 553-555 真实 NULL | 2 | 1 |
| 558-560 `GetObject` 错误返回 | 1 | 1 |
| 561 正常取值 | 1 | 23 |

## 风险

传播错误会改变此前“部分列写成 NULL 后仍成功返回”的语义。错误信息带列名，便于定位。可按提交回滚。
