### PR TITLE
✨ feat(sidebar): 支持按表注释搜索并展示注释

### DIFF
--- a/frontend/src/components/sidebar/useSidebarSearchModel.search-dedupe.test.tsx
+++ b/frontend/src/components/sidebar/useSidebarSearchModel.search-dedupe.test.tsx
@@ -304,4 +304,131 @@ describe('useSidebarSearchModel search filtering', () => {
         }),
       ]));
   });
+
+  it('matches tables by comment in smart scope and command search', () => {
+    const connection = {
+      id: 'conn-1',
+      name: 'MySQL',
+      config: { type: 'mysql', host: '127.0.0.1', port: 3306 },
+    } as SavedConnection;
+    const userTable = {
+      title: 'sys_user',
+      key: 'conn-1-app-tables-sys_user',
+      type: 'table' as const,
+      dataRef: {
+        ...connection,
+        dbName: 'app',
+        tableName: 'sys_user',
+        tableComment: '系统用户表',
+      },
+    };
+    const orderTable = {
+      title: 't_order',
+      key: 'conn-1-app-tables-t_order',
+      type: 'table' as const,
+      dataRef: {
+        ...connection,
+        dbName: 'app',
+        tableName: 't_order',
+        tableComment: '订单主表',
+      },
+    };
+    const treeData = [{
+      title: connection.name,
+      key: connection.id,
+      type: 'connection' as const,
+      dataRef: connection,
+      children: [{
+        title: 'app',
+        key: 'conn-1-app',
+        type: 'database' as const,
+        dataRef: { ...connection, dbName: 'app' },
+        children: [{
+          title: 'Tables',
+          key: 'conn-1-app-tables',
+          type: 'object-group' as const,
+          children: [userTable, orderTable],
+        }],
+      }],
+    }];
+
+    const buildHarness = (args: {
+      deferredSearchValue: string;
+      searchScopes?: any[];
+      isV2CommandSearchOpen?: boolean;
+      v2CommandSearchValue?: string;
+    }) => {
+      let model: ReturnType<typeof useSidebarSearchModel> | undefined;
+      const Harness = () => {
+        model = useSidebarSearchModel({
+          searchScopes: args.searchScopes ?? ['smart'],
+          setSearchScopes: () => undefined,
+          setSearchValue: () => undefined,
+          deferredSearchValue: args.deferredSearchValue,
+          deferredV2CommandSearchValue: args.v2CommandSearchValue ?? '',
+          v2CommandSearchValue: args.v2CommandSearchValue ?? '',
+          setV2CommandActiveIndex: () => undefined,
+          v2ExplorerFilter: 'all',
+          sidebarTableMetadataFields: [],
+          treeData,
+          treeViewportWidth: 320,
+          treeHeight: 400,
+          isV2CommandSearchOpen: args.isV2CommandSearchOpen ?? false,
+          connections: [connection],
+          connectionIds: [connection.id],
+          selectedKeys: [],
+          expandedKeys: [],
+          selectedNodesRef: useRef<any[]>([]),
+          activeContext: null,
+          activeTab: null,
+          recentSqlLogs: [],
+          shortcutOptions: {},
+          activeShortcutPlatform: 'mac',
+          overlayTheme: {
+            sectionBorder: '1px solid #ddd',
+            mutedText: '#666',
+            titleText: '#111',
+            shellBg: '#fff',
+            divider: '#eee',
+          },
+          darkMode: false,
+          setAIPanelVisible: () => undefined,
+          extractObjectName: (name) => name,
+        });
+        return null;
+      };
+
+      act(() => {
+        renderer = create(<Harness />);
+      });
+      return model;
+    };
+
+    // Smart scope: comment keyword surfaces the table in the filtered tree.
+    const smartModel = buildHarness({ deferredSearchValue: '订单主表' });
+    const smartMatchedKeys = collectTreeNodes(smartModel?.displayTreeData || []).map((node) => node.key);
+    expect(smartMatchedKeys).toContain(orderTable.key);
+    expect(smartMatchedKeys).not.toContain(userTable.key);
+
+    // Object scope: comment keyword also matches through the scoped filter.
+    const objectModel = buildHarness({ deferredSearchValue: '系统用户', searchScopes: ['object'] });
+    const objectMatchedKeys = collectTreeNodes(objectModel?.displayTreeData || []).map((node) => node.key);
+    expect(objectMatchedKeys).toContain(userTable.key);
+    expect(objectMatchedKeys).not.toContain(orderTable.key);
+
+    // Command search: comment keyword matches via the default node index.
+    const commandModel = buildHarness({
+      deferredSearchValue: '订单主表',
+      isV2CommandSearchOpen: true,
+      v2CommandSearchValue: '订单主表',
+    });
+    expect(commandModel?.filteredCommandSearchTreeItems.map((item) => item.key))
+      .toContain(`node-${orderTable.key}`);
+    expect(commandModel?.filteredCommandSearchTreeItems.map((item) => item.key))
+      .not.toContain(`node-${userTable.key}`);
+
+    // Command palette rows surface the comment in meta next to connection · database.
+    const orderItem = commandModel?.commandSearchTreeItems.find((item) => item.key === `node-${orderTable.key}`);
+    expect(orderItem?.meta).toBe('MySQL · app — 订单主表');
+  });
 });

--- a/frontend/src/components/sidebar/useSidebarSearchModel.tsx
+++ b/frontend/src/components/sidebar/useSidebarSearchModel.tsx
@@ -307,6 +307,14 @@ export const useSidebarSearchModel = ({
     return String(name || '').toLowerCase();
   };
 
+  // Table comments live on dataRef regardless of whether the user displays
+  // them, so the keyword should match them in both smart and object scopes.
+  const getObjectCommentSearchText = (node: TreeNode): string => (
+    isV2SidebarObjectNode(node)
+      ? String(node?.dataRef?.tableComment || '').toLowerCase()
+      : ''
+  );
+
   const matchByScopes = (node: TreeNode, keyword: string, scopes: SearchScope[]): boolean => {
     const title = String(node.title || '').toLowerCase();
     if (
@@ -325,7 +333,7 @@ export const useSidebarSearchModel = ({
     if (
       scopes.includes('object')
       && (isV2SidebarObjectNode(node) || node.type === 'object-group' || node.type === 'message-object-group')
-      && title.includes(keyword)
+      && (title.includes(keyword) || getObjectCommentSearchText(node).includes(keyword))
     ) {
       return true;
     }
@@ -351,7 +359,7 @@ export const useSidebarSearchModel = ({
       const titleMatch = String(item.title || '').toLowerCase().includes(keyword);
       const smartMatch = item.type === 'connection'
         ? getConnectionNameSearchText(item).includes(keyword) || getConnectionHostSearchText(item).includes(keyword)
-        : titleMatch;
+        : titleMatch || getObjectCommentSearchText(item).includes(keyword);
       const scopedMatch = matchByScopes(item, keyword, searchScopes);
       const selfMatch = isSmartMode ? smartMatch : scopedMatch;
       const filteredChildren = item.children ? loop(item.children, keyword) : [];
@@ -434,11 +442,15 @@ export const useSidebarSearchModel = ({
             || '',
           ).trim();
           const displayName = String(node.title || extractObjectName(objectName) || objectName).trim();
+          const tableComment = String(dataRef.tableComment || '').trim();
           result.push({
             key: `node-${node.key}`,
             kind: 'node',
             title: displayName,
-            meta: [conn?.name || dataRef.id, dataRef.dbName].filter(Boolean).join(' · '),
+            meta: [
+              [conn?.name || dataRef.id, dataRef.dbName].filter(Boolean).join(' · '),
+              tableComment,
+            ].filter(Boolean).join(' — '),
             icon: node.type === 'table'
               ? <TableOutlined />
               : (node.type === 'sequence'

--- a/frontend/src/components/sidebarV2Utils.command-search.test.ts
+++ b/frontend/src/components/sidebarV2Utils.command-search.test.ts
@@ -256,6 +256,82 @@ describe('sidebarV2 command search performance helpers', () => {
     );
   });
 
+  it('matches tables by comment in default and object command search modes', () => {
+    const items: V2CommandSearchItem[] = [
+      {
+        key: 'node-user-table',
+        kind: 'node',
+        title: 'sys_user',
+        meta: 'app',
+        icon: null,
+        node: {
+          type: 'table',
+          key: 'user-table',
+          title: 'sys_user',
+          dataRef: {
+            tableName: 'sys_user',
+            dbName: 'app',
+            tableComment: '系统用户表',
+          },
+        },
+      },
+      {
+        key: 'node-order-table',
+        kind: 'node',
+        title: 't_order',
+        meta: 'app',
+        icon: null,
+        node: {
+          type: 'table',
+          key: 'order-table',
+          title: 't_order',
+          dataRef: {
+            tableName: 't_order',
+            dbName: 'app',
+            tableComment: '订单主表',
+          },
+        },
+      },
+    ];
+
+    const matchedKeys = (query: string) =>
+      filterV2CommandSearchTreeItems(items, parseV2CommandSearchQuery(query)).map((item) => item.key);
+
+    expect(matchedKeys('订单主表')).toEqual(['node-order-table']);
+    expect(matchedKeys('系统用户')).toEqual(['node-user-table']);
+    expect(matchedKeys('@订单主表')).toEqual(['node-order-table']);
+    expect(matchedKeys('order')).toEqual(['node-order-table']);
+  });
+
+  it('matches table comments case-insensitively in object command search mode', () => {
+    const items: V2CommandSearchItem[] = [
+      {
+        key: 'node-user-table',
+        kind: 'node',
+        title: 'sys_user',
+        meta: 'app',
+        icon: null,
+        node: {
+          type: 'table',
+          key: 'user-table',
+          title: 'sys_user',
+          dataRef: {
+            tableName: 'sys_user',
+            dbName: 'app',
+            tableComment: 'User Profile Table',
+          },
+        },
+      },
+    ];
+
+    const matchedKeys = (query: string) =>
+      filterV2CommandSearchTreeItems(items, parseV2CommandSearchQuery(query)).map((item) => item.key);
+
+    expect(matchedKeys('@user profile')).toEqual(['node-user-table']);
+    expect(matchedKeys('@User Profile')).toEqual(['node-user-table']);
+    expect(matchedKeys('user profile')).toEqual(['node-user-table']);
+  });
+
   it('prunes only cold collapsed database trees when too many object trees stay loaded', () => {
     expect(resolveSidebarDatabaseTreePruneKeys({
       treeData: [

--- a/frontend/src/components/sidebarV2Utils.ts
+++ b/frontend/src/components/sidebarV2Utils.ts
@@ -1241,11 +1241,12 @@ export const buildV2CommandSearchTreeIndex = (
         dataRef.viewName,
         dataRef.sequenceName,
         dataRef.packageName,
+        dataRef.tableComment,
         dataRef.dbName,
         dataRef.name,
         dataRef.config?.host,
       ].filter(Boolean).join(' ').toLowerCase(),
-      normalizedObjectText: `${normalizedPrimaryObjectText} ${normalizedTitle}`.trim(),
+      normalizedObjectText: `${normalizedPrimaryObjectText} ${String(dataRef.tableComment || '').trim().toLowerCase()} ${normalizedTitle}`.trim(),
       objectNode: isV2CommandSearchObjectNode(item.node),
     }];
   });


### PR DESCRIPTION
## 问题

侧栏搜索（树搜索框与命令面板）只能按表名匹配，无法按表注释检索。表注释其实已经随元数据加载进 `node.dataRef.tableComment`，但没有参与任何匹配逻辑，用户记得注释却记不住表名时搜不到。

## 变更说明

- `useSidebarSearchModel` 新增 `getObjectCommentSearchText`，smart 作用域与 object 作用域都把表注释纳入匹配；连接、分组等非对象节点不受影响。
- 命令面板结果行的 `meta` 追加表注释，形如 `MySQL · app — 订单主表`，命中原因对用户可见。
- `buildV2CommandSearchTreeIndex` 中，默认模式把 `dataRef.tableComment` 加入 `normalizedSearchText`，对象模式加入 `normalizedObjectText`。
- 修复对象模式下表注释未做大小写归一的问题：`normalizedObjectText` 里拼接的注释此前保留了原始大小写，而搜索关键字统一转小写，导致注释含大写英文（如 `User Profile Table`）时 `@user profile` 匹配不到。

## 兼容性

- 只影响侧栏搜索过滤与命令面板索引，未改动树节点结构、元数据加载和已有匹配优先级。
- 表名为空的注释不会产生额外噪声：注释为空时不进入索引文本。
- 未提交 `wails dev` 生成的 binding 文件。

## 验证

- `sidebarV2Utils.command-search.test.ts`、`useSidebarSearchModel.search-dedupe.test.tsx`：20 / 20 通过，覆盖 smart 作用域、object 作用域、命令面板默认模式与对象模式，以及大小写不敏感的场景。
- 侧栏全量相关测试（`src/components/sidebar` + `Sidebar.locate-toolbar.test.tsx` 等）：46 个文件、373 个用例通过。
- `tsc --noEmit`：通过。
