### PR TITLE
✨ feat(table): 在单表右键菜单增加清空入口

### DIFF
--- a/frontend/src/components/Sidebar.locate-toolbar.test.tsx
+++ b/frontend/src/components/Sidebar.locate-toolbar.test.tsx
@@ -2297,6 +2297,7 @@ describe('Sidebar locate toolbar', () => {
           engine: 'InnoDB',
         }}
         supportsTruncate
+        supportsClear
       />,
     );
 
@@ -2332,8 +2333,20 @@ describe('Sidebar locate toolbar', () => {
     expect(markup).toContain('用 AI 解释这张表');
     expect(markup).toContain('用 AI 生成查询');
     expect(markup).toContain('截断表 · TRUNCATE');
+    expect(markup).toContain('清空表 · DELETE');
     expect(markup).toContain('删除表 · DROP');
-    expect(markup).not.toContain('清空表');
+  });
+
+  it('hides clear-table when the caller marks the database as unsupported', () => {
+    const unsupportedMarkup = renderToStaticMarkup(
+      <V2TableContextMenuView tableName="search-index" supportsClear={false} />,
+    );
+    const supportedMarkup = renderToStaticMarkup(
+      <V2TableContextMenuView tableName="orders" supportsClear />,
+    );
+
+    expect(unsupportedMarkup).not.toContain('清空表');
+    expect(supportedMarkup).toContain('清空表 · DELETE');
   });
 
   it('renders the v2 table context menu pinned state', () => {
@@ -2795,12 +2808,14 @@ describe('Sidebar locate toolbar', () => {
     setCurrentLanguage('en-US');
 
     const markup = renderToStaticMarkup(
-      <V2TableContextMenuView tableName="t1" supportsTruncate />,
+      <V2TableContextMenuView tableName="t1" supportsTruncate supportsClear />,
     );
 
     expect(markup).toContain('Truncate table · TRUNCATE');
+    expect(markup).toContain('Clear table · DELETE');
     expect(markup).toContain('Delete table · DROP');
     expect(markup).toContain('TRUNCATE');
+    expect(markup).toContain('DELETE');
     expect(markup).toContain('DROP');
     expect(markup).not.toContain('截断表 · TRUNCATE');
     expect(markup).not.toContain('删除表 · DROP');

--- a/frontend/src/components/TableOverview.tdengine.test.tsx
+++ b/frontend/src/components/TableOverview.tdengine.test.tsx
@@ -7,6 +7,7 @@ import TableOverview from './TableOverview';
 const storeSubscribers = vi.hoisted(() => new Set<() => void>());
 const renderedDropdownMenus = vi.hoisted(() => [] as Array<{ items?: any[] }>);
 const countdownConfirm = vi.hoisted(() => vi.fn());
+const modalConfirm = vi.hoisted(() => vi.fn());
 
 const storeState = vi.hoisted(() => ({
   theme: 'light',
@@ -50,11 +51,13 @@ const backendApp = vi.hoisted(() => ({
   ExportTable: vi.fn(),
   DropTable: vi.fn(),
   RenameTable: vi.fn(),
+  ClearTables: vi.fn(),
 }));
 
 const messageApi = vi.hoisted(() => ({
   error: vi.fn(),
   success: vi.fn(),
+  loading: vi.fn(() => vi.fn()),
 }));
 
 vi.mock('../store', async () => {
@@ -91,11 +94,21 @@ vi.mock('./ExportProgressModal', () => ({
   }),
 }));
 vi.mock('./V2TableContextMenu', () => ({
-  V2TableContextMenuView: ({ onAction }: { onAction?: (action: string) => void }) => (
-    <button type="button" data-overview-menu-action="drop-table" onClick={() => onAction?.('drop-table')}>
-      drop table
-    </button>
+  V2TableContextMenuView: ({ onAction, supportsClear }: { onAction?: (action: string) => void; supportsClear?: boolean }) => (
+    <>
+      <button type="button" data-overview-menu-action="drop-table" onClick={() => onAction?.('drop-table')}>
+        drop table
+      </button>
+      {supportsClear ? (
+        <button type="button" data-overview-menu-action="clear-table" onClick={() => onAction?.('clear-table')}>
+          clear table
+        </button>
+      ) : null}
+    </>
   ),
+}));
+vi.mock('./common/ResizableDraggableModal', () => ({
+  default: { confirm: modalConfirm },
 }));
 vi.mock('./common/countdownDangerConfirm', () => ({
   showCountdownDangerConfirm: countdownConfirm,
@@ -196,6 +209,14 @@ describe('TableOverview metadata compatibility', () => {
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
       body: {},
+    });
+    vi.stubGlobal('window', {
+      go: { app: { App: backendApp } },
+      innerWidth: 1280,
+      innerHeight: 800,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
     });
     vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
       callback(0);
@@ -347,6 +368,63 @@ describe('TableOverview metadata compatibility', () => {
     const renderedAfterStaleResponse = collectText(renderer!.toJSON());
     renderer!.unmount();
     expect(renderedAfterStaleResponse).not.toContain('meters');
+  });
+
+  it('routes the overview clear action through confirmation and the existing ClearTables RPC', async () => {
+    storeState.connections = [{
+      id: 'conn-1',
+      config: {
+        type: 'mysql',
+        host: '127.0.0.1',
+        port: 3306,
+        user: 'root',
+        password: 'secret',
+        database: 'app_db',
+        useSSH: false,
+        ssh: { host: '', port: 22, user: '', password: '', keyPath: '' },
+      },
+    }];
+    backendApp.DBQuery.mockResolvedValue({
+      success: true,
+      data: [{ TABLE_NAME: 'orders', TABLE_ROWS: 8 }],
+    });
+    backendApp.ClearTables.mockResolvedValue({
+      success: true,
+      data: { executedSQLs: ['DELETE FROM `orders`'], count: 1 },
+    });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<TableOverview tab={{
+        id: 'tab-1',
+        title: '表概览 - app_db',
+        type: 'table-overview',
+        connectionId: 'conn-1',
+        dbName: 'app_db',
+      } as any} />);
+    });
+    await flushPromises();
+
+    act(() => {
+      renderer!.root.findByProps({ 'data-table-overview-card': 'orders' }).props.onContextMenu({
+        clientX: 100,
+        clientY: 100,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      });
+    });
+    act(() => {
+      renderer!.root.findByProps({ 'data-overview-menu-action': 'clear-table' }).props.onClick();
+    });
+
+    expect(modalConfirm).toHaveBeenCalledOnce();
+    await act(async () => {
+      await modalConfirm.mock.calls[0][0].onOk();
+    });
+
+    expect(backendApp.ClearTables).toHaveBeenCalledWith(expect.any(Object), 'app_db', ['orders']);
+    expect(backendApp.DBQuery).toHaveBeenCalledTimes(2);
+    expect(messageApi.success).toHaveBeenCalled();
   });
 
   it('loads tdengine overview rows through DBGetTables instead of direct metadata SQL', async () => {

--- a/frontend/src/components/TableOverview.tsx
+++ b/frontend/src/components/TableOverview.tsx
@@ -10,7 +10,7 @@ import type { TabData } from '../types';
 import { useAutoFetchVisibility } from '../utils/autoFetchVisibility';
 import { buildRpcConnectionConfig } from '../utils/connectionRpcConfig';
 import { noAutoCapInputProps } from '../utils/inputAutoCap';
-import { supportsTableTruncateAction, type TableDataDangerActionKind } from './tableDataDangerActions';
+import { supportsTableClearAction, supportsTableTruncateAction, type TableDataDangerActionKind } from './tableDataDangerActions';
 import { resolveTableSelectQuery } from '../utils/objectQueryTemplates';
 import {
     TABLE_OVERVIEW_RENDER_BATCH_SIZE,
@@ -33,6 +33,7 @@ import { confirmCopyTable } from './tableCopyAction';
 import { APP_POPUP_Z_INDEX } from '../utils/overlayZIndex';
 import { formatSidebarTableTimestamp } from './sidebar/sidebarHelpers';
 import { confirmProductionMutation } from '../utils/productionRiskConfirm';
+import { isConnectionDataEditRestricted } from '../utils/connectionReadOnly';
 import { stripSchemaFromTabObjectLabel } from '../utils/tabDisplay';
 
 interface TableOverviewProps {
@@ -310,8 +311,13 @@ const TableOverview: React.FC<TableOverviewProps> = ({ tab }) => {
     const overviewSchemaName = isSchemaScopedTableOverviewDialect(metadataDialect)
         ? (schemaName || 'public')
         : '';
-    const supportsDesignWrite = !getDataSourceCapabilities(connection?.config).forceReadOnlyStructureDesigner;
-    const supportsCopyTable = getDataSourceCapabilities(connection?.config).supportsCopyTable;
+    const dataSourceCapabilities = getDataSourceCapabilities(connection?.config);
+    const supportsDesignWrite = !dataSourceCapabilities.forceReadOnlyStructureDesigner;
+    const supportsCopyTable = dataSourceCapabilities.supportsCopyTable;
+    const allowClear = supportsTableClearAction(
+        connection?.config?.type || '',
+        connection?.config?.driver,
+    ) && !isConnectionDataEditRestricted(connection?.config);
     const autoFetchVisible = useAutoFetchVisibility();
     const loadDataRequestIdRef = useRef(0);
 
@@ -737,6 +743,7 @@ const TableOverview: React.FC<TableOverviewProps> = ({ tab }) => {
     }, [buildConfig, connection, loadData, t, tab.dbName]);
 
     const handleTableDataDangerAction = useCallback((tableName: string, action: TableDataDangerActionKind) => {
+        if (action === 'clear' && !allowClear) return;
         const config = buildConfig();
         if (!config) return;
 
@@ -783,7 +790,7 @@ const TableOverview: React.FC<TableOverviewProps> = ({ tab }) => {
                 }
             },
         });
-    }, [buildConfig, connection, loadData, t, tab.dbName]);
+    }, [allowClear, buildConfig, connection, loadData, t, tab.dbName]);
 
     const toggleOverviewTablePinned = useCallback((tableName: string, pinned?: boolean) => {
         if (!connection?.id || !tab.dbName || !tableName) return;
@@ -1034,6 +1041,9 @@ const TableOverview: React.FC<TableOverviewProps> = ({ tab }) => {
             case 'truncate-table':
                 void handleTableDataDangerAction(tableName, 'truncate');
                 return;
+            case 'clear-table':
+                void handleTableDataDangerAction(tableName, 'clear');
+                return;
             case 'drop-table':
                 handleDeleteTable(tableName);
                 return;
@@ -1074,6 +1084,7 @@ const TableOverview: React.FC<TableOverviewProps> = ({ tab }) => {
             }}
             isPinned={isOverviewTablePinned(pinnedSidebarTables, connection?.id, tab.dbName, schemaName, table.name)}
             supportsTruncate={allowTruncate}
+            supportsClear={allowClear}
             supportsCopyTable={supportsCopyTable}
             supportsStarRocksRollup={metadataDialect === 'starrocks'}
             onAction={(action) => {
@@ -1081,7 +1092,7 @@ const TableOverview: React.FC<TableOverviewProps> = ({ tab }) => {
                 handleV2TableContextMenuAction(table, action);
             }}
         />
-    ), [activeShortcutPlatform, allowTruncate, connection?.id, handleV2TableContextMenuAction, metadataDialect, pinnedSidebarTables, schemaName, supportsCopyTable, tab.dbName]);
+    ), [activeShortcutPlatform, allowClear, allowTruncate, connection?.id, handleV2TableContextMenuAction, metadataDialect, pinnedSidebarTables, schemaName, supportsCopyTable, tab.dbName]);
 
     const renderOverviewSectionTitle = (section: OverviewTableSection) => {
         const sectionTitle = section.kind === 'pinned'

--- a/frontend/src/components/V2TableContextMenu.tsx
+++ b/frontend/src/components/V2TableContextMenu.tsx
@@ -64,6 +64,7 @@ export type V2TableContextMenuActionKey =
   | 'ai-explain'
   | 'ai-generate-query'
   | 'truncate-table'
+  | 'clear-table'
   | 'drop-table';
 
 export type V2TableContextMenuStats = {
@@ -173,6 +174,7 @@ export const V2TableContextMenuView: React.FC<{
   stats?: V2TableContextMenuStats;
   isPinned?: boolean;
   supportsTruncate?: boolean;
+  supportsClear?: boolean;
   supportsCopyTable?: boolean;
   supportsStarRocksRollup?: boolean;
   supportsMessagePublish?: boolean;
@@ -184,6 +186,7 @@ export const V2TableContextMenuView: React.FC<{
   stats,
   isPinned = false,
   supportsTruncate = true,
+  supportsClear = false,
   supportsCopyTable = false,
   supportsStarRocksRollup = false,
   supportsMessagePublish = false,
@@ -207,6 +210,12 @@ export const V2TableContextMenuView: React.FC<{
       action: 'truncate-table' as const,
       icon: <DeleteOutlined />,
       title: t('sidebar.v2_table_menu.item_with_suffix', { label: t('sidebar.v2_table_menu.truncate_table'), suffix: 'TRUNCATE' }),
+      tone: 'danger' as const,
+    }] : []),
+    ...(supportsClear ? [{
+      action: 'clear-table' as const,
+      icon: <ClearOutlined />,
+      title: t('sidebar.v2_table_menu.item_with_suffix', { label: t('sidebar.menu.clear_table'), suffix: 'DELETE' }),
       tone: 'danger' as const,
     }] : []),
     {

--- a/frontend/src/components/sidebar/useSidebarV2ActionHandlers.table-danger.test.ts
+++ b/frontend/src/components/sidebar/useSidebarV2ActionHandlers.table-danger.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { useSidebarV2ActionHandlers } from './useSidebarV2ActionHandlers';
+
+const buildHandlers = () => {
+  const dangerAction = vi.fn();
+  const handlers = useSidebarV2ActionHandlers({
+    connections: [],
+    connectionTags: [],
+    pinnedSidebarTables: [],
+    pinnedSidebarDatabases: [],
+    loadingNodesRef: { current: new Set() },
+    treeDataRef: { current: [] },
+    findTreeNodeByKeyRef: { current: () => null },
+    refreshV2TableContextMenuStatsRef: { current: vi.fn() },
+    handleTableDataDangerAction: dangerAction,
+  } as any);
+  return { handlers, dangerAction };
+};
+
+describe('useSidebarV2ActionHandlers table danger actions', () => {
+  it('routes the table clear action through the existing danger handler', () => {
+    const { handlers, dangerAction } = buildHandlers();
+    const node = { dataRef: { tableName: 'orders', config: { type: 'mysql' } } };
+
+    handlers.handleV2TableContextMenuAction(node, 'clear-table');
+
+    expect(dangerAction).toHaveBeenCalledWith(node, 'clear');
+  });
+
+  it('rejects a forged clear action for an unsupported backend', () => {
+    const { handlers, dangerAction } = buildHandlers();
+    const node = { dataRef: { tableName: 'orders', config: { type: 'elasticsearch' } } };
+
+    handlers.handleV2TableContextMenuAction(node, 'clear-table');
+
+    expect(dangerAction).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { readOnly: true },
+    { protection: { restrictDataEdit: true } },
+  ])('rejects a forged clear action for a protected SQL connection', (guard) => {
+    const { handlers, dangerAction } = buildHandlers();
+    const node = {
+      dataRef: {
+        tableName: 'orders',
+        config: { type: 'mysql', ...guard },
+      },
+    };
+
+    handlers.handleV2TableContextMenuAction(node, 'clear-table');
+
+    expect(dangerAction).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/sidebar/useSidebarV2ActionHandlers.tsx
+++ b/frontend/src/components/sidebar/useSidebarV2ActionHandlers.tsx
@@ -8,6 +8,7 @@ import type { ConnectionTag, SavedConnection } from '../../types';
 import { buildRpcConnectionConfig } from '../../utils/connectionRpcConfig';
 import { resolveConnectionAccentColor, resolveConnectionIconType } from '../../utils/connectionVisual';
 import { getDataSourceCapabilities } from '../../utils/dataSourceCapabilities';
+import { isConnectionDataEditRestricted } from '../../utils/connectionReadOnly';
 import { buildElasticsearchConsoleTemplates } from '../../utils/elasticsearchConsole';
 import {
   buildTableSelectQuery,
@@ -35,6 +36,7 @@ import {
   type V2RailConnectionGroup,
 } from '../sidebarV2Utils';
 import type { SidebarTreeLoadOptions } from './useSidebarTreeLoaders';
+import { supportsTableClearAction } from '../tableDataDangerActions';
 
 type UseSidebarV2ActionHandlersArgs = {
   connections: SavedConnection[];
@@ -268,6 +270,13 @@ export const useSidebarV2ActionHandlers = ({
         return;
       case 'truncate-table':
         void handleTableDataDangerAction(node, 'truncate');
+        return;
+      case 'clear-table':
+        if (
+          !supportsTableClearAction(node.dataRef?.config?.type, node.dataRef?.config?.driver)
+          || isConnectionDataEditRestricted(node.dataRef?.config)
+        ) return;
+        void handleTableDataDangerAction(node, 'clear');
         return;
       case 'drop-table':
         handleDeleteTable(node);

--- a/frontend/src/components/sidebar/useSidebarV2ContextMenu.tsx
+++ b/frontend/src/components/sidebar/useSidebarV2ContextMenu.tsx
@@ -21,6 +21,7 @@ import { t } from '../../i18n';
 import { DBQuery } from '../../../wailsjs/go/app/App';
 import { getCaseInsensitiveRawValue, getCaseInsensitiveValue, getMetadataDialect, splitQualifiedName, escapeSQLLiteral, parseSidebarTableRowCount } from './sidebarMetadataLoaders';
 import { getDataSourceCapabilities } from '../../utils/dataSourceCapabilities';
+import { isConnectionDataEditRestricted } from '../../utils/connectionReadOnly';
 import { resolveConnectionHostSummary } from '../../utils/tabDisplay';
 import { resolveConnectionIconType } from '../../utils/connectionVisual';
 import { formatSidebarRowCount } from './sidebarHelpers';
@@ -30,7 +31,7 @@ import {
   type SidebarTreeNode as TreeNode,
   type V2RailConnectionGroup,
 } from '../sidebarV2Utils';
-import { getTableDataDangerActionMeta, supportsTableTruncateAction } from '../tableDataDangerActions';
+import { getTableDataDangerActionMeta, supportsTableClearAction, supportsTableTruncateAction } from '../tableDataDangerActions';
 import {
   SIDEBAR_CONTEXT_MENU_FALLBACK_HEIGHT,
   SIDEBAR_CONTEXT_MENU_FALLBACK_WIDTH,
@@ -370,7 +371,12 @@ export const useSidebarV2ContextMenu = ({
       const statsKey = getV2TableContextMenuStatsKey(node);
       const stats = v2TableContextMenuStats[statsKey];
       const isStarRocks = getMetadataDialect(node.dataRef as SavedConnection) === 'starrocks';
-      const supportsCopyTable = getDataSourceCapabilities(node.dataRef?.config).supportsCopyTable;
+      const dataSourceCapabilities = getDataSourceCapabilities(node.dataRef?.config);
+      const supportsCopyTable = dataSourceCapabilities.supportsCopyTable;
+      const supportsClear = supportsTableClearAction(
+          node.dataRef?.config?.type,
+          node.dataRef?.config?.driver,
+      ) && !isConnectionDataEditRestricted(node.dataRef?.config);
       const supportsMessagePublish = Boolean(resolveMessagePublishTarget(node));
       const isPinned = isSidebarTablePinned(
           pinnedSidebarTables,
@@ -386,10 +392,11 @@ export const useSidebarV2ContextMenu = ({
               stats={stats}
               isPinned={isPinned}
               supportsTruncate={supportsTableTruncateAction(node.dataRef?.config?.type, node.dataRef?.config?.driver)}
+              supportsClear={supportsClear}
               supportsCopyTable={supportsCopyTable}
               supportsStarRocksRollup={isStarRocks}
               supportsMessagePublish={supportsMessagePublish}
-              supportsBatchTables={getDataSourceCapabilities(node.dataRef?.config).supportsSqlQueryExport}
+              supportsBatchTables={dataSourceCapabilities.supportsSqlQueryExport}
               onAction={(action) => {
                   setContextMenu(null);
                   handleV2TableContextMenuAction(node, action);

--- a/frontend/src/components/tableDataDangerActions.test.ts
+++ b/frontend/src/components/tableDataDangerActions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { supportsTableTruncateAction } from './tableDataDangerActions';
+import { supportsTableClearAction, supportsTableTruncateAction } from './tableDataDangerActions';
 
 describe('tableDataDangerActions', () => {
   it('supports native truncate for known relational dialects', () => {
@@ -25,5 +25,20 @@ describe('tableDataDangerActions', () => {
     expect(supportsTableTruncateAction('sqlite')).toBe(false);
     expect(supportsTableTruncateAction('mongodb')).toBe(false);
     expect(supportsTableTruncateAction('custom', 'sqlite3')).toBe(false);
+  });
+
+  it('supports delete-all only for SQL-style and MongoDB table backends', () => {
+    expect(supportsTableClearAction('mysql')).toBe(true);
+    expect(supportsTableClearAction('sqlite')).toBe(true);
+    expect(supportsTableClearAction('mongodb')).toBe(true);
+    expect(supportsTableClearAction('tdengine')).toBe(true);
+    expect(supportsTableClearAction('custom', 'postgresql')).toBe(true);
+    expect(supportsTableClearAction('custom', 'sqlite3')).toBe(true);
+
+    expect(supportsTableClearAction('elasticsearch')).toBe(false);
+    expect(supportsTableClearAction('redis')).toBe(false);
+    expect(supportsTableClearAction('qdrant')).toBe(false);
+    expect(supportsTableClearAction('iotdb')).toBe(false);
+    expect(supportsTableClearAction('custom', 'unknown-driver')).toBe(false);
   });
 });

--- a/frontend/src/components/tableDataDangerActions.ts
+++ b/frontend/src/components/tableDataDangerActions.ts
@@ -121,6 +121,37 @@ export const supportsTableTruncateAction = (type: string, driver?: string): bool
   }
 };
 
+export const supportsTableClearAction = (type: string, driver?: string): boolean => {
+  switch (resolveTableDataActionDBType(type, driver)) {
+    case 'mysql':
+    case 'goldendb':
+    case 'mariadb':
+    case 'oceanbase':
+    case 'diros':
+    case 'starrocks':
+    case 'sphinx':
+    case 'postgres':
+    case 'kingbase':
+    case 'highgo':
+    case 'vastbase':
+    case 'opengauss':
+    case 'gaussdb':
+    case 'sqlserver':
+    case 'sqlite':
+    case 'duckdb':
+    case 'oracle':
+    case 'dameng':
+    case 'iris':
+    case 'tdengine':
+    case 'clickhouse':
+    case 'trino':
+    case 'mongodb':
+      return true;
+    default:
+      return false;
+  }
+};
+
 const tableDataDangerActionCopy = (
   translate: TableDataDangerActionTranslator | undefined,
   key: string,


### PR DESCRIPTION
Fixes #1223

## 问题

V2 单表右键菜单没有暴露已有的清空数据能力。用户只能进入批量表操作或手动删除数据，无法直接对当前表执行清空。

## 变更说明

- 在 V2 单表右键菜单增加“清空表 · DELETE”危险操作入口，并使用独立的清空图标与 DROP 区分。
- 侧栏和 TableOverview 均复用现有 `ClearTables([table])` 链路，包括确认弹窗、生产环境二次确认和操作后刷新。
- PostgreSQL、Kingbase、SQL Server 等 schema 数据源继续沿用现有限定表名处理。
- 新增数据库能力判断，仅 SQL 类数据源和 MongoDB 显示入口；Elasticsearch、Redis、向量数据库和 IoTDB 等不显示。
- 只读或启用 `restrictDataEdit` 的连接不显示入口，伪造动作也会在分发层被拒绝。

## 兼容性

- 未新增后端接口，也未修改现有批量清空、TRUNCATE 或 DROP 行为。
- 复用已有多语言文案，不新增翻译键。
- 未提交 AQG 工作记录、依赖软链接或构建产物。

## 验证

- 聚焦 Vitest：5 个测试文件，137 / 137 通过。
- `npm run build`：通过，7,889 个模块完成生产构建。
- `npm run i18n:scan`：通过。
- `git diff --check`：通过。
- AQG construction checker：通过（full，9 files，261 lines）。