### PR TITLE
📝 docs(readme): 拆清轻量口径（安装包 vs RSS vs UI 栈）

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   A high-performance cross-platform database client built with
   <a href="https://wails.io">Wails</a> (Go) + <a href="https://react.dev">React</a>.
-  Desktop-first. MCP-ready. ~30MB class binaries.
+  Desktop-first. MCP-ready. ~20–26MB class installers.
 </p>
 
 <p align="center">
@@ -57,16 +57,24 @@
 
 ## Why GoNavi?
 
-Most database GUIs are Electron shells with megabytes of tax. GoNavi takes a different path:
+Most database GUIs are Electron shells with megabytes of tax. GoNavi takes a different path — and “lightweight” only makes sense if you separate three numbers:
+
+| Number | What it means | GoNavi (v0.9.8) |
+|---|---|---|
+| **Installer size** | What you download | **~20–26 MB** class (Win / macOS / Linux release assets) |
+| **Steady-state RSS** | What RAM the running UI holds | Linux WebKit build, idle empty workbench: main ≈ **429 MB**; with WebKit helpers ≈ **765 MB** (method below) |
+| **UI stack** | Chromium tax or not | **Go + system WebView (Wails)** — not Electron |
 
 | | Typical Electron client | **GoNavi** |
 |---|---|---|
 | Runtime | Chromium + Node | **Go + native WebView** |
-| Binary size | Hundreds of MB | **~30MB class** |
+| Installer | Hundreds of MB common | **~20–26 MB class** |
 | Startup | Heavy | **Fast** |
-| Memory | High baseline | **Lean** |
-| AI / Agents | Bolt-on or absent | **First-class MCP + multi-provider AI** |
+| Memory claim | Often mixed with installer size | **Measure RSS separately** (see note) |
+| AI / Agents | Bolt-on or absent | **First-class MCP + multi-provider AI** (draft SQL; GUI still owns schema / edits / EXPLAIN) |
 | Data sources | Mostly RDBMS | **SQL · Cache · Vector · MQ · Search · Time-series · Domestic DBs** |
+
+> **Installer MB ≠ RAM.** The RSS figures above are one Linux cloud run of the v0.9.8 WebKit41 build (empty workbench, no DB connections, remote display, ~30–40 s steady). Do not compare them to installer size, or to unverified “native ~80 MB” marketing. Windows / macOS laptop numbers may differ — treat them as a labeled sample, not a leaderboard score.
 
 > **One cockpit for MySQL, Postgres, Redis, Kafka, Milvus, OceanBase, ClickHouse…**  
 > Query, edit, audit, sync — and hand structured context to coding agents without leaking passwords off-host.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   基于 <a href="https://wails.io">Wails</a>（Go）+ <a href="https://react.dev">React</a> 的跨平台数据库工作台。
-  桌面优先，MCP 原生，二进制约 <b>30MB</b> 量级。
+  桌面优先，MCP 原生，安装包约 <b>20–26MB</b> 量级。
 </p>
 
 <p align="center">
@@ -56,16 +56,24 @@
 
 ## 为什么是 GoNavi？
 
-市面上大量数据库 GUI 仍是 Electron 壳：体积大、启动慢、内存高。GoNavi 换了一条路：
+市面上大量数据库 GUI 仍是 Electron 壳：体积大、启动慢、内存高。GoNavi 换了一条路——谈「轻量」先把三个数字拆开：
+
+| 数字 | 含义 | GoNavi（v0.9.8） |
+|---|---|---|
+| **安装包体积** | 你下载的是什么 | **约 20–26 MB** 量级（Win / macOS / Linux 发布产物） |
+| **稳态 RSS** | 跑起来占多少内存 | Linux WebKit 构建、空工作台闲置：主进程约 **429 MB**；含 WebKit 子进程约 **765 MB**（方法见下） |
+| **UI 栈** | 有没有 Chromium 税 | **Go + 系统 WebView（Wails）**，不是 Electron |
 
 | | 常见 Electron 客户端 | **GoNavi** |
 |---|---|---|
 | 运行时 | Chromium + Node | **Go + 系统 WebView** |
-| 体积 | 动辄数百 MB | **约 30MB 量级** |
+| 安装包 | 动辄数百 MB | **约 20–26 MB 量级** |
 | 启动 | 偏重 | **更快** |
-| 内存 | 基线高 | **更轻** |
-| AI / Agent | 外挂或缺失 | **MCP + 多模型一等公民** |
+| 内存口径 | 常和安装包混谈 | **RSS 单独测**（见注） |
+| AI / Agent | 外挂或缺失 | **MCP + 多模型一等公民**（AI 起草 SQL；GUI 仍管 schema / 改行 / EXPLAIN） |
 | 数据源 | 以 RDBMS 为主 | **SQL · 缓存 · 向量 · 消息 · 搜索 · 时序 · 国产库** |
+
+> **安装包 MB ≠ 运行内存。** 上表 RSS 来自一次云电脑 Linux 实测：v0.9.8 WebKit41 包、空工作台、无数据库连接、远程显示、约 30–40 s 稳态。不要拿它和安装包比，也不要和未经核实的「原生 ~80 MB」宣传混比。Windows / macOS 本机结果可能不同——这是带方法学的样本，不是排行榜分数。
 
 > **MySQL、Postgres、Redis、Kafka、Milvus、OceanBase、ClickHouse… 一个工作台打通。**  
 > 查询、编辑、审计、同步；把结构化上下文交给编码 Agent，密码仍留在本机。


### PR DESCRIPTION
## Summary
- README 中英文「为什么是 GoNavi」按三数字口径改写：安装包 MB / 稳态 RSS / UI 栈
- 写入 v0.9.8 安装包约 20–26MB，以及 Linux WebKit 空工作台 RSS（主进程 ≈429MB，含子进程 ≈765MB）并注明方法学
- 不把安装包与 RAM、社区「原生 ~80MB」混比

## Test plan
- [ ] 预览 README.md / README.zh-CN.md Why 段落渲染
- [ ] 确认数字与群内实测口径一致