### PR TITLE
🐛 fix(ui): 统一应用右键菜单并补全连接树热区

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -295,6 +295,7 @@ import { canInheritNewQueryTableContext, resolveNewQueryContext } from './utils/
 import { useAppUtilityStyles } from './hooks/useAppUtilityStyles';
 import { useWorkbenchTabs } from './hooks/useWorkbenchTabs';
 import { useAIWorkspaceSnapshot } from './components/ai/useAIWorkspaceSnapshot';
+import { shouldAllowNativeContextMenu } from './utils/nativeContextMenu';
 import AgentDataSettingsPanel from './components/ai/AgentDataSettingsPanel';
 import {
   ApplyDataRootDirectory,
@@ -8092,6 +8093,10 @@ function App() {
   const sidebarPanelCollapseLabel = t('app.sidebar.collapse');
   const sidebarPanelExpandLabel = t('app.sidebar.expand');
   const sidebarPanelToggleLabel = isSidebarCollapsed ? sidebarPanelExpandLabel : sidebarPanelCollapseLabel;
+  const handleAppContextMenu = useCallback((event: React.MouseEvent<HTMLElement>) => {
+    if (event.defaultPrevented || shouldAllowNativeContextMenu(event.target)) return;
+    event.preventDefault();
+  }, []);
 
   return (
     <ConfigProvider
@@ -8107,6 +8112,7 @@ function App() {
         <ToolbarAppearanceStyleHost />
         <Layout
           className="gn-v2-app-root"
+          onContextMenu={handleAppContextMenu}
           data-gonavi-close-shortcut-scope="workspace"
           data-empty-workbench={tabs.length === 0 ? 'true' : 'false'}
           data-collapsed-sidebar-actions-docked={

--- a/frontend/src/components/NativeDetachedWindowApp.tsx
+++ b/frontend/src/components/NativeDetachedWindowApp.tsx
@@ -50,6 +50,7 @@ import {
 } from '../utils/queryEditorResultSessionCache';
 import { buildOverlayWorkbenchTheme } from '../utils/overlayWorkbenchTheme';
 import { APP_OVERLAY_Z_INDEX_BASE } from '../utils/overlayZIndex';
+import { shouldAllowNativeContextMenu } from '../utils/nativeContextMenu';
 import { resolveLiveQueryTab, resolveLiveQueryTabs } from '../utils/liveQueryTabs';
 import { subscribeQueryTabDraftChanges } from '../utils/sqlFileTabDrafts';
 import CustomThemeStyleHost, {
@@ -1359,6 +1360,10 @@ const NativeDetachedWindowApp: React.FC<NativeDetachedWindowAppProps> = ({
   const v2ControlActiveHoverBg = customThemeAntTokens.controlActiveHoverBg ?? (isDark ? 'rgba(34, 197, 94, 0.24)' : 'rgba(34, 197, 94, 0.16)');
   const v2ControlOutline = customThemeAntTokens.controlOutline ?? (isDark ? 'rgba(34, 197, 94, 0.42)' : 'rgba(22, 163, 74, 0.22)');
   const componentSize = uiScale <= 0.92 ? 'small' : (uiScale >= 1.12 ? 'large' : 'middle');
+  const handleWindowContextMenu = useCallback((event: React.MouseEvent<HTMLElement>) => {
+    if (event.defaultPrevented || shouldAllowNativeContextMenu(event.target)) return;
+    event.preventDefault();
+  }, []);
   return (
     <>
       <CustomThemeStyleHost
@@ -1417,6 +1422,7 @@ const NativeDetachedWindowApp: React.FC<NativeDetachedWindowAppProps> = ({
       <div
         className="gn-native-detached-window"
         data-kind={bootstrap?.kind || 'loading'}
+        onContextMenu={handleWindowContextMenu}
       >
         <style>{`
         .gn-native-detached-window {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -217,6 +217,7 @@ import {
   SIDEBAR_CONTEXT_MENU_FALLBACK_HEIGHT,
   SIDEBAR_CONTEXT_MENU_FALLBACK_WIDTH,
   resolveSidebarContextMenuPosition,
+  resolveSidebarTreeRowKey,
   type SearchScope,
 } from './sidebarCoreUtils';
 export { resolveSidebarContextMenuPosition } from './sidebarCoreUtils';
@@ -4455,6 +4456,16 @@ const Sidebar: React.FC<{
       }
   };
 
+  const handleV2TreeContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
+      if (event.defaultPrevented) return;
+      const nodeKey = resolveSidebarTreeRowKey(event.target);
+      if (!nodeKey) return;
+      const node = findTreeNodeByKeyRef.current(treeDataRef.current, nodeKey);
+      if (!node) return;
+      event.preventDefault();
+      onRightClick({ event, node });
+  };
+
   const v2RailObjectActionsLabel = t('sidebar.rail.object_actions');
   const v2RailSystemActionsLabel = t('sidebar.rail.system_actions');
   const v2NewGroupLabel = t('sidebar.action.new_group');
@@ -4841,6 +4852,7 @@ const Sidebar: React.FC<{
                     itemHeight={30}
                     itemHeightResolver={resolveSidebarTreeRowHeight}
                     scrollWidth={v2TreeHorizontalScrollWidth}
+                    onContextMenu={handleV2TreeContextMenu}
                     onRightClick={onRightClick}
                 />
             </div>

--- a/frontend/src/components/sidebarCoreUtils.test.ts
+++ b/frontend/src/components/sidebarCoreUtils.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeMySQLViewDDLForEditing,
   resolveSidebarContextMenuPosition,
   resolveSidebarObjectDragText,
+  resolveSidebarTreeRowKey,
 } from './sidebarCoreUtils';
 
 describe('sidebarCoreUtils', () => {
@@ -22,6 +23,19 @@ describe('sidebarCoreUtils', () => {
       y: 290,
       maxHeight: 300,
     });
+  });
+
+  it('resolves the tree node key from the full visual row', () => {
+    const row = {
+      getAttribute: (name: string) => name === 'data-sidebar-node-key' ? 'connection-1' : null,
+      querySelector: () => null,
+    };
+    const target = {
+      closest: (selector: string) => selector === '.ant-tree-treenode' ? row : null,
+    };
+
+    expect(resolveSidebarTreeRowKey(target as unknown as EventTarget)).toBe('connection-1');
+    expect(resolveSidebarTreeRowKey({ closest: () => null } as unknown as EventTarget)).toBeNull();
   });
 
   it('normalizes MySQL view definitions for editor updates', () => {

--- a/frontend/src/components/sidebarCoreUtils.ts
+++ b/frontend/src/components/sidebarCoreUtils.ts
@@ -54,6 +54,14 @@ export const resolveSidebarContextMenuPosition = (
   };
 };
 
+export const resolveSidebarTreeRowKey = (target: EventTarget | null | undefined): string | null => {
+  if (!target || typeof (target as Element).closest !== 'function') return null;
+  const row = (target as Element).closest('.ant-tree-treenode');
+  const key = row?.getAttribute('data-sidebar-node-key')
+    || row?.querySelector('[data-sidebar-node-key]')?.getAttribute('data-sidebar-node-key');
+  return String(key || '').trim() || null;
+};
+
 export const isV2SidebarObjectNode = (node: Pick<SidebarObjectNodeLike, 'type'> | null | undefined): boolean => {
   return node?.type === 'message-object'
     || node?.type === 'table'

--- a/frontend/src/utils/nativeContextMenu.test.ts
+++ b/frontend/src/utils/nativeContextMenu.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { shouldAllowNativeContextMenu } from './nativeContextMenu';
+
+type ContextMenuElement = EventTarget & {
+  parentElement: ContextMenuElement | null;
+  matches: (selector: string) => boolean;
+  hasAttribute: (name: string) => boolean;
+  getAttribute: (name: string) => string | null;
+};
+
+const createElement = ({
+  selector,
+  contentEditable,
+  parent = null,
+}: {
+  selector?: string;
+  contentEditable?: string;
+  parent?: ContextMenuElement | null;
+} = {}): ContextMenuElement => ({
+  parentElement: parent,
+  matches: (selectors) => Boolean(selector && selectors.split(',').some((item) => item.trim() === selector)),
+  hasAttribute: (name) => name === 'contenteditable' && contentEditable !== undefined,
+  getAttribute: (name) => name === 'contenteditable' ? contentEditable ?? null : null,
+} as ContextMenuElement);
+
+describe('shouldAllowNativeContextMenu', () => {
+  it('allows native menus for editable controls', () => {
+    expect(shouldAllowNativeContextMenu(createElement({ selector: 'input' }))).toBe(true);
+    expect(shouldAllowNativeContextMenu(createElement({ selector: 'textarea' }))).toBe(true);
+    expect(shouldAllowNativeContextMenu(createElement({ selector: '[role="textbox"]' }))).toBe(true);
+  });
+
+  it('allows native menus for Monaco and explicit opt-in surfaces', () => {
+    expect(shouldAllowNativeContextMenu(createElement({ selector: '.monaco-editor' }))).toBe(true);
+    expect(shouldAllowNativeContextMenu(createElement({ selector: '[data-allow-native-context-menu="true"]' }))).toBe(true);
+  });
+
+  it('blocks native menus on ordinary application surfaces', () => {
+    const surface = createElement();
+    const child = createElement({ parent: surface });
+
+    expect(shouldAllowNativeContextMenu(surface)).toBe(false);
+    expect(shouldAllowNativeContextMenu(child)).toBe(false);
+  });
+
+  it('allows descendants of editable content', () => {
+    const editable = createElement({ contentEditable: 'true' });
+    expect(shouldAllowNativeContextMenu(createElement({ parent: editable }))).toBe(true);
+  });
+
+  it('keeps a disabled nested editing region blocked', () => {
+    const editable = createElement({ contentEditable: 'true' });
+    const blocked = createElement({ contentEditable: 'false', parent: editable });
+    expect(shouldAllowNativeContextMenu(createElement({ parent: blocked }))).toBe(false);
+  });
+});

--- a/frontend/src/utils/nativeContextMenu.ts
+++ b/frontend/src/utils/nativeContextMenu.ts
@@ -1,0 +1,28 @@
+const NATIVE_CONTEXT_MENU_SELECTOR = [
+  'input',
+  'textarea',
+  'select',
+  '[role="textbox"]',
+  '.monaco-editor',
+  '[data-allow-native-context-menu="true"]',
+].join(',');
+
+/**
+ * Keep browser editing menus available while suppressing the browser menu on
+ * ordinary application surfaces. Custom application menus still get a chance
+ * to handle the event before the root fallback runs.
+ */
+export const shouldAllowNativeContextMenu = (target: EventTarget | null | undefined): boolean => {
+  let element = target as (Element & { parentElement?: Element | null }) | null | undefined;
+  if (!element || typeof element.matches !== 'function') {
+    element = element?.parentElement;
+  }
+  while (element) {
+    if (element.matches(NATIVE_CONTEXT_MENU_SELECTOR)) return true;
+    if (element.hasAttribute('contenteditable')) {
+      return element.getAttribute('contenteditable') !== 'false';
+    }
+    element = element.parentElement;
+  }
+  return false;
+};


### PR DESCRIPTION
## 变更说明

- 普通工作区与独立窗口的右键事件统一禁止 WebView 原生网页菜单。
- 输入框、contenteditable、Monaco 编辑器等编辑区域保留原生右键能力。
- 连接树整行背景区域统一支持业务右键菜单，覆盖箭头、缩进和行尾空白，避免视觉热区与事件热区不一致。
- 补充原生菜单例外判断和连接树行节点 key 解析测试。

## 兼容性

- 已有连接、数据库、表和分组自定义右键菜单行为保持不变。
- 树下方没有对应节点的空白区域不会弹出浏览器菜单。
- wails dev 生成的 bindings、go.mod、go.sum 和 package.json.md5 未纳入提交。

## 验证

- Sidebar.locate-toolbar.test.tsx：110 / 110 通过。
- NativeDetachedWindowApp.test.tsx：60 / 60 通过。
- sidebarCoreUtils.test.ts 与 nativeContextMenu.test.ts：10 / 10 通过。
- tsc --noEmit：通过。
- vite build：通过，7877 个模块构建完成。
