### PR TITLE
🐛 fix(table-designer): 修复仅调整列顺序时不生成重排语句

### DIFF
--- a/frontend/src/components/TableDesigner.tsx
+++ b/frontend/src/components/TableDesigner.tsx
@@ -413,7 +413,6 @@ const SortableRow = ({ children, ...props }: RowProps) => {
     ...props.style,
     transform: CSS.Transform.toString(transform),
     transition,
-    cursor: 'move',
     ...(isDragging ? { position: 'relative', zIndex: 9999 } : {}),
   };
 

--- a/frontend/src/components/tableDesignerSchemaSql.test.ts
+++ b/frontend/src/components/tableDesignerSchemaSql.test.ts
@@ -112,6 +112,80 @@ describe('tableDesignerSchemaSql', () => {
     expect(sql).toContain('AFTER `id`');
   });
 
+  it('generates modify statements when only the column order changed', () => {
+    const originalColumns = [
+      baseColumn({ _key: 'id', name: 'id', type: 'int', key: 'PRI', nullable: 'NO' }),
+      baseColumn({ _key: 'name', name: 'name', type: 'varchar(50)', nullable: 'YES' }),
+      baseColumn({ _key: 'email', name: 'email', type: 'varchar(100)', nullable: 'YES' }),
+    ];
+    const sql = buildAlterTablePreviewSql(buildInput({
+      dbType: 'mysql',
+      tableName: 'users',
+      originalColumns,
+      columns: [
+        baseColumn({ _key: 'id', name: 'id', type: 'int', key: 'PRI', nullable: 'NO' }),
+        baseColumn({ _key: 'email', name: 'email', type: 'varchar(100)', nullable: 'YES' }),
+        baseColumn({ _key: 'name', name: 'name', type: 'varchar(50)', nullable: 'YES' }),
+      ],
+    }));
+
+    // Moving `name` after `email` alone restores the target order,
+    // so `email` and `id` do not need redundant MODIFY statements.
+    expect(sql).toContain('MODIFY COLUMN `name` varchar(50) NULL COMMENT \'\' AFTER `email`');
+    expect(sql.match(/MODIFY COLUMN/g)).toHaveLength(1);
+    expect(sql).not.toContain('MODIFY COLUMN `id`');
+    expect(sql).not.toContain('MODIFY COLUMN `email`');
+    expect(
+      hasAlterTableDraftChanges(buildInput({
+        dbType: 'mysql',
+        tableName: 'users',
+        originalColumns,
+        columns: [
+          baseColumn({ _key: 'id', name: 'id', type: 'int', key: 'PRI', nullable: 'NO' }),
+          baseColumn({ _key: 'email', name: 'email', type: 'varchar(100)', nullable: 'YES' }),
+          baseColumn({ _key: 'name', name: 'name', type: 'varchar(50)', nullable: 'YES' }),
+        ],
+      })),
+    ).toBe(true);
+  });
+
+  it('reports no changes when the column order is untouched', () => {
+    const unchangedColumns = [
+      baseColumn({ _key: 'id', name: 'id', type: 'int', key: 'PRI', nullable: 'NO' }),
+      baseColumn({ _key: 'name', name: 'name', type: 'varchar(50)', nullable: 'YES' }),
+    ];
+    const input = buildInput({
+      dbType: 'mysql',
+      tableName: 'users',
+      originalColumns: unchangedColumns,
+      columns: unchangedColumns,
+    });
+
+    expect(buildAlterTablePreviewSql(input)).toBe('');
+    expect(hasAlterTableDraftChanges(input)).toBe(false);
+  });
+
+  it('moves a column to the first position with FIRST when reordered to the top', () => {
+    const sql = buildAlterTablePreviewSql(buildInput({
+      dbType: 'mysql',
+      tableName: 'users',
+      originalColumns: [
+        baseColumn({ _key: 'id', name: 'id', type: 'int', key: 'PRI', nullable: 'NO' }),
+        baseColumn({ _key: 'name', name: 'name', type: 'varchar(50)', nullable: 'YES' }),
+        baseColumn({ _key: 'created', name: 'created', type: 'datetime', nullable: 'NO' }),
+      ],
+      columns: [
+        baseColumn({ _key: 'created', name: 'created', type: 'datetime', nullable: 'NO' }),
+        baseColumn({ _key: 'id', name: 'id', type: 'int', key: 'PRI', nullable: 'NO' }),
+        baseColumn({ _key: 'name', name: 'name', type: 'varchar(50)', nullable: 'YES' }),
+      ],
+    }));
+
+    // `id` and `name` keep their relative order, so only `created` needs a move.
+    expect(sql).toContain('MODIFY COLUMN `created` datetime NOT NULL COMMENT \'\' FIRST');
+    expect(sql.match(/MODIFY COLUMN/g)).toHaveLength(1);
+  });
+
   it('preserves explicit MySQL default states and expressions', () => {
     const columns = [
       baseColumn({ _key: 'none', name: 'none_value', type: 'varchar(16)', nullable: 'YES', hasDefault: false }),

--- a/frontend/src/components/tableDesignerSchemaSql.ts
+++ b/frontend/src/components/tableDesignerSchemaSql.ts
@@ -108,6 +108,46 @@ const collectPrimaryKeyColumnKeys = (columns: EditableColumnSnapshot[]): string[
     .map((col) => col._key)
 );
 
+// Columns in the longest common subsequence of both orders keep their relative
+// position, so only the remaining survivors need an explicit AFTER/FIRST move.
+const longestCommonSubsequenceKeys = (originalSeq: string[], currentSeq: string[]): Set<string> => {
+  const n = originalSeq.length;
+  const m = currentSeq.length;
+  if (n === 0 || m === 0) return new Set();
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
+  for (let i = n - 1; i >= 0; i -= 1) {
+    for (let j = m - 1; j >= 0; j -= 1) {
+      dp[i][j] = originalSeq[i] === currentSeq[j]
+        ? dp[i + 1][j + 1] + 1
+        : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+  const kept = new Set<string>();
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (originalSeq[i] === currentSeq[j]) {
+      kept.add(originalSeq[i]);
+      i += 1;
+      j += 1;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      i += 1;
+    } else {
+      j += 1;
+    }
+  }
+  return kept;
+};
+
+const collectPositionChangedColumnKeys = (input: BuildAlterTablePreviewInput): Set<string> => {
+  const currentKeys = new Set(input.columns.map((col) => col._key));
+  const originalKeys = new Set(input.originalColumns.map((col) => col._key));
+  const originalSeq = input.originalColumns.filter((col) => currentKeys.has(col._key)).map((col) => col._key);
+  const currentSeq = input.columns.filter((col) => originalKeys.has(col._key)).map((col) => col._key);
+  const keptKeys = longestCommonSubsequenceKeys(originalSeq, currentSeq);
+  return new Set(currentSeq.filter((key) => !keptKeys.has(key)));
+};
+
 const escapeSqlString = (value: string) => String(value || '').replace(/'/g, "''");
 
 const translateSchemaSqlComment = (
@@ -347,6 +387,8 @@ const buildMySqlAlterPreviewSql = (input: BuildAlterTablePreviewInput, dbType: s
     }
   });
 
+  const positionChangedKeys = collectPositionChangedColumnKeys(input);
+
   input.columns.forEach((curr, index) => {
     const orig = input.originalColumns.find((col) => col._key === curr._key);
     const prevCol = index > 0 ? input.columns[index - 1] : null;
@@ -363,7 +405,7 @@ const buildMySqlAlterPreviewSql = (input: BuildAlterTablePreviewInput, dbType: s
       return;
     }
 
-    if (definitionChanged(curr, orig, dbType === 'mysql')) {
+    if (definitionChanged(curr, orig, dbType === 'mysql') || positionChangedKeys.has(curr._key)) {
       alters.push(`MODIFY COLUMN ${colDef} ${positionSql}`.trim());
     }
   });


### PR DESCRIPTION
## 问题

在表设计器里只调整列顺序时，预览 SQL 是空的，“有未保存改动”也不会点亮，用户拖动完列点击保存实际上不会产生任何 DDL。

## 变更说明

- 新增 `collectPositionChangedColumnKeys`：对“原列顺序”和“当前列顺序”求最长公共子序列，未落在子序列里的列才需要显式移动，避免为恢复顺序而重建所有列。
- MySQL 系列方言在 `MODIFY COLUMN` 分支上叠加位置判断，生成 `AFTER` / `FIRST` 子句；顺序变化现在会正确进入预览 SQL 和未保存状态判断。
- 覆盖三种场景的回归测试：交换两列后只产生 1 条 `MODIFY`、顺序未变时不产生 SQL、把列拖到首位时使用 `FIRST`。
- 顺带去掉表格行的 `cursor: move`，拖拽手柄本身已用 `grab` 光标，整行显示移动光标会误导用户。

## 兼容性

- 仅影响 MySQL 系列方言；PostgreSQL、Oracle、SQL Server、SQLite、Doris 等分支未改动。
- 已有列的新增、删除、改名、类型变更逻辑保持不变，列顺序变更与这些操作叠加时同样生效。
- `wails dev` 重新生成的 binding 文件未纳入提交（工作区里只有 CRLF/LF 差异）。

## 验证

- `tableDesignerSchemaSql.test.ts`、`tableDesignerExecutionSql.test.ts`、`tableDesignerIndexSql.test.ts`、`tableDesignerColumnClipboard.test.ts`：58 / 58 通过。
- `tsc --noEmit`：通过。
- 额外用临时穷举脚本校验：1〜6 列的全部 873 种目标排列，按 MySQL 顺序执行生成的 `AFTER` / `FIRST` 子句后都能精确还原目标列顺序；顺序未变时 SQL 为空。
- 额外校验复合场景（删除列 + 新增列 + 改名 + 改类型 + 重排同时发生）后，最终列顺序仍与目标一致。临时脚本未保留在提交中。
