### PR TITLE
🐛 fix(qdrant): 将单一比较条件包装为官方 Filter 根结构

### DIFF
--- a/internal/db/qdrant_impl_test.go
+++ b/internal/db/qdrant_impl_test.go
@@ -220,6 +220,66 @@ func TestQdrantSelectPassesWhereToScrollAndCount(t *testing.T) {
 	}
 }
 
+func TestQdrantSelectSingleWhereUsesOfficialFilterForScrollAndCount(t *testing.T) {
+	var bodies []map[string]interface{}
+	server := newMockQdrantServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/collections":
+			writeQdrantJSON(w, map[string]interface{}{"result": map[string]interface{}{"collections": []interface{}{}}})
+		case r.Method == http.MethodPost && (strings.HasSuffix(r.URL.Path, "/points/scroll") || strings.HasSuffix(r.URL.Path, "/points/count")):
+			var body map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			bodies = append(bodies, body)
+			if strings.HasSuffix(r.URL.Path, "/points/count") {
+				writeQdrantJSON(w, map[string]interface{}{"result": map[string]interface{}{"count": 0}})
+			} else {
+				writeQdrantJSON(w, map[string]interface{}{"result": map[string]interface{}{"points": []interface{}{}}})
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	db := newTestQdrantDB(t, server.URL)
+
+	queries := []string{
+		`SELECT * FROM products WHERE category = 'book'`,
+		`SELECT COUNT(*) FROM products WHERE category = 'book'`,
+		`SELECT * FROM products WHERE price < 5`,
+		`SELECT COUNT(*) FROM products WHERE price < 5`,
+		`SELECT * FROM products WHERE id = 1`,
+		`SELECT COUNT(*) FROM products WHERE id = 1`,
+	}
+	for _, query := range queries {
+		if _, _, err := db.Query(query); err != nil {
+			t.Fatalf("Query(%q) failed: %v", query, err)
+		}
+	}
+	if len(bodies) != len(queries) {
+		t.Fatalf("expected %d Qdrant requests, got %#v", len(queries), bodies)
+	}
+	for i := 0; i < len(bodies); i += 2 {
+		scrollFilter, _ := bodies[i]["filter"].(map[string]interface{})
+		countFilter, _ := bodies[i+1]["filter"].(map[string]interface{})
+		if scrollFilter == nil || countFilter == nil {
+			t.Fatalf("missing filter in requests %#v", bodies[i:i+2])
+		}
+		if scrollFilter["must"] == nil {
+			t.Fatalf("single comparison filter = %#v, want must wrapper", scrollFilter)
+		}
+		if _, hasKey := scrollFilter["key"]; hasKey {
+			t.Fatalf("bare Condition leaked to Filter root: %#v", scrollFilter)
+		}
+		if _, hasID := scrollFilter["has_id"]; hasID {
+			t.Fatalf("bare has_id leaked to Filter root: %#v", scrollFilter)
+		}
+		scrollJSON, _ := json.Marshal(scrollFilter)
+		countJSON, _ := json.Marshal(countFilter)
+		if string(scrollJSON) != string(countJSON) {
+			t.Fatalf("scroll/count filters diverged: %s vs %s", scrollJSON, countJSON)
+		}
+	}
+}
+
 func TestQdrantSelectRejectsUnsupportedWhereWithoutDataRequest(t *testing.T) {
 	db := &QdrantDB{client: &http.Client{Transport: vectorWhereRoundTripFunc(func(*http.Request) (*http.Response, error) {
 		t.Fatal("unsupported WHERE must not make an HTTP request")

--- a/internal/db/vector_sql_where.go
+++ b/internal/db/vector_sql_where.go
@@ -286,13 +286,31 @@ func chromaWhereFromExpr(expr vectorWhereExpr) interface{} {
 }
 
 func qdrantFilterFromExpr(expr vectorWhereExpr) interface{} {
+	return qdrantEnsureRootFilter(qdrantConditionFromExpr(expr))
+}
+
+func qdrantEnsureRootFilter(value interface{}) interface{} {
+	m, ok := value.(map[string]interface{})
+	if !ok {
+		return value
+	}
+	if _, hasKey := m["key"]; hasKey {
+		return map[string]interface{}{"must": []interface{}{m}}
+	}
+	if _, hasID := m["has_id"]; hasID {
+		return map[string]interface{}{"must": []interface{}{m}}
+	}
+	return m
+}
+
+func qdrantConditionFromExpr(expr vectorWhereExpr) interface{} {
 	switch value := expr.(type) {
 	case vectorWhereLogical:
 		key := "must"
 		if value.Op == "OR" {
 			key = "should"
 		}
-		return map[string]interface{}{key: []interface{}{qdrantFilterFromExpr(value.Left), qdrantFilterFromExpr(value.Right)}}
+		return map[string]interface{}{key: []interface{}{qdrantConditionFromExpr(value.Left), qdrantConditionFromExpr(value.Right)}}
 	case vectorWhereComparison:
 		field := strings.TrimPrefix(value.Field, "payload.")
 		if strings.EqualFold(field, "id") && (value.Op == "=" || value.Op == "!=") {

--- a/internal/db/vector_sql_where_test.go
+++ b/internal/db/vector_sql_where_test.go
@@ -95,7 +95,7 @@ func TestQdrantIDPredicatesUsePointIDFilter(t *testing.T) {
 		query string
 		want  interface{}
 	}{
-		{`SELECT * FROM products WHERE id = 42`, map[string]interface{}{"has_id": []interface{}{int64(42)}}},
+		{`SELECT * FROM products WHERE id = 42`, map[string]interface{}{"must": []interface{}{map[string]interface{}{"has_id": []interface{}{int64(42)}}}}},
 		{`SELECT * FROM products WHERE id != 'point-1'`, map[string]interface{}{"must_not": []interface{}{map[string]interface{}{"has_id": []interface{}{"point-1"}}}}},
 	}
 	for _, test := range tests {
@@ -103,8 +103,143 @@ func TestQdrantIDPredicatesUsePointIDFilter(t *testing.T) {
 		if err != nil {
 			t.Fatalf("parseVectorSQLWhere(%q): %v", test.query, err)
 		}
-		if got := qdrantFilterFromExpr(expr); !reflect.DeepEqual(got, test.want) {
+		got := qdrantFilterFromExpr(expr)
+		assertOfficialQdrantFilter(t, got)
+		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("qdrantFilterFromExpr(%q) = %#v, want %#v", test.query, got, test.want)
+		}
+	}
+}
+
+func TestQdrantWhereSingleComparisonFiltersUseMust(t *testing.T) {
+	tests := []struct {
+		query string
+		want  interface{}
+	}{
+		{
+			`SELECT * FROM products WHERE category = 'book'`,
+			map[string]interface{}{"must": []interface{}{map[string]interface{}{"key": "category", "match": map[string]interface{}{"value": "book"}}}},
+		},
+		{
+			`SELECT * FROM products WHERE payload.price > 10`,
+			map[string]interface{}{"must": []interface{}{map[string]interface{}{"key": "price", "range": map[string]interface{}{"gt": int64(10)}}}},
+		},
+		{
+			`SELECT * FROM products WHERE price >= 10`,
+			map[string]interface{}{"must": []interface{}{map[string]interface{}{"key": "price", "range": map[string]interface{}{"gte": int64(10)}}}},
+		},
+		{
+			`SELECT * FROM products WHERE price < 5`,
+			map[string]interface{}{"must": []interface{}{map[string]interface{}{"key": "price", "range": map[string]interface{}{"lt": int64(5)}}}},
+		},
+		{
+			`SELECT * FROM products WHERE price <= 5`,
+			map[string]interface{}{"must": []interface{}{map[string]interface{}{"key": "price", "range": map[string]interface{}{"lte": int64(5)}}}},
+		},
+		{
+			`SELECT COUNT(*) FROM products WHERE id = 1`,
+			map[string]interface{}{"must": []interface{}{map[string]interface{}{"has_id": []interface{}{int64(1)}}}},
+		},
+		{
+			`SELECT * FROM products WHERE active != false`,
+			map[string]interface{}{"must_not": []interface{}{map[string]interface{}{"key": "active", "match": map[string]interface{}{"value": false}}}},
+		},
+	}
+	for _, test := range tests {
+		expr, _, err := parseVectorSQLWhere(test.query)
+		if err != nil {
+			t.Fatalf("parseVectorSQLWhere(%q): %v", test.query, err)
+		}
+		got := qdrantFilterFromExpr(expr)
+		assertOfficialQdrantFilter(t, got)
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("qdrantFilterFromExpr(%q) = %#v, want %#v", test.query, got, test.want)
+		}
+	}
+}
+
+func TestQdrantWhereNestedMustShouldLogicIsPreserved(t *testing.T) {
+	expr, found, err := parseVectorSQLWhere(`SELECT * FROM products WHERE (category = 'book' OR price < 5) AND active != false`)
+	if err != nil || !found {
+		t.Fatalf("parseVectorSQLWhere() = (%#v, %v, %v)", expr, found, err)
+	}
+	got := qdrantFilterFromExpr(expr)
+	assertOfficialQdrantFilter(t, got)
+	want := map[string]interface{}{
+		"must": []interface{}{
+			map[string]interface{}{
+				"should": []interface{}{
+					map[string]interface{}{"key": "category", "match": map[string]interface{}{"value": "book"}},
+					map[string]interface{}{"key": "price", "range": map[string]interface{}{"lt": int64(5)}},
+				},
+			},
+			map[string]interface{}{
+				"must_not": []interface{}{
+					map[string]interface{}{"key": "active", "match": map[string]interface{}{"value": false}},
+				},
+			},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("qdrantFilterFromExpr() = %#v, want %#v", got, want)
+	}
+}
+
+func TestQdrantWhereScrollAndCountFiltersMatch(t *testing.T) {
+	predicates := []string{
+		`category = 'book'`,
+		`price >= 10`,
+		`id = 1`,
+		`active != false`,
+		`category = 'book' AND price < 5`,
+		`active != false OR price < 5`,
+	}
+	for _, predicate := range predicates {
+		scroll, scrollOK := parseQdrantSQL(`SELECT * FROM products WHERE ` + predicate)
+		count, countOK := parseQdrantSQL(`SELECT COUNT(*) FROM products WHERE ` + predicate)
+		if !scrollOK || !countOK || scroll.WhereError != nil || count.WhereError != nil {
+			t.Fatalf("parseQdrantSQL(%q) scroll=(%#v, %v) count=(%#v, %v)", predicate, scroll, scrollOK, count, countOK)
+		}
+		assertOfficialQdrantFilter(t, scroll.Filter)
+		assertOfficialQdrantFilter(t, count.Filter)
+		if !reflect.DeepEqual(scroll.Filter, count.Filter) {
+			t.Errorf("scroll/count filter mismatch for %q: scroll=%#v count=%#v", predicate, scroll.Filter, count.Filter)
+		}
+	}
+}
+
+func TestQdrantWhereFilterFromExprCoversNonConditionRoots(t *testing.T) {
+	if got := qdrantFilterFromExpr(nil); got != nil {
+		t.Fatalf("qdrantFilterFromExpr(nil) = %#v, want nil", got)
+	}
+	if got := qdrantEnsureRootFilter("not-a-filter"); got != "not-a-filter" {
+		t.Fatalf("qdrantEnsureRootFilter(non-map) = %#v", got)
+	}
+	already := map[string]interface{}{"should": []interface{}{map[string]interface{}{"key": "category", "match": map[string]interface{}{"value": "book"}}}}
+	if got := qdrantEnsureRootFilter(already); !reflect.DeepEqual(got, already) {
+		t.Fatalf("qdrantEnsureRootFilter(should) = %#v, want original filter", got)
+	}
+	got := qdrantFilterFromExpr(vectorWhereComparison{Field: "ID", Op: ">", Value: int64(42)})
+	want := map[string]interface{}{"must": []interface{}{map[string]interface{}{"key": "ID", "range": map[string]interface{}{"gt": int64(42)}}}}
+	assertOfficialQdrantFilter(t, got)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("id range comparison = %#v, want %#v", got, want)
+	}
+}
+
+func assertOfficialQdrantFilter(t *testing.T, filter interface{}) {
+	t.Helper()
+	m, ok := filter.(map[string]interface{})
+	if !ok {
+		t.Fatalf("filter is not an object: %#v", filter)
+	}
+	allowed := map[string]struct{}{"must": {}, "should": {}, "must_not": {}, "min_should": {}}
+	if len(m) == 0 {
+		t.Fatalf("official Filter must not be empty: %#v", filter)
+	}
+	for key := range m {
+		if _, ok := allowed[key]; !ok {
+			t.Fatalf("illegal Filter root key %q in %#v", key, filter)
 		}
 	}
 }


### PR DESCRIPTION
Fixes Syngnat/GoNavi#1185

## 背景

单一等值、范围或 `id=` WHERE 由 `qdrantFilterFromExpr` 返回 Condition（`key/match`、`range`、`has_id`），`parseQdrantSQL` 把它直接当作 scroll/count 的根 filter。官方 Qdrant Filter 只允许 `must` / `should` / `must_not` / `min_should`，并禁止额外字段，因此裸 Condition 作为根结构无效。

## 关键改动

- 拆分 Filter 与 Condition 转换：`qdrantConditionFromExpr` 负责递归生成条件
- 顶层单一比较（`=`、范围、`id=`）由 `qdrantEnsureRootFilter` 包进 `must`
- 已是 Filter 的 AND / OR / `!=`（`must` / `should` / `must_not`）保持原结构，嵌套 must/should 不被二次包装

## 影响范围

仅 Qdrant 简化 SQL WHERE → scroll/count filter 合成。Chroma 及其他数据源不受影响。

## 验证

```
go test ./internal/db -run 'Qdrant.*Where|QdrantID|VectorWhere' -count=1
```

全部通过。改动函数覆盖率：

| 函数 | 语句 |
| --- | --- |
| `qdrantFilterFromExpr` | 1/1 (100.0%) |
| `qdrantEnsureRootFilter` | 8/8 (100.0%) |
| `qdrantConditionFromExpr` | 18/18 (100.0%) |
| 合计 | 27/27 (100.0%) |

## 风险与回滚

只改变请求 filter JSON 形状；语义与原先 AND/OR/!= 一致。回滚该提交即可。