### PR TITLE
fix(db): escape CustomDB GetColumns schema and table names

### DIFF
--- a/internal/db/custom_impl.go
+++ b/internal/db/custom_impl.go
@@ -298,29 +298,7 @@ func (c *CustomDB) GetCreateStatement(dbName, tableName string) (string, error) 
 }
 
 func (c *CustomDB) GetColumns(dbName, tableName string) ([]connection.ColumnDefinition, error) {
-	// ANSI Standard
-	// SELECT column_name, data_type, is_nullable, column_default FROM information_schema.columns WHERE table_name = '...'
-
-	schema := "public"
-	if dbName != "" {
-		schema = dbName
-	}
-
-	query := fmt.Sprintf(`SELECT column_name, data_type, character_maximum_length, numeric_precision, numeric_scale, is_nullable, column_default
-		FROM information_schema.columns
-		WHERE table_name = '%s'`, tableName)
-
-	// Adjust for schema if likely supported
-	if c.driver == "postgres" || c.driver == "kingbase" {
-		query += fmt.Sprintf(" AND table_schema = '%s'", schema)
-	} else if c.driver == "mysql" {
-		query = fmt.Sprintf("SHOW FULL COLUMNS FROM `%s`", tableName)
-		if dbName != "" {
-			query = fmt.Sprintf("SHOW FULL COLUMNS FROM `%s`.`%s`", dbName, tableName)
-		}
-	}
-
-	data, _, err := c.Query(query)
+	data, _, err := c.Query(buildCustomColumnsQuery(c.driver, dbName, tableName))
 	if err != nil {
 		return nil, err
 	}
@@ -330,6 +308,33 @@ func (c *CustomDB) GetColumns(dbName, tableName string) ([]connection.ColumnDefi
 		columns = append(columns, buildCustomColumnDefinition(row))
 	}
 	return columns, nil
+}
+
+func buildCustomColumnsQuery(driver, dbName, tableName string) string {
+	driverName := strings.ToLower(strings.TrimSpace(driver))
+	schema := "public"
+	if dbName != "" {
+		schema = dbName
+	}
+
+	if driverName == "mysql" {
+		if dbName != "" {
+			return fmt.Sprintf(
+				"SHOW FULL COLUMNS FROM `%s`.`%s`",
+				escapeMySQLBacktickIdent(dbName),
+				escapeMySQLBacktickIdent(tableName),
+			)
+		}
+		return fmt.Sprintf("SHOW FULL COLUMNS FROM `%s`", escapeMySQLBacktickIdent(tableName))
+	}
+
+	query := fmt.Sprintf(`SELECT column_name, data_type, character_maximum_length, numeric_precision, numeric_scale, is_nullable, column_default
+		FROM information_schema.columns
+		WHERE table_name = '%s'`, escapePGLikeMetadataLiteral(tableName))
+	if driverName == "postgres" || driverName == "kingbase" {
+		query += fmt.Sprintf(" AND table_schema = '%s'", escapePGLikeMetadataLiteral(schema))
+	}
+	return query
 }
 
 func buildCustomColumnDefinition(row map[string]interface{}) connection.ColumnDefinition {

--- a/internal/db/custom_impl_test.go
+++ b/internal/db/custom_impl_test.go
@@ -674,3 +674,239 @@ func TestBuildCustomColumnDefinitionBuildsTypeFromLengthAndPrecision(t *testing.
 		t.Fatalf("expected decimal(10,2), got %q", amountCol.Type)
 	}
 }
+
+func openCustomMetadataTestDB(t *testing.T, columns []string, rows [][]driver.Value) *sql.DB {
+	t.Helper()
+	registerCustomGetTablesDriverOnce.Do(func() {
+		sql.Register(customGetTablesDriverName, customGetTablesDriver{})
+	})
+
+	copiedRows := make([][]driver.Value, len(rows))
+	for i, row := range rows {
+		copiedRows[i] = append([]driver.Value(nil), row...)
+	}
+
+	customGetTablesStateMu.Lock()
+	customGetTablesState.lastQuery = ""
+	customGetTablesState.columns = append([]string(nil), columns...)
+	customGetTablesState.rows = copiedRows
+	customGetTablesStateMu.Unlock()
+	t.Cleanup(func() {
+		customGetTablesStateMu.Lock()
+		customGetTablesState.lastQuery = ""
+		customGetTablesState.columns = nil
+		customGetTablesState.rows = nil
+		customGetTablesStateMu.Unlock()
+	})
+
+	conn, err := sql.Open(customGetTablesDriverName, "")
+	if err != nil {
+		t.Fatalf("open custom metadata test database: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func customMetadataLastQuery() string {
+	customGetTablesStateMu.Lock()
+	defer customGetTablesStateMu.Unlock()
+	return customGetTablesState.lastQuery
+}
+
+func TestCustomDBGetColumnsQueryEscaping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		driver      string
+		dbName      string
+		tableName   string
+		contains    []string
+		notContains []string
+		exact       string
+	}{
+		{
+			name:      "postgres schema and table single quotes",
+			driver:    "postgres",
+			dbName:    "tenant's",
+			tableName: "user's",
+			contains: []string{
+				"table_name = 'user''s'",
+				"table_schema = 'tenant''s'",
+			},
+			notContains: []string{
+				"table_name = 'user's'",
+				"table_schema = 'tenant's'",
+			},
+		},
+		{
+			name:      "kingbase schema and table single quotes",
+			driver:    "Kingbase",
+			dbName:    "schema'name",
+			tableName: "table'name",
+			contains: []string{
+				"table_name = 'table''name'",
+				"table_schema = 'schema''name'",
+			},
+		},
+		{
+			name:      "postgres empty schema uses public",
+			driver:    "postgres",
+			tableName: "orders",
+			contains: []string{
+				"table_name = 'orders'",
+				"table_schema = 'public'",
+			},
+			notContains: []string{"''"},
+		},
+		{
+			name:      "postgres normal names unchanged",
+			driver:    "postgres",
+			dbName:    "app",
+			tableName: "orders",
+			contains: []string{
+				"table_name = 'orders'",
+				"table_schema = 'app'",
+			},
+			notContains: []string{"''"},
+		},
+		{
+			name:      "mysql schema and table backticks",
+			driver:    "mysql",
+			dbName:    "db`name",
+			tableName: "we`ird",
+			exact:     "SHOW FULL COLUMNS FROM `db``name`.`we``ird`",
+		},
+		{
+			name:      "mysql table backticks without schema",
+			driver:    "MySQL",
+			tableName: "we`ird",
+			exact:     "SHOW FULL COLUMNS FROM `we``ird`",
+		},
+		{
+			name:      "mysql normal names with schema unchanged",
+			driver:    "mysql",
+			dbName:    "app",
+			tableName: "orders",
+			exact:     "SHOW FULL COLUMNS FROM `app`.`orders`",
+		},
+		{
+			name:      "mysql normal names without schema unchanged",
+			driver:    "mysql",
+			tableName: "orders",
+			exact:     "SHOW FULL COLUMNS FROM `orders`",
+		},
+		{
+			name:      "generic driver escapes table literal",
+			driver:    "sqlite",
+			dbName:    "ignored's",
+			tableName: "user's",
+			contains:  []string{"table_name = 'user''s'"},
+			notContains: []string{
+				"table_schema =",
+				"table_name = 'user's'",
+			},
+		},
+		{
+			name:        "generic driver keeps normal table name",
+			driver:      "sqlite",
+			tableName:   "orders",
+			contains:    []string{"table_name = 'orders'"},
+			notContains: []string{"table_schema =", "''"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildCustomColumnsQuery(tt.driver, tt.dbName, tt.tableName)
+			if tt.exact != "" && got != tt.exact {
+				t.Fatalf("buildCustomColumnsQuery()=%q, want %q", got, tt.exact)
+			}
+			for _, want := range tt.contains {
+				if !strings.Contains(got, want) {
+					t.Fatalf("expected %q in %q", want, got)
+				}
+			}
+			for _, blocked := range tt.notContains {
+				if strings.Contains(got, blocked) {
+					t.Fatalf("did not expect %q in %q", blocked, got)
+				}
+			}
+		})
+	}
+}
+
+func TestCustomDBGetColumnsEscapesIdentifiersInExecutedQuery(t *testing.T) {
+	tests := []struct {
+		name      string
+		driver    string
+		dbName    string
+		tableName string
+		contains  []string
+	}{
+		{
+			name:      "postgres",
+			driver:    "postgres",
+			dbName:    "tenant's",
+			tableName: "user's",
+			contains:  []string{"table_name = 'user''s'", "table_schema = 'tenant''s'"},
+		},
+		{
+			name:      "mysql",
+			driver:    "mysql",
+			dbName:    "db`name",
+			tableName: "we`ird",
+			contains:  []string{"SHOW FULL COLUMNS FROM `db``name`.`we``ird`"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := openCustomMetadataTestDB(t, []string{"column_name"}, nil)
+			if _, err := (&CustomDB{conn: conn, driver: tt.driver}).GetColumns(tt.dbName, tt.tableName); err != nil {
+				t.Fatalf("GetColumns returned error: %v", err)
+			}
+			got := customMetadataLastQuery()
+			if got != buildCustomColumnsQuery(tt.driver, tt.dbName, tt.tableName) {
+				t.Fatalf("executed query %q, want %q", got, buildCustomColumnsQuery(tt.driver, tt.dbName, tt.tableName))
+			}
+			for _, want := range tt.contains {
+				if !strings.Contains(got, want) {
+					t.Fatalf("expected %q in executed query %q", want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestCustomDBGetColumnsReturnsQueryError(t *testing.T) {
+	_, err := (&CustomDB{}).GetColumns("public", "orders")
+	if err == nil {
+		t.Fatal("expected GetColumns to return a query error")
+	}
+}
+
+func TestCustomDBGetColumnsParsesMetadataRows(t *testing.T) {
+	conn := openCustomMetadataTestDB(t, []string{"column_name", "data_type", "is_nullable"}, [][]driver.Value{
+		{"id", "int", "NO"},
+	})
+
+	columns, err := (&CustomDB{conn: conn, driver: "postgres"}).GetColumns("public", "orders")
+	if err != nil {
+		t.Fatalf("GetColumns returned error: %v", err)
+	}
+	if len(columns) != 1 {
+		t.Fatalf("GetColumns returned %d columns, want 1", len(columns))
+	}
+	if columns[0].Name != "id" {
+		t.Fatalf("column name = %q, want id", columns[0].Name)
+	}
+	if columns[0].Type != "int" {
+		t.Fatalf("column type = %q, want int", columns[0].Type)
+	}
+	if columns[0].Nullable != "NO" {
+		t.Fatalf("column nullable = %q, want NO", columns[0].Nullable)
+	}
+}


### PR DESCRIPTION
## 背景

`CustomDB.GetColumns` 把 `table` / `schema` 直接拼进 SQL 字面量或反引号标识符。名称包含单引号或反引号时，会生成未闭合的元数据查询，导致无法读取列定义。

`GetTables` 已有转义边界，`GetColumns` 未复用。

Fixes Syngnat/GoNavi#1191

## 关键改动

- 抽出 `buildCustomColumnsQuery`，按驱动方言转义对象名
- PG-like（postgres/kingbase）及通用 `information_schema` 路径：使用 `escapePGLikeMetadataLiteral` 转义 schema/table 单引号
- MySQL：使用 `escapeMySQLBacktickIdent` 将标识符中的反引号双写
- 驱动名改为大小写不敏感，与 `GetTables` 一致
- 普通名称生成的 SQL 保持不变

## 影响范围

仅 Custom 连接的列元数据查询。浏览/编辑含特殊字符对象名的表时，列定义查询可正确执行。

## 验证

```bash
go test ./internal/db -run 'CustomDBGetColumns' -count=1
```

结果：`ok GoNavi-Wails/internal/db`

变更代码覆盖率（`go test ./internal/db -run 'CustomDBGetColumns' -coverprofile=... -covermode=atomic`）：

| 函数 | 覆盖率 |
| --- | --- |
| `CustomDB.GetColumns` | **100.0%** |
| `buildCustomColumnsQuery` | **100.0%** |

变更语句：19/19 覆盖，未覆盖 0，变更代码覆盖率 **100.0%**。

验收对照：

- PG-like schema/table 单引号转为 `''`
- MySQL schema/table 反引号双写
- 普通名称字面量/标识符不变

## 风险与回滚

不同方言的字面量与标识符规则不同；测试已覆盖 postgres/kingbase/mysql/generic。行为回滚可还原本 PR。
